### PR TITLE
fix ktest colorful output printing for non-ANSI terminals (issue #368)

### DIFF
--- a/src/javasources/KTool/src/org/kframework/ktest/KTest.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/KTest.java
@@ -4,6 +4,7 @@ package org.kframework.ktest;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.FilenameUtils;
+import org.fusesource.jansi.AnsiConsole;
 import org.kframework.ktest.CmdArgs.CmdArg;
 import org.kframework.ktest.CmdArgs.CmdArgParser;
 import org.kframework.ktest.CmdArgs.Constants;
@@ -98,6 +99,7 @@ public class KTest {
     }
 
     public static void main(String[] args) {
+        AnsiConsole.systemInstall();
         try {
             System.exit(new KTest(args).run());
         } catch (ParseException | InvalidArgumentException | SAXException |


### PR DESCRIPTION
#368

This should fix it. We could do two things:
1. Replace `System.out.print[ln]` calls that prints colorful texts with `AnsiTerminal.out.print[ln]`
2. Just call `AnsiTerminal.systemInstall()` and use `System.out` as usual.

I choose second one. Please tell me if you see problems with that.

Note: We can also do that in krun. Currently it uses `AnsiTerminal.out` when it prints colorful text and we don't know for sure that no colorful text is printed using `System.out`.
