### PR TITLE
Added sample documentation comments 

### DIFF
--- a/include/builtins/list.k
+++ b/include/builtins/list.k
@@ -15,20 +15,20 @@ module LIST
 
   /*@ \section{User-Defined Lists} It is very common in \K to define a shorthand
    for lists of user-defined sorts. \K 's builtin way of doing this is to use
-   List\left{K,"Separator"\right}, where "Separator" is any valid character or sequence of
+   List\{K,"Separator"\}, where "Separator" is any valid character or sequence of
    characters used to separate distinct elements.
    For example, after defining \\
    syntax K ::= Elt\\ 
    a user could then define
-   syntax Elts ::= List\left{Elt,","\right} \\
+   syntax Elts ::= List\{Elt,","\} \\
    which would be a comma-separated list whose elements are all of sort Elt. A
    user could just as well define \\
-   syntax Elts ::= List\left{Elt,"and"\right} \\
+   syntax Elts ::= List\{Elt,"and"\} \\
    which would be a list containing elements of sort Elt that are separated with
    the word "and". If only one argument is given, the separator is asumed to be
    commas. So, \\
-   syntax Elts = List\left{Elt\right} \\
-   sould define a comma-separated list containing elements of sort Elt.
+   syntax Elts = List\{Elt\} \\
+   would define a comma-separated list containing elements of sort Elt.
   */
 
 

--- a/include/builtins/list.k
+++ b/include/builtins/list.k
@@ -10,8 +10,11 @@ module LIST
    duplicate elements. These behave more like lists in functional programming
    languages than arrays in imperative programming languages; there's no
    numerical indexing, but instead specific elements are refered to using the
-   Mylist,Mylist construct in combination with the MyListItem construct. For
-   example, to refer to element E in a MyList, one would write L:Mylist,E . */
+   Mylist,Mylist construct in combination with the MyListItem construct. It's 
+   worth noting that \K lists aren't exactly like lists in functional languages;
+   they're associative, which means that it's easy to access elements at both
+   ends of the lists and concatenate them. For example, L:Mylist,E accesses
+   element E at the end of a list. */
 
   /*@ \section{User-Defined Lists} It is very common in \K to define a shorthand
    for lists of user-defined sorts. \K 's builtin way of doing this is to use

--- a/include/builtins/list.k
+++ b/include/builtins/list.k
@@ -6,11 +6,43 @@ module LIST
   imports K-EQUAL-HOOKS
   imports INT-HOOKS
 
-  syntax MyList ::= MyList "," MyList   [left, function, hook(List:__), klabel('_List_)]
-                  | ".MyList"       [function, hook(List:.List)]
-                  | MyListItem(K)   [function, hook(List:ListItem)]
+  /*@ \section{Description} \K lists are ordered collections that may contain
+   duplicate elements. These behave more like lists in functional programming
+   languages than arrays in imperative programming languages; there's no
+   numerical indexing, but instead specific elements are refered to using the
+   Mylist,Mylist construct in combination with the MyListItem construct. For
+   example, to refer to element E in a MyList, one would write L:Mylist,E . */
 
