### PR TITLE
add negative contracts on KilProperty

### DIFF
--- a/src/javasources/KTool/src/org/kframework/compile/utils/KilProperty.java
+++ b/src/javasources/KTool/src/org/kframework/compile/utils/KilProperty.java
@@ -12,6 +12,13 @@ import java.lang.annotation.Target;
  * Since contracts can be either positive or negative in nature, we could hypothetically specify each
  * KilProperty as its inverse as well as itself. By convention, the positive form of the KilProperty
  * represents the state the KilProperty is in following a successful compilation sequence.
+ *
+ * The goal of this class and its annotations is to eventually annotate all kompilation transformers
+ * with the properties that they affect, and then demonstrate that those annotations are complete
+ * by means of mutation testing which reorders the transformers and verifies that the output remains
+ * the same. We do this so that we have a complete picture of the interdependencies of the
+ * compilation stages, which is the first step towards eventually breaking down those dependencies
+ * as much as possible.
  */
 public enum KilProperty {
     NO_CONCRETE_SYNTAX,

--- a/src/javasources/KTool/src/org/kframework/compile/utils/KilProperty.java
+++ b/src/javasources/KTool/src/org/kframework/compile/utils/KilProperty.java
@@ -8,6 +8,10 @@ import java.lang.annotation.Target;
 /**
  * Represents a contract asserting that a particular AST has a particular
  * property (e.g. does not contain any concrete syntax, does not contain any contexts, etc).
+ *
+ * Since contracts can be either positive or negative in nature, we could hypothetically specify each
+ * KilProperty as its inverse as well as itself. By convention, the positive form of the KilProperty
+ * represents the state the KilProperty is in following a successful compilation sequence.
  */
 public enum KilProperty {
     NO_CONCRETE_SYNTAX,
@@ -27,13 +31,24 @@ public enum KilProperty {
 
     /**
      * Used to annotate code which takes an AST as input which will not work on
-     * terms without a particular KilProperty.
+     * terms <b>without</b> a particular KilProperty.
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
     public static @interface Requires {
         KilProperty[] value();
     }
+
+    /**
+     * Used to annotate code which takes an AST as input which will not work on
+     * terms <b>with</b> a particular KilProperty.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public static @interface Forbids {
+        KilProperty[] value();
+    }
+
 
     /**
      * Used to annotate code which outputs an AST which is guaranteed to ensure
@@ -44,4 +59,15 @@ public enum KilProperty {
     public static @interface Ensures {
         KilProperty[] value();
     }
+
+    /**
+     * Used to annotate code which outputs an AST which is guaranteed to destroy
+     * a particular KilProperty.
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public static @interface Destroys {
+        KilProperty[] value();
+    }
+
 }


### PR DESCRIPTION
Technically the KilProperty contracts are ternary, not binary: a kilproperty can either be required/ensured, or it can be forbidden/destroyed, or it can be unspecified. Trying to implement a ternary EnumSet with an undefined state seemed overkill for this, so I just created negative annotations. If someone has a better solution, I'm open to it.
