### PR TITLE
Eliminate tabs from source file.

### DIFF
--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/AbstractMatcher.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/AbstractMatcher.java
@@ -9,10 +9,10 @@ public abstract class AbstractMatcher implements Matcher {
 
     /**
      * Fails the pattern matching task.
-     * 
+     *
      * @throws PatternMatchingFailure
      */
-	protected void fail(Term term, Term otherTerm) {
-		throw PatternMatchingFailure.PATTERN_MATCHING_FAILURE;
-	}
+    protected void fail(Term term, Term otherTerm) {
+        throw PatternMatchingFailure.PATTERN_MATCHING_FAILURE;
+    }
 }


### PR DESCRIPTION
Without this, "ant test" fails with

```
checkstyle:
[checkstyle] Running Checkstyle 5.7 on 701 files
[checkstyle] AbstractMatcher.java:15:1: File contains tab characters
  (this is the first instance).
```
