### PR TITLE
Fixing StringUtil escape not taking into consideration '\f'.

### DIFF
--- a/src/javasources/KTool/src/org/kframework/utils/StringUtil.java
+++ b/src/javasources/KTool/src/org/kframework/utils/StringUtil.java
@@ -13,8 +13,11 @@ public class StringUtil {
                     sb.append('\r');
                 else if (str.charAt(i + 1) == 't')
                     sb.append('\t');
+                else if (str.charAt(i + 1) == 'f')
+                    sb.append('\f');
                 else if (str.charAt(i + 1) == '"')
                     sb.append('"');
+                // TODO: else, I think it should throw an exception
                 i++;
             } else
                 sb.append(str.charAt(i));
@@ -42,6 +45,8 @@ public class StringUtil {
                 result.append("\\t");
             } else if (codepoint == '\r') {
                 result.append("\\r");
+            } else if (codepoint == '\f') {
+                result.append("\\f");
             } else if (codepoint >= 32 && codepoint < 127) {
                 result.append((char)codepoint);
             } else if (codepoint <= 0xff) {
@@ -111,6 +116,9 @@ public class StringUtil {
                 } else if (str.charAt(i + 1) == 't') {
                     sb.append('\t');
                     i++;
+                } else if (str.charAt(i + 1) == 'f') {
+                    sb.append('\f');
+                    i++;
                 } else if (str.charAt(i + 1) == 'x') {
                     String arg = str.substring(i + 2, i + 4);
                     sb.append((char)Integer.parseInt(arg, 16));
@@ -128,6 +136,7 @@ public class StringUtil {
                     sb.append(Character.toChars(codePoint));
                     i += 9;
                 }
+                // TODO: else, I think it should throw an exception
             } else {
                 sb.append(str.charAt(i));
             }
@@ -152,6 +161,8 @@ public class StringUtil {
                 result.append("\\t");
             } else if (codepoint == '\r') {
                 result.append("\\r");
+            } else if (codepoint == '\f') {
+                result.append("\\f");
             } else if (codepoint >= 32 && codepoint < 127) {
                 result.append((char)codepoint);
             } else if (codepoint <= 0xff) {


### PR DESCRIPTION
Daejun found this problem when you would write in a string "\f" and the result after processing through K would be "f".
The problem was with the way we esacpe and unescape strings internally. When we load a StringBuiltin, we try to use the internal representation, meaning "\n" would be transformed into the string that contains the new line character.

The way unescape works right now, makes it that "\a" would be converted into "a". Completely removing the backslash character. At one point we had a request from Denis I believe to allow almost everything to be escaped, and the definition would take care of escaping those into something that the backend would understand.

In this patch I've fixed the case of '\f', but there are still the other cases. I think the backend should reject (throw an exception) if it doesn't know how to unescape something.
