### PR TITLE
fix bug where kompile crashes but ktest reports success

### DIFF
--- a/src/javasources/KTool/src/org/kframework/utils/BinaryLoader.java
+++ b/src/javasources/KTool/src/org/kframework/utils/BinaryLoader.java
@@ -13,6 +13,7 @@ public class BinaryLoader {
             serializer.writeObject(o);
         } catch (IOException e) {
             e.printStackTrace();
+            System.exit(1);
         }
     }
 
@@ -22,6 +23,7 @@ public class BinaryLoader {
             return deserializer.readObject();
         } catch (ClassNotFoundException e) {
             e.printStackTrace();
+            System.exit(1);
         } catch (IOException e) {
             GlobalSettings.kem.register(new KException(KException.ExceptionType.ERROR, KException.KExceptionGroup.CRITICAL, "Kompiled definition is out of date with latest version of the K tool. Please re-run kompile and try again."));
         }


### PR DESCRIPTION
This is a bug that causes serialization errors to report a 0 return value on the command line, resulting in ktest passing even though kompilation did not succeed.
