### PR TITLE
Lowercase copyright

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Copyright (C) 2012-2014 K Team. All Rights Reserved. -->
+<!-- Copyright (c) 2012-2014 K Team. All Rights Reserved. -->
 <project basedir="." default="build" name="KTool Build file">
 
 	<property location="src/javasources" name="javasources" />

--- a/include/builtins/float.k
+++ b/include/builtins/float.k
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 require "bool.k"
 require "int.k"
 module FLOAT-SYNTAX-HOOKS

--- a/include/builtins/id.k
+++ b/include/builtins/id.k
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 require "string.k"
 
 module ID-SYNTAX-HOOKS

--- a/include/builtins/int.k
+++ b/include/builtins/int.k
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 require "k-equal.k"
 module INT-SYNTAX-HOOKS
   imports #INT-INTERFACE

--- a/include/builtins/model-checker.k
+++ b/include/builtins/model-checker.k
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 require "bool.k"
 
 module LTL-SYNTAX-HOOKS

--- a/include/builtins/string.k
+++ b/include/builtins/string.k
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 require "int.k"
 require "float.k"
 

--- a/include/modules/k-visitor.k
+++ b/include/modules/k-visitor.k
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 
 require "builtins/k-equal.k"
 

--- a/lib/ktest.xsd
+++ b/lib/ktest.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
-<!-- Copyright (C) 2013-2014 K Team. All Rights Reserved. -->
+<!-- Copyright (c) 2013-2014 K Team. All Rights Reserved. -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 <xs:complexType name="program-config">
   <xs:sequence>

--- a/samples/agent/quote-unquote.k
+++ b/samples/agent/quote-unquote.k
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 
 require "/modules/k-visitor.k"
 

--- a/samples/java_rewrite_engine/tutorial/1_k/2_imp/tests/config.xml
+++ b/samples/java_rewrite_engine/tutorial/1_k/2_imp/tests/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (C) 2012-2014 K Team. All Rights Reserved. -->
+<!-- Copyright (c) 2012-2014 K Team. All Rights Reserved. -->
 
 <tests>
 

--- a/samples/java_rewrite_engine/tutorial/1_k/4_imp++/tests/config.xml
+++ b/samples/java_rewrite_engine/tutorial/1_k/4_imp++/tests/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (C) 2012-2014 K Team. All Rights Reserved. -->
+<!-- Copyright (c) 2012-2014 K Team. All Rights Reserved. -->
 <tests>
 
   <include file="../../../../../../tutorial/1_k/4_imp++/lesson_8/tests/config.xml" exclude="spawn 2_imp div">

--- a/src/javasources/KTool/buildjar.xml
+++ b/src/javasources/KTool/buildjar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Copyright (C) 2012-2014 K Team. All Rights Reserved. -->
+<!-- Copyright (c) 2012-2014 K Team. All Rights Reserved. -->
 <project default="jar" name="Create Runnable Jar for Project KTool">
 	<property name="jarfile" location="../../../lib/java/k3.jar" />
 	<target name="jar">

--- a/src/javasources/KTool/buildjava.xml
+++ b/src/javasources/KTool/buildjava.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Copyright (C) 2012-2014 K Team. All Rights Reserved. -->
+<!-- Copyright (c) 2012-2014 K Team. All Rights Reserved. -->
 <!-- WARNING: Eclipse auto-generated file.
               Any modifications will be overwritten.
               To include a user specific buildfile here, simply create one in the same

--- a/src/javasources/KTool/checkstyle-copyright.xml
+++ b/src/javasources/KTool/checkstyle-copyright.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (C) 2014 K Team. All Rights Reserved. -->
+<!-- Copyright (c) 2014 K Team. All Rights Reserved. -->
 <!DOCTYPE module PUBLIC
 "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
 "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
@@ -12,43 +12,43 @@
        be effectively automated. -->
   <!-- TODO: add modules as needed to support comments in other programming languages -->
   <module name="RegexpHeader">
-    <property name="header" value="^&lt;\?xml.*\?&gt;$\n^&lt;!-- Copyright \(C\) (\d\d\d\d-)?2014 K Team. All Rights Reserved. --&gt;$" />
+    <property name="header" value="^&lt;\?xml.*\?&gt;$\n^&lt;!-- Copyright \(c\) (\d\d\d\d-)?2014 K Team. All Rights Reserved. --&gt;$" />
     <property name="fileExtensions" value="xml,xsd" />
   </module>
   <module name="RegexpHeader">
