### PR TITLE
Prevent kompile from creating multiple kompiled definitions in the same directory

### DIFF
--- a/javasources/KTool/src/org/kframework/kompile/KompileFrontEnd.java
+++ b/javasources/KTool/src/org/kframework/kompile/KompileFrontEnd.java
@@ -196,8 +196,10 @@ public class KompileFrontEnd {
 		} else if (cmd.hasOption("xml")) {
 			backendOpt = "xml";
 		*/
+		/*
 		} else if (cmd.hasOption("doc")) {
 			backendOpt = "doc";
+		*/
 		} else {
 			backendOpt = "maude";
 		}
@@ -210,6 +212,7 @@ public class KompileFrontEnd {
 			GlobalSettings.documentation = true;
 			backend = new LatexBackend(Stopwatch.sw, context);
 			break;
+		/*
 		case "doc":
 			GlobalSettings.documentation = true;
 			if (!cmd.hasOption("doc-style")) {
@@ -217,6 +220,7 @@ public class KompileFrontEnd {
 			}
 			backend = new DocumentationBackend(Stopwatch.sw, context);
 			break;
+		*/
 		/*
 		case "xml":
 			GlobalSettings.xml = true;
@@ -361,3 +365,5 @@ public class KompileFrontEnd {
 		}
 	}
 }
+
+// vim: noexpandtab

--- a/javasources/KTool/src/org/kframework/kompile/KompileOptionsParser.java
+++ b/javasources/KTool/src/org/kframework/kompile/KompileOptionsParser.java
@@ -61,7 +61,6 @@ public class KompileOptionsParser {
 
 		// Experimental options
 		addOptionE(OptionBuilder.withLongOpt("step").hasArg().withArgName("string").withDescription("Name of the compilation phase after which the compilation process should stop.").create());
-		addOptionE(OptionBuilder.withLongOpt("doc").withDescription("Generate reference manual of K framework.").create());
 		addOptionE(OptionBuilder.withLongOpt("lib").hasArg().withArgName("file").withDescription("Specify extra-libraries for compile/runtime.").create());
 		addOptionE(OptionBuilder.withLongOpt("add-top-cell").withDescription("Add a top cell to configuration and all rules.").create());
 		addOptionE(OptionBuilder.withLongOpt("kcells").hasArg().withArgName("string").withDescription("Cells which contain komputations.").create());

--- a/javasources/KTool/src/org/kframework/krun/Main.java
+++ b/javasources/KTool/src/org/kframework/krun/Main.java
@@ -974,7 +974,7 @@ public class Main {
                 K.compiled_def = null;
                 for (int i = 0; i < dirs.length; i++) {
                     if (dirs[i].getAbsolutePath().endsWith("-kompiled")) {
-                        if (context.kompiled != null) {
+                        if (K.compiled_def != null) {
                             String msg = "Multiple compiled definitions found.";
                             GlobalSettings.kem.register(new KException(ExceptionType.ERROR, KExceptionGroup.CRITICAL, msg, "command line", new File(".").getAbsolutePath()));
                         } else {


### PR DESCRIPTION
Also, krun doesn't come into action when there are multiple kompiled definitions in the same directory.
