### PR TITLE
Fix Latex output of don't-care variables.

### DIFF
--- a/dist/include/modules/unification.k
+++ b/dist/include/modules/unification.k
@@ -24,7 +24,7 @@ module UNIFICATION
     (e.g. _ in Prolog), they should declare some syntax like the following:
 syntax ThingThatCanBeUnified ::= "_" [onlyLabel, klabel($dontcare)]
 */
-  syntax K ::= "$dontcare" [klabel($dontcare)]
+  syntax K ::= "$dontcare" [klabel($dontcare), latex(\AnyVar[K])]
 
 // Traian: I would remove applySubst all together and only keep applyMgu
 //         Mgu gives a nicer, more intuitive user interface than Subst


### PR DESCRIPTION
Forces the unification module's `$dontcare` values--wildcard syntax that would unify against anything--to output in Latex identically to the underscores that K uses for don't-care values.

Sorry for the lousy branch name, but it seems like Github chose it for me and I'm not sure how to change it.