-    <property name="header" value="^&lt;!-- Copyright \(C\) (\d\d\d\d-)?2014 K Team. All Rights Reserved. --&gt;$" />
+    <property name="header" value="^&lt;!-- Copyright \(c\) (\d\d\d\d-)?2014 K Team. All Rights Reserved. --&gt;$" />
     <property name="fileExtensions" value="md" />
   </module>
   <module name="RegexpHeader">
-    <property name="header" value="^// Copyright \(C\) (\d\d\d\d-)?2014 K Team. All Rights Reserved.$" />
+    <property name="header" value="^// Copyright \(c\) (\d\d\d\d-)?2014 K Team. All Rights Reserved.$" />
     <property name="fileExtensions" value="k,kore,java,jj,c,h,str" />
   </module>
   <module name="RegexpHeader">
-    <property name="header" value="^--- Copyright \(C\) (\d\d\d\d-)?2014 K Team. All Rights Reserved.$" />
+    <property name="header" value="^--- Copyright \(c\) (\d\d\d\d-)?2014 K Team. All Rights Reserved.$" />
     <property name="fileExtensions" value="maude" />
   </module>
   <module name="RegexpHeader">
-    <property name="header" value="^-- Copyright \(C\) (\d\d\d\d-)?2014 K Team. All Rights Reserved.$" />
+    <property name="header" value="^-- Copyright \(c\) (\d\d\d\d-)?2014 K Team. All Rights Reserved.$" />
     <property name="fileExtensions" value="hs" />
   </module>
   <module name="RegexpHeader">
-    <property name="header" value="^/\* Copyright \(C\) (\d\d\d\d-)?2014 K Team. All Rights Reserved. \*/$" />
+    <property name="header" value="^/\* Copyright \(c\) (\d\d\d\d-)?2014 K Team. All Rights Reserved. \*/$" />
     <property name="fileExtensions" value="css" />
   </module>
   <module name="RegexpHeader">
-    <property name="header" value="^#!.*$\n^# Copyright \(C\) (\d\d\d\d-)?2014 K Team. All Rights Reserved.$" />
+    <property name="header" value="^#!.*$\n^# Copyright \(c\) (\d\d\d\d-)?2014 K Team. All Rights Reserved.$" />
     <property name="fileExtensions" value="sh,py" />
   </module>
   <module name="RegexpHeader">
-    <property name="header" value="^&quot; Copyright \(C\) (\d\d\d\d-)?2014 K Team. All Rights Reserved.$" />
+    <property name="header" value="^&quot; Copyright \(c\) (\d\d\d\d-)?2014 K Team. All Rights Reserved.$" />
     <property name="fileExtensions" value="vim" />
   </module>
   <module name="RegexpHeader">
-    <property name="header" value="% Copyright \(C\) (\d\d\d\d-)?2014 K Team. All Rights Reserved.$" />
+    <property name="header" value="% Copyright \(c\) (\d\d\d\d-)?2014 K Team. All Rights Reserved.$" />
     <property name="fileExtensions" value="sty,tex,cls" />
   </module>
   <module name="RegexpHeader">
-    <property name="header" value="%% Copyright \(C\) (\d\d\d\d-)?2014 K Team. All Rights Reserved.$" />
+    <property name="header" value="%% Copyright \(c\) (\d\d\d\d-)?2014 K Team. All Rights Reserved.$" />
     <property name="fileExtensions" value="sdf" />
   </module>
 </module>

--- a/src/javasources/KTool/src/org/kframework/backend/BackendFilter.java
+++ b/src/javasources/KTool/src/org/kframework/backend/BackendFilter.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.backend;
 
 import org.kframework.kil.loader.Context;

--- a/src/javasources/KTool/src/org/kframework/backend/BasicBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/BasicBackend.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.backend;
 
 import org.kframework.compile.FlattenModules;