-  /* element membership */
+  /*@ \section{User-Defined Lists} It is very common in \K to define a shorthand
+   for lists of user-defined sorts. \K 's builtin way of doing this is to use
+   List\left{K,"Separator"\right}, where "Separator" is any valid character or sequence of
+   characters used to separate distinct elements.
+   For example, after defining \\
+   syntax K ::= Elt\\ 
+   a user could then define
+   syntax Elts ::= List\left{Elt,","\right} \\
+   which would be a comma-separated list whose elements are all of sort Elt. A
+   user could just as well define \\
+   syntax Elts ::= List\left{Elt,"and"\right} \\
+   which would be a list containing elements of sort Elt that are separated with
+   the word "and". If only one argument is given, the separator is asumed to be
+   commas. So, \\
+   syntax Elts = List\left{Elt\right} \\
+   sould define a comma-separated list containing elements of sort Elt.
+  */
+
+
+  /*@ Construct a List using two Lists. This is similar to the "Cons" operation
+   in many functional programming languages.*/
+  syntax MyList ::= MyList "," MyList   [left, function, hook(List:__), klabel('_List_)]
+  /*@ Construct an empty list: */
+  syntax MyList ::= ".MyList"       [function, hook(List:.List)]
+  /*@ TODO: How does this work, exactly? Create a list with one element? Also,
+   mention that MyListElement is commonly etended to create lists of arbitrary
+   contents, especially tuples. */
+  syntax MyList ::= MyListItem(K)   [function, hook(List:ListItem)]
+
+  /*@ Test element membership in the given list: */
   syntax Bool ::= K "in" MyList   [function]
 //  rule
 //    K1:K in /* L1:MyList */ MyListItem(K2:K) L2:MyList
@@ -18,7 +50,7 @@ module LIST
 //    K1 =K K2 orBool /* K1 in L1 orBool */ K1 in L2
 //  rule _ in .MyList => false
 
-  /* list length */
+  /*@  Get list length: */
   syntax Int ::= size(MyList)   [function]
 //  rule
 //    size(/* L1:MyList */ MyListItem(_) L2:MyList)

--- a/include/builtins/map.k
+++ b/include/builtins/map.k
@@ -6,25 +6,38 @@ module MAP
   imports BAG
   imports SET
 
+  /*@\section{Description} The Map represents a generalized associative array;
+   arbitrary keys can be paired with arbitrary values; the values can later
+   be referenced using the key.
+  (TODO: What are all these "MyMap"s doing? how are they different from Maps?) 
+  */
+
+  /*@ Construct a new Map consisting of key-value pairs of multiple Maps (deep copy) (TODO: double-check this):*/
   syntax MyMap ::= MyMap "," MyMap    [left,function, hook(Map:__), klabel('_Map_)]
-                 | ".MyMap"       [function, hook(Map:.Map)]
-                 | K "|->" K      [function, hook(Map:_|->_)]
+  /*@  Construct an empty Map: */
+  syntax MyMap ::= ".MyMap"       [function, hook(Map:.Map)]
+  /*@ This construct is used to refer to key-value pairs within a map, with the 
+   key on the left and the value on the right: */
+  syntax MyMap ::= K "|->" K      [function, hook(Map:_|->_)]
                  // breaks klabel uniqueness
                  //| "."            [function, hook(Map:.Map)]
   syntax priorities '_|->_ > '_Map_ '.MyMap
 
-  /* map of keys and values */
+  /*@ Construct a map from two lists, the first list containing keys and the
+   second list containing values (TODO: Difference between Lists and KLists?
+   What happens if the lists are of different sizes?): */
   syntax MyMap ::= MyMapOf(KList, KList)    [function]
 //  rule MyMapOf(K1:K,,KL1:KList, K2:K,,KL2:KList) => K1 |-> K2 MyMapOf(KL1, KL2)
 //  rule MyMapOf(.KList, .KList) => .MyMap
 
-  /* map key lookup */
+  /*@ Retreive the value associated with the given key: */
   // AndreiS: using () instead of [] causes ambiguities with __
   // () cannot be used for disambiguation
   syntax K ::= MyMap "[" K "]"    [function, hook(Map:lookup), klabel(Map:lookup)]
 //  rule (K1:K |-> K2:K _:MyMap)[K1] => K2
 
-  /* map values update (update in form of KLists of keys and values) */
+  /*@ Update a Map in form of KLists of keys and values:
+ (TODO: There are no KLists here. What it this function actually doing?) */
   syntax MyMap ::= MyMap "[" K "<-" K "]"    [function, hook(Map:update), prefer]
 //  rule (K1:K |-> _ M:MyMap)[K1 <- K2:K] => K1 |-> K2 M
 //  rule M:MyMap[K1:K <- K2:K] => K1 |-> K2 M
@@ -39,13 +52,15 @@ module MAP
   //rule M:MyMap[K1:K <- K2:K] => K1 |-> K2 M
   //when notBool(K1 in keys(M))
 
-  /* map values update (update in form of a second map) */
+  /*@ Update the first map by adding all key-value pairs in the second map. 
+   If a key in the first map exists also in the second map, its associated value
+   will be overwritten by the value from the second map.*/
   // TODO: rename operator
   syntax MyMap ::= update(MyMap, MyMap)   [function]
 //  rule update(M1:MyMap, K1:K |-> K2:K M2:MyMap) => update(M1[K1 <- K2], M2)
 //  rule update(M:MyMap, .MyMap) => M
 
-  /* map domain restriction */
+  /*@ map domain restriction (TODO: what does this mean? Remove key from map? This will aslo remove the resulting value, right?) */
   syntax MyMap ::= MyMap "[" K "<-" "undef" "]"    [function, hook(Map:remove)] 
 //  rule
 //    M:MyMap[K1:K,,K2:K,,KL:KList <- undef]
@@ -54,17 +69,17 @@ module MAP
 //  rule (K:K |-> _ M:MyMap)[K <- undef] => M
 //  rule M:MyMap[.KList <- undef] => M
 
-  /* set of map keys */
+  /*@ Construct a Set consisting of all keys in the Map (TODO: What is the difference between Sets and MySets?):*/
 	syntax MySet ::= keys(MyMap)    [function, hook(Map:keys)]
 //  rule keys(K:K |-> _ M:MyMap) => MySetItem(K) keys(M)
 //  rule keys(.MyMap) => .MySet
 
-  /* bag of map values */
+  /*@ Construct a Bag consisting of all values in the Map: */
 	syntax MyBag ::= values(MyMap)    [function]
 //  rule values(_ |-> K:K M:MyMap) => MyBagItem(K) values(M)
 //  rule values(.MyMap) => .MyBag
 
-  /* map size */
+  /*@ Get Map size (TODO: number of key/value pairs? Total combined number of keys and values?):*/
   syntax Int ::= size(MyMap)   [function]
 //  rule size(_ |-> _ M:MyMap) => 1 +Int size(M)
 //  rule size(.MyMap) => 0

--- a/include/builtins/map.k
+++ b/include/builtins/map.k
@@ -8,8 +8,7 @@ module MAP
 
   /*@\section{Description} The Map represents a generalized associative array;
    arbitrary keys can be paired with arbitrary values; the values can later
-   be referenced using the key.
-  (TODO: What are all these "MyMap"s doing? how are they different from Maps?) 
+   be referenced using the key. 
   */
 
   /*@ Construct a new Map consisting of key-value pairs of multiple Maps (deep copy) (TODO: double-check this):*/

--- a/include/builtins/set.k
+++ b/include/builtins/set.k
@@ -15,7 +15,7 @@ module SET
  */
 
 
-  /*@ Construct a set from the union of two different sets (A \cup B): */
+  /*@ Construct a set from the union of two different sets (A $\cup$ B): */
   syntax MySet ::= MySet "," MySet    [left, function, hook(Set:__), klabel('_Set_)]
   /*@ Construct an empty Set: */
   syntax MySet ::= ".MySet"       [function, hook(Set:.Set)]
@@ -37,16 +37,16 @@ module SET
 //  when notBool(K in S1)
 //  rule S:MySet -MySet .MySet => S
 
-  /*@ Construct a Set consisting of the intersection of two sets (A \cap B):*/
+  /*@ Construct a Set consisting of the intersection of two sets (A $\cap$ B):*/
   syntax MySet ::= intersectSet(MySet, MySet)   [function]
 //  rule intersectSet(S1:MySet, S2:MySet) => S1 -MySet (S1 -MySet S2)
 
-  /*@ Test element membership in a set ( a \epsilon A ) :*/
+  /*@ Test element membership in a set ( a $\epsilon$ A ) :*/
   syntax Bool ::= K "in" MySet    [function, hook(Set:in)]
 //  rule K1:K in MySetItem(K2:K) S:MySet => K1 =K K2 orBool K1 in S
 //  rule _ in .MySet => false
 
-  /*@ Get the cardinality of a set (\left|A\right|) :*/
+  /*@ Get the cardinality of a set (|A|) :*/
   syntax Int ::= size(MySet)   [function]
 //  rule size(MySetItem(_) S:MySet) => 1 +Int size(S)
 //  rule size(.MySet) => 0

--- a/include/builtins/set.k
+++ b/include/builtins/set.k
@@ -6,11 +6,25 @@ module SET
   imports K-EQUAL-HOOKS
   imports INT-HOOKS
 
-  syntax MySet ::= MySet "," MySet    [left, function, hook(Set:__), klabel('_Set_)]
-                 | ".MySet"       [function, hook(Set:.Set)]
-                 | MySetItem(K)   [function, hook(Set:SetItem)]
+ /*@ \section{Description} The Set construct behaves like a mathematical
+  set: it is a collection of unique items. The builtin \K Set offers support
+  for some common set operations.
+  (TODO: How does one add an element to a Set? How does one remove an element
+  from a set? What is the difference between a Set and a MySet? What does this
+  matter to the user?)
+ */
 
-  /* set difference */
+
+  /*@ Construct a set from the union of two different sets (A \cup B): */
+  syntax MySet ::= MySet "," MySet    [left, function, hook(Set:__), klabel('_Set_)]
+  /*@ Construct an empty Set: */
+  syntax MySet ::= ".MySet"       [function, hook(Set:.Set)]
+  /*@ TODO: I don't know what this does. Construct a set of one element? Is this
+   used to add elements to Sets? I never figured out how to add elements to
+   Sets in 422; I actually once used Lists just to avoid having to. */
+  syntax MySet ::= MySetItem(K)   [function, hook(Set:SetItem)]
+
+  /*@ Get the difference of two sets: */
   syntax MySet ::= MySet "-MySet" MySet   [function, hook(Set:difference), latex({#1}-_{\it Set}{#2})]
 //  rule (MySetItem(K:K) S1:MySet) -MySet S2:MySet => S1 -MySet S2
 //  when K in S2
@@ -23,16 +37,16 @@ module SET
 //  when notBool(K in S1)
 //  rule S:MySet -MySet .MySet => S
 
-  /* set intersection */
+  /*@ Construct a Set consisting of the intersection of two sets (A \cap B):*/
   syntax MySet ::= intersectSet(MySet, MySet)   [function]
 //  rule intersectSet(S1:MySet, S2:MySet) => S1 -MySet (S1 -MySet S2)
 
-  /* element membership */
+  /*@ Test element membership in a set ( a \epsilon A ) :*/
   syntax Bool ::= K "in" MySet    [function, hook(Set:in)]
 //  rule K1:K in MySetItem(K2:K) S:MySet => K1 =K K2 orBool K1 in S
 //  rule _ in .MySet => false
 
-  /* set cardinality */
+  /*@ Get the cardinality of a set (\left|A\right|) :*/
   syntax Int ::= size(MySet)   [function]
 //  rule size(MySetItem(_) S:MySet) => 1 +Int size(S)
 //  rule size(.MySet) => 0


### PR DESCRIPTION
These comments were added to to include/builtins/map.k, include/builtins/set.k, and include/builtins/list.k. As autoinclude cannot currently be turned off, these modules will be present in any file kompiled with the option --backend-doc. 

These comments represent what I think would be helpful to users looking for general-purpose tools and information. The documentation for each builtin module should include a general description of the module, as well as information on usage that may not be mentioned explicitly in the module, such as user-defined lists. For any container sort, information on adding, removing, and updating elements should be present. 

These comments are based on what existing comments there were, which were sometimes cryptic. As I'm not an expert in internal implementations, these comments are spare, and should probably include information about potential misuse or common errors. These comments are meant to be an example and a starting point, not as authoritative and sufficient, and they should be updated by persons more knowledgeable about implementation and use.