--- a/src/javasources/KTool/src/org/kframework/backend/SMTSolver.java
+++ b/src/javasources/KTool/src/org/kframework/backend/SMTSolver.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.backend;
 
 /**

--- a/src/javasources/KTool/src/org/kframework/backend/html/HTMLFilter.java
+++ b/src/javasources/KTool/src/org/kframework/backend/html/HTMLFilter.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.backend.html;
 
 import org.kframework.backend.BackendFilter;

--- a/src/javasources/KTool/src/org/kframework/backend/html/HtmlBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/html/HtmlBackend.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.backend.html;
 
 import org.apache.commons.io.FilenameUtils;

--- a/src/javasources/KTool/src/org/kframework/backend/java/indexing/IndexingAlgorithm.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/indexing/IndexingAlgorithm.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.indexing;
 
 import org.kframework.backend.java.indexing.pathIndex.PathIndex;

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/BuiltinList.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/BuiltinList.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 
 package org.kframework.backend.java.kil;
 

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/KItem.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/KItem.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.kil;
 
 import java.util.Collection;

--- a/src/javasources/KTool/src/org/kframework/backend/java/ksimulation/Adjuster.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/ksimulation/Adjuster.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.ksimulation;
 
 import java.util.ArrayList;

--- a/src/javasources/KTool/src/org/kframework/backend/java/ksimulation/Waitor.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/ksimulation/Waitor.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.ksimulation;
 
 import java.util.ArrayList;

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/JavaSymbolicBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/JavaSymbolicBackend.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.symbolic;
 
 import org.kframework.backend.BasicBackend;

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/JavaSymbolicKRun.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/JavaSymbolicKRun.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.symbolic;
 
 

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicConstraint.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicConstraint.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 
 package org.kframework.backend.java.symbolic;
 

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.symbolic;
 
 import static org.kframework.backend.java.util.TestCaseGenerationSettings.PHASE_ONE_BOUND_FREEVARS;

--- a/src/javasources/KTool/src/org/kframework/backend/kore/KoreBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/kore/KoreBackend.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.kore;
 
 import org.kframework.backend.BasicBackend;

--- a/src/javasources/KTool/src/org/kframework/backend/latex/DocumentationFilter.java
+++ b/src/javasources/KTool/src/org/kframework/backend/latex/DocumentationFilter.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.backend.latex;
 
 import org.kframework.kil.Attributes;

--- a/src/javasources/KTool/src/org/kframework/backend/latex/LatexBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/latex/LatexBackend.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.backend.latex;
 
 import org.apache.commons.io.FileUtils;

--- a/src/javasources/KTool/src/org/kframework/backend/latex/PdfBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/latex/PdfBackend.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.backend.latex;
 
 import org.apache.commons.io.FilenameUtils;

--- a/src/javasources/KTool/src/org/kframework/backend/maude/KompileBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/maude/KompileBackend.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.maude;
 
 import org.kframework.backend.BasicBackend;

--- a/src/javasources/KTool/src/org/kframework/backend/maude/MaudeBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/maude/MaudeBackend.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.backend.maude;
 
 import org.apache.commons.lang3.StringEscapeUtils;

--- a/src/javasources/KTool/src/org/kframework/backend/maude/MaudeFilter.java
+++ b/src/javasources/KTool/src/org/kframework/backend/maude/MaudeFilter.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.backend.maude;
 
 import org.kframework.backend.BackendFilter;

--- a/src/javasources/KTool/src/org/kframework/backend/maude/krun/MaudeKRun.java
+++ b/src/javasources/KTool/src/org/kframework/backend/maude/krun/MaudeKRun.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.maude.krun;
 
 import org.apache.commons.collections15.Transformer;

--- a/src/javasources/KTool/src/org/kframework/backend/symbolic/AddPathCondition.java
+++ b/src/javasources/KTool/src/org/kframework/backend/symbolic/AddPathCondition.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.symbolic;
 
 import java.util.ArrayList;

--- a/src/javasources/KTool/src/org/kframework/backend/symbolic/AddSymbolicVariablesDeclaration.java
+++ b/src/javasources/KTool/src/org/kframework/backend/symbolic/AddSymbolicVariablesDeclaration.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.symbolic;
 
 import org.kframework.kil.*;

--- a/src/javasources/KTool/src/org/kframework/backend/symbolic/ResolveLtlAttributes.java
+++ b/src/javasources/KTool/src/org/kframework/backend/symbolic/ResolveLtlAttributes.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 
 package org.kframework.backend.symbolic;
 

--- a/src/javasources/KTool/src/org/kframework/backend/symbolic/SearchLTLState.java
+++ b/src/javasources/KTool/src/org/kframework/backend/symbolic/SearchLTLState.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 
 package org.kframework.backend.symbolic;
 

--- a/src/javasources/KTool/src/org/kframework/backend/symbolic/SymbolicBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/symbolic/SymbolicBackend.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.symbolic;
 
 import org.kframework.backend.Backend;

--- a/src/javasources/KTool/src/org/kframework/backend/symbolic/TagUserRules.java
+++ b/src/javasources/KTool/src/org/kframework/backend/symbolic/TagUserRules.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.symbolic;
 
 import org.kframework.kil.ASTNode;

--- a/src/javasources/KTool/src/org/kframework/backend/symbolic/WrapVariableWithTopCell.java
+++ b/src/javasources/KTool/src/org/kframework/backend/symbolic/WrapVariableWithTopCell.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 
 package org.kframework.backend.symbolic;
 

--- a/src/javasources/KTool/src/org/kframework/backend/unparser/Indenter.java
+++ b/src/javasources/KTool/src/org/kframework/backend/unparser/Indenter.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.backend.unparser;
 
 public class Indenter {

--- a/src/javasources/KTool/src/org/kframework/backend/unparser/UnflattenBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/unparser/UnflattenBackend.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.unparser;
 
 import org.apache.commons.io.FilenameUtils;

--- a/src/javasources/KTool/src/org/kframework/backend/unparser/UnparserBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/unparser/UnparserBackend.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.backend.unparser;
 
 import org.apache.commons.io.FilenameUtils;

--- a/src/javasources/KTool/src/org/kframework/backend/unparser/UnparserFilterNew.java
+++ b/src/javasources/KTool/src/org/kframework/backend/unparser/UnparserFilterNew.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.backend.unparser;
 
 import org.kframework.compile.utils.MetaK;

--- a/src/javasources/KTool/src/org/kframework/compile/checks/CheckSyntaxDecl.java
+++ b/src/javasources/KTool/src/org/kframework/compile/checks/CheckSyntaxDecl.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.compile.checks;
 
 import java.util.HashMap;

--- a/src/javasources/KTool/src/org/kframework/compile/checks/CheckVariables.java
+++ b/src/javasources/KTool/src/org/kframework/compile/checks/CheckVariables.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.compile.checks;
 
 import org.kframework.compile.utils.MetaK;

--- a/src/javasources/KTool/src/org/kframework/compile/sharing/TokenSortCollector.java
+++ b/src/javasources/KTool/src/org/kframework/compile/sharing/TokenSortCollector.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.compile.sharing;
 
 import org.kframework.kil.Configuration;

--- a/src/javasources/KTool/src/org/kframework/compile/tags/AddOptionalTags.java
+++ b/src/javasources/KTool/src/org/kframework/compile/tags/AddOptionalTags.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.compile.tags;
 
 import org.kframework.kil.ASTNode;

--- a/src/javasources/KTool/src/org/kframework/compile/transformers/AddHeatingConditions.java
+++ b/src/javasources/KTool/src/org/kframework/compile/transformers/AddHeatingConditions.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.compile.transformers;
 
 import org.kframework.compile.utils.MetaK;

--- a/src/javasources/KTool/src/org/kframework/compile/transformers/AddSuperheatRules.java
+++ b/src/javasources/KTool/src/org/kframework/compile/transformers/AddSuperheatRules.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.compile.transformers;
 
 import org.kframework.compile.utils.MetaK;

--- a/src/javasources/KTool/src/org/kframework/compile/transformers/ContextsToHeating.java
+++ b/src/javasources/KTool/src/org/kframework/compile/transformers/ContextsToHeating.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.compile.transformers;
 
 import org.kframework.compile.utils.MetaK;

--- a/src/javasources/KTool/src/org/kframework/compile/transformers/FlattenSyntax.java
+++ b/src/javasources/KTool/src/org/kframework/compile/transformers/FlattenSyntax.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.compile.transformers;
 
 import org.kframework.compile.utils.KilProperty;

--- a/src/javasources/KTool/src/org/kframework/compile/transformers/FlattenTerms.java
+++ b/src/javasources/KTool/src/org/kframework/compile/transformers/FlattenTerms.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.compile.transformers;
 
 import org.kframework.compile.utils.KilProperty;

--- a/src/javasources/KTool/src/org/kframework/compile/transformers/ResolveBinder.java
+++ b/src/javasources/KTool/src/org/kframework/compile/transformers/ResolveBinder.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.compile.transformers;
 
 import com.google.common.collect.HashMultimap;

--- a/src/javasources/KTool/src/org/kframework/compile/transformers/ResolveFunctions.java
+++ b/src/javasources/KTool/src/org/kframework/compile/transformers/ResolveFunctions.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 
 package org.kframework.compile.transformers;
 

--- a/src/javasources/KTool/src/org/kframework/compile/transformers/ResolveSupercool.java
+++ b/src/javasources/KTool/src/org/kframework/compile/transformers/ResolveSupercool.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.compile.transformers;
 
 import org.kframework.kil.*;

--- a/src/javasources/KTool/src/org/kframework/compile/transformers/StrictnessToContexts.java
+++ b/src/javasources/KTool/src/org/kframework/compile/transformers/StrictnessToContexts.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.compile.transformers;
 
 import org.kframework.compile.utils.MetaK;

--- a/src/javasources/KTool/src/org/kframework/kagreg/KagregFrontEnd.java
+++ b/src/javasources/KTool/src/org/kframework/kagreg/KagregFrontEnd.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.kagreg;
 
 import java.io.*;

--- a/src/javasources/KTool/src/org/kframework/kast/KastFrontEnd.java
+++ b/src/javasources/KTool/src/org/kframework/kast/KastFrontEnd.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.kast;
 
 import java.io.*;

--- a/src/javasources/KTool/src/org/kframework/kast/KastOptionsParser.java
+++ b/src/javasources/KTool/src/org/kframework/kast/KastOptionsParser.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.kast;
 
 import org.apache.commons.cli.*;

--- a/src/javasources/KTool/src/org/kframework/kcheck/KCheckFrontEnd.java
+++ b/src/javasources/KTool/src/org/kframework/kcheck/KCheckFrontEnd.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.kcheck;
 
 import java.io.File;

--- a/src/javasources/KTool/src/org/kframework/kcheck/RLBackend.java
+++ b/src/javasources/KTool/src/org/kframework/kcheck/RLBackend.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.kcheck;
 
 import java.io.File;

--- a/src/javasources/KTool/src/org/kframework/kil/Ambiguity.java
+++ b/src/javasources/KTool/src/org/kframework/kil/Ambiguity.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.kil;
 
 import org.kframework.kil.matchers.Matcher;

--- a/src/javasources/KTool/src/org/kframework/kil/KLabelConstant.java
+++ b/src/javasources/KTool/src/org/kframework/kil/KLabelConstant.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 
 package org.kframework.kil;
 

--- a/src/javasources/KTool/src/org/kframework/kil/KList.java
+++ b/src/javasources/KTool/src/org/kframework/kil/KList.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.kil;
 
 import org.kframework.kil.visitors.Transformer;

--- a/src/javasources/KTool/src/org/kframework/kil/Production.java
+++ b/src/javasources/KTool/src/org/kframework/kil/Production.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.kil;
 
 import com.google.common.collect.Multimap;

--- a/src/javasources/KTool/src/org/kframework/kil/TermCons.java
+++ b/src/javasources/KTool/src/org/kframework/kil/TermCons.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.kil;
 
 import java.util.ArrayList;

--- a/src/javasources/KTool/src/org/kframework/kil/UserList.java
+++ b/src/javasources/KTool/src/org/kframework/kil/UserList.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.kil;
 
 import org.kframework.kil.visitors.Transformer;

--- a/src/javasources/KTool/src/org/kframework/kil/loader/Constants.java
+++ b/src/javasources/KTool/src/org/kframework/kil/loader/Constants.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.kil.loader;
 
 import java.util.HashMap;

--- a/src/javasources/KTool/src/org/kframework/kil/loader/Context.java
+++ b/src/javasources/KTool/src/org/kframework/kil/loader/Context.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.kil.loader;
 
 import java.io.File;

--- a/src/javasources/KTool/src/org/kframework/kil/visitors/BasicTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/kil/visitors/BasicTransformer.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.kil.visitors;
 
 import java.util.*;

--- a/src/javasources/KTool/src/org/kframework/kil/visitors/CopyOnWriteTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/kil/visitors/CopyOnWriteTransformer.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.kil.visitors;
 
 import java.util.ArrayList;

--- a/src/javasources/KTool/src/org/kframework/kompile/KompileFrontEnd.java
+++ b/src/javasources/KTool/src/org/kframework/kompile/KompileFrontEnd.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.kompile;
 
 import java.io.File;

--- a/src/javasources/KTool/src/org/kframework/kompile/KompileOptions.java
+++ b/src/javasources/KTool/src/org/kframework/kompile/KompileOptions.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.kompile;
 
 import java.io.File;

--- a/src/javasources/KTool/src/org/kframework/krun/K.java
+++ b/src/javasources/KTool/src/org/kframework/krun/K.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.krun;
 
 import org.kframework.kil.loader.Context;

--- a/src/javasources/KTool/src/org/kframework/krun/Main.java
+++ b/src/javasources/KTool/src/org/kframework/krun/Main.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.krun;
 
 import static org.apache.commons.io.FileUtils.deleteDirectory;

--- a/src/javasources/KTool/src/org/kframework/krun/api/io/FileSystem.java
+++ b/src/javasources/KTool/src/org/kframework/krun/api/io/FileSystem.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.krun.api.io;
 
 import java.io.IOException;

--- a/src/javasources/KTool/src/org/kframework/krun/gui/Controller/RunKRunCommand.java
+++ b/src/javasources/KTool/src/org/kframework/krun/gui/Controller/RunKRunCommand.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.krun.gui.Controller;
 
 import org.kframework.backend.java.symbolic.JavaSymbolicKRun;

--- a/src/javasources/KTool/src/org/kframework/krun/ioserver/main/MainServer.java
+++ b/src/javasources/KTool/src/org/kframework/krun/ioserver/main/MainServer.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.krun.ioserver.main;
 
 import org.kframework.kil.loader.Context;

--- a/src/javasources/KTool/src/org/kframework/ktest/CmdArgs/CmdArg.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/CmdArgs/CmdArg.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.ktest.CmdArgs;
 
 import org.apache.commons.cli.CommandLine;

--- a/src/javasources/KTool/src/org/kframework/ktest/Config/ConfigFileParser.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Config/ConfigFileParser.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.ktest.Config;
 
 import org.apache.commons.io.FilenameUtils;

--- a/src/javasources/KTool/src/org/kframework/ktest/IgnoringStringMatcher.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/IgnoringStringMatcher.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.ktest;
 
 public class IgnoringStringMatcher implements StringMatcher {

--- a/src/javasources/KTool/src/org/kframework/ktest/KTest.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/KTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.ktest;
 
 import org.apache.commons.cli.HelpFormatter;

--- a/src/javasources/KTool/src/org/kframework/ktest/Proc.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Proc.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.ktest;
 
 import org.apache.commons.io.IOUtils;

--- a/src/javasources/KTool/src/org/kframework/ktest/RegexStringMatcher.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/RegexStringMatcher.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.ktest;
 
 import java.util.regex.Matcher;

--- a/src/javasources/KTool/src/org/kframework/ktest/StringMatcher.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/StringMatcher.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.ktest;
 
 public interface StringMatcher {

--- a/src/javasources/KTool/src/org/kframework/ktest/Test/KRunProgram.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Test/KRunProgram.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.ktest.Test;
 
 import org.apache.commons.io.FilenameUtils;

--- a/src/javasources/KTool/src/org/kframework/ktest/Test/ProgramProfile.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Test/ProgramProfile.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.ktest.Test;
 
 import java.util.List;

--- a/src/javasources/KTool/src/org/kframework/ktest/Test/TestCase.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Test/TestCase.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.ktest.Test;
 
 import org.apache.commons.io.FilenameUtils;

--- a/src/javasources/KTool/src/org/kframework/ktest/Test/TestSuite.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Test/TestSuite.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.ktest.Test;
 
 import org.apache.commons.io.FilenameUtils;

--- a/src/javasources/KTool/src/org/kframework/main/GlobalOptions.java
+++ b/src/javasources/KTool/src/org/kframework/main/GlobalOptions.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.main;
 
 import java.util.EnumSet;

--- a/src/javasources/KTool/src/org/kframework/main/Main.java
+++ b/src/javasources/KTool/src/org/kframework/main/Main.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.main;
 
 import java.io.IOException;

--- a/src/javasources/KTool/src/org/kframework/parser/DefinitionLoader.java
+++ b/src/javasources/KTool/src/org/kframework/parser/DefinitionLoader.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.parser;
 
 import java.io.File;

--- a/src/javasources/KTool/src/org/kframework/parser/ExperimentalParserOptions.java
+++ b/src/javasources/KTool/src/org/kframework/parser/ExperimentalParserOptions.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.parser;
 
 import com.beust.jcommander.Parameter;

--- a/src/javasources/KTool/src/org/kframework/parser/ProgramLoader.java
+++ b/src/javasources/KTool/src/org/kframework/parser/ProgramLoader.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.parser;
 
 import java.io.File;

--- a/src/javasources/KTool/src/org/kframework/parser/concrete2/AutoVivifyingBiMap.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete2/AutoVivifyingBiMap.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.parser.concrete2;
 
 import com.google.common.collect.BiMap;

--- a/src/javasources/KTool/src/org/kframework/parser/concrete2/Grammar.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete2/Grammar.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.parser.concrete2;
 
 import java.io.Serializable;

--- a/src/javasources/KTool/src/org/kframework/parser/concrete2/KSyntax2GrammarStatesFilter.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete2/KSyntax2GrammarStatesFilter.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.parser.concrete2;
 
 import java.util.regex.Pattern;

--- a/src/javasources/KTool/src/org/kframework/parser/concrete2/Nullability.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete2/Nullability.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.parser.concrete2;
 
 import java.util.HashSet;

--- a/src/javasources/KTool/src/org/kframework/parser/concrete2/Parser.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete2/Parser.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.parser.concrete2;
 
 import com.google.common.collect.BiMap;

--- a/src/javasources/KTool/src/org/kframework/parser/concrete2/Rule.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete2/Rule.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.parser.concrete2;
 
 import java.io.Serializable;

--- a/src/javasources/KTool/src/org/kframework/parser/concrete2/SCCTarjan.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete2/SCCTarjan.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 // This is a modified version of
 // https://github.com/indy256/codelibrary/blob/master/java/src/SCCTarjan.java
 // which is licensed under the Unlicense http://unlicense.org/UNLICENSE

--- a/src/javasources/KTool/src/org/kframework/parser/concrete2/TreeCleanerVisitor.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete2/TreeCleanerVisitor.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.parser.concrete2;
 
 import java.util.ArrayList;

--- a/src/javasources/KTool/src/org/kframework/parser/generator/BasicParser.java
+++ b/src/javasources/KTool/src/org/kframework/parser/generator/BasicParser.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.parser.generator;
 
 import java.io.File;

--- a/src/javasources/KTool/src/org/kframework/parser/generator/ParseConfigsFilter.java
+++ b/src/javasources/KTool/src/org/kframework/parser/generator/ParseConfigsFilter.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.parser.generator;
 
 import org.kframework.kil.ASTNode;

--- a/src/javasources/KTool/src/org/kframework/parser/generator/ParseRulesFilter.java
+++ b/src/javasources/KTool/src/org/kframework/parser/generator/ParseRulesFilter.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.parser.generator;
 
 import java.io.File;

--- a/src/javasources/KTool/src/org/kframework/parser/generator/ProgramSDF.java
+++ b/src/javasources/KTool/src/org/kframework/parser/generator/ProgramSDF.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.parser.generator;
 
 import java.util.HashSet;

--- a/src/javasources/KTool/src/org/kframework/utils/BinaryLoader.java
+++ b/src/javasources/KTool/src/org/kframework/utils/BinaryLoader.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2013-2014 K Team. All Rights Reserved.
+// Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.utils;
 
 import java.io.*;

--- a/src/javasources/KTool/src/org/kframework/utils/Error.java
+++ b/src/javasources/KTool/src/org/kframework/utils/Error.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.utils;
 
 import java.io.File;

--- a/src/javasources/KTool/src/org/kframework/utils/Stopwatch.java
+++ b/src/javasources/KTool/src/org/kframework/utils/Stopwatch.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.utils;
 
 import org.kframework.main.GlobalOptions;

--- a/src/javasources/KTool/src/org/kframework/utils/StringUtil.java
+++ b/src/javasources/KTool/src/org/kframework/utils/StringUtil.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.utils;
 
 import java.util.Arrays;

--- a/src/javasources/KTool/src/org/kframework/utils/errorsystem/KExceptionManager.java
+++ b/src/javasources/KTool/src/org/kframework/utils/errorsystem/KExceptionManager.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.utils.errorsystem;
 
 import org.kframework.main.GlobalOptions;

--- a/src/javasources/KTool/src/org/kframework/utils/general/GlobalSettings.java
+++ b/src/javasources/KTool/src/org/kframework/utils/general/GlobalSettings.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.utils.general;
 
 import org.kframework.utils.errorsystem.KExceptionManager;

--- a/src/javasources/KTool/src/org/kframework/utils/options/BaseEnumConverter.java
+++ b/src/javasources/KTool/src/org/kframework/utils/options/BaseEnumConverter.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.utils.options;
 
 import java.util.EnumSet;

--- a/src/javasources/KTool/src/org/kframework/utils/options/SortedParameterDescriptions.java
+++ b/src/javasources/KTool/src/org/kframework/utils/options/SortedParameterDescriptions.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.utils.options;
 
 import java.util.Comparator;

--- a/src/javasources/KTool/test/org/kframework/backend/java/kil/BuiltinListTest.java
+++ b/src/javasources/KTool/test/org/kframework/backend/java/kil/BuiltinListTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 
 package org.kframework.backend.java.kil;
 

--- a/src/javasources/KTool/test/org/kframework/backend/symbolic/LTLModelCheckerTest.java
+++ b/src/javasources/KTool/test/org/kframework/backend/symbolic/LTLModelCheckerTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 
 package org.kframework.backend.symbolic;
 

--- a/src/javasources/KTool/test/org/kframework/kompile/KompileOptionsTest.java
+++ b/src/javasources/KTool/test/org/kframework/kompile/KompileOptionsTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.kompile;
 
 import static org.junit.Assert.*;

--- a/src/javasources/KTool/test/org/kframework/parser/concrete2/ParserTest.java
+++ b/src/javasources/KTool/test/org/kframework/parser/concrete2/ParserTest.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.parser.concrete2;
 
 import java.lang.management.ManagementFactory;

--- a/tests/config.xml
+++ b/tests/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!-- Copyright (C) 2012-2014 K Team. All Rights Reserved. -->
+<!-- Copyright (c) 2012-2014 K Team. All Rights Reserved. -->
 
 <!--
   Use these tags for comments.  To test only one language,

--- a/tests/config_java.xml
+++ b/tests/config_java.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (C) 2012-2014 K Team. All Rights Reserved. -->
+<!-- Copyright (c) 2012-2014 K Team. All Rights Reserved. -->
 <tests>
 
 <!-- begin Java Rewrite Engine tests -->

--- a/tests/newparser/01-list/test.k
+++ b/tests/newparser/01-list/test.k
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 module TEST
 
   configuration <k> $PGM:Exps </k>

--- a/tests/newparser/02-arithmetic-expressions/test.k
+++ b/tests/newparser/02-arithmetic-expressions/test.k
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 module TEST
 
   configuration <k> $PGM:Exp </k>

--- a/tests/newparser/03-arithmetic-expressions-amb/test.k
+++ b/tests/newparser/03-arithmetic-expressions-amb/test.k
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 module TEST
 
   configuration <k> $PGM:Exp </k>

--- a/tests/newparser/04-ambiguous-constructor/test.k
+++ b/tests/newparser/04-ambiguous-constructor/test.k
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 K Team. All Rights Reserved.
+// Copyright (c) 2014 K Team. All Rights Reserved.
 module TEST
 
   configuration <k> $PGM:Exp </k>

--- a/tests/regression/issue#313/test.k
+++ b/tests/regression/issue#313/test.k
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 
 module TEST
   syntax KLabel ::= "#foo"

--- a/tests/regression/profiler/test.k
+++ b/tests/regression/profiler/test.k
@@ -1,4 +1,4 @@
-// Copyright (C) 2012-2014 K Team. All Rights Reserved.
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 
 module TEST
      syntax K ::= "a" | "b"

--- a/tutorial/1_k/4_imp++/lesson_3/tests/config.xml
+++ b/tutorial/1_k/4_imp++/lesson_3/tests/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!-- Copyright (C) 2012-2014 K Team. All Rights Reserved. -->
+<!-- Copyright (c) 2012-2014 K Team. All Rights Reserved. -->
 <tests>
 
   <include file="../../lesson_2/tests/config.xml"

--- a/tutorial/2_languages/4_logik/basic/tests/config.xml
+++ b/tutorial/2_languages/4_logik/basic/tests/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<!-- Copyright (C) 2012-2014 K Team. All Rights Reserved. -->
+<!-- Copyright (c) 2012-2014 K Team. All Rights Reserved. -->
 <tests>
 
   <test


### PR DESCRIPTION
Changed the top-of-file copyright to use a lower case "(c)" instead of upper case.  This makes it consistent with the LICENSE file and is the way it is most commonly seen.
