### PR TITLE
use AnsiConsole.systemInstall and remove AnsiConsole.out calls

### DIFF
--- a/src/javasources/KTool/src/org/kframework/backend/java/ksimulation/Adjuster.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/ksimulation/Adjuster.java
@@ -24,7 +24,6 @@ import com.microsoft.z3.Expr;
 import com.microsoft.z3.Solver;
 import com.microsoft.z3.Status;
 import com.microsoft.z3.Z3Exception;
-import org.fusesource.jansi.AnsiConsole;
 
 public class Adjuster {
     

--- a/src/javasources/KTool/src/org/kframework/backend/java/ksimulation/Adjuster.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/ksimulation/Adjuster.java
@@ -1,3 +1,4 @@
+// Copyright (C) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.ksimulation;
 
 import java.util.ArrayList;

--- a/src/javasources/KTool/src/org/kframework/backend/java/ksimulation/Waitor.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/ksimulation/Waitor.java
@@ -5,7 +5,6 @@ import java.util.HashSet;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import org.fusesource.jansi.AnsiConsole;
 import org.kframework.backend.java.symbolic.JavaSymbolicKRun;
 import org.kframework.kil.loader.Context;
 import org.kframework.krun.KRunExecutionException;
@@ -96,8 +95,7 @@ public class Waitor extends Thread{
             
             if(Waitor.result){
                 
-                AnsiConsole.out
-                .println(true);
+                System.out.println(true);
                 break;
             }
             else {
@@ -115,8 +113,7 @@ public class Waitor extends Thread{
                 
                 if(temp<=0){
                 
-                    AnsiConsole.out
-                    .println(false);
+                    System.out.println(false);
                 break;
                 }
             }

--- a/src/javasources/KTool/src/org/kframework/backend/java/ksimulation/Waitor.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/ksimulation/Waitor.java
@@ -1,3 +1,4 @@
+// Copyright (C) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.ksimulation;
 
 import java.util.ArrayList;

--- a/src/javasources/KTool/src/org/kframework/kil/TermCons.java
+++ b/src/javasources/KTool/src/org/kframework/kil/TermCons.java
@@ -1,3 +1,4 @@
+// Copyright (C) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.kil;
 
 import java.util.ArrayList;

--- a/src/javasources/KTool/src/org/kframework/kil/TermCons.java
+++ b/src/javasources/KTool/src/org/kframework/kil/TermCons.java
@@ -3,7 +3,6 @@ package org.kframework.kil;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.fusesource.jansi.AnsiConsole;
 import org.kframework.kil.loader.*;
 import org.kframework.kil.loader.Context;
 import org.kframework.kil.matchers.Matcher;

--- a/src/javasources/KTool/src/org/kframework/krun/Main.java
+++ b/src/javasources/KTool/src/org/kframework/krun/Main.java
@@ -29,7 +29,6 @@ import jline.SimpleCompletor;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.io.FilenameUtils;
-import org.fusesource.jansi.AnsiConsole;
 import org.kframework.backend.java.ksimulation.Waitor;
 import org.kframework.backend.java.symbolic.JavaSymbolicKRun;
 import org.kframework.backend.maude.krun.MaudeKRun;
@@ -513,7 +512,7 @@ public class Main {
                 }
                 
                 if (!cmd.hasOption("output-file")) {
-                    AnsiConsole.out.println(output);
+                    System.out.println(output);
                 } else {
                     writeStringToFile(new File(K.output), output);
                 }
@@ -522,8 +521,7 @@ public class Main {
                     System.out.println(K.lineSeparator + "The search graph is:"
                             + K.lineSeparator);
                     KRunResult<SearchResults> searchResult = (KRunResult<SearchResults>) result;
-                    AnsiConsole.out
-                            .println(searchResult.getResult().getGraph());
+                    System.out.println(searchResult.getResult().getGraph());
                     // offer the user the possibility to turn execution into
                     // debug mode
                     while (true) {
@@ -619,8 +617,7 @@ public class Main {
                     debugger = krun.debug(t);
                     System.out
                             .println("After running one step of execution the result is:");
-                    AnsiConsole.out.println(debugger.printState(debugger
-                            .getCurrentState()));
+                    System.out.println(debugger.printState(debugger.getCurrentState()));
                 } else {
                     debugger = krun.debug(state.getResult().getGraph());
                 }
@@ -680,8 +677,7 @@ public class Main {
                     if (cmd.hasOption("resume")) {
                         try {
                             debugger.resume();
-                            AnsiConsole.out.println(debugger
-                                    .printState(debugger.getCurrentState()));
+                            System.out.println(debugger.printState(debugger.getCurrentState()));
                         } catch (IllegalStateException e) {
                             org.kframework.utils.Error.silentReport("Wrong command: If you previously used the step-all command you must"
                                     + K.lineSeparator
@@ -701,8 +697,7 @@ public class Main {
                         try {
                             int steps = Integer.parseInt(arg);
                             debugger.step(steps);
-                            AnsiConsole.out.println(debugger
-                                    .printState(debugger.getCurrentState()));
+                            System.out.println(debugger.printState(debugger.getCurrentState()));
                         } catch (NumberFormatException e) {
                             org.kframework.utils.Error.silentReport("Argument to step must be an integer.");
                         } catch (IllegalStateException e) {
@@ -722,7 +717,7 @@ public class Main {
                         try {
                             int steps = Integer.parseInt(arg);
                             SearchResults states = debugger.stepAll(steps);
-                            AnsiConsole.out.println(states);
+                            System.out.println(states);
 
                         } catch (NumberFormatException e) {
                             org.kframework.utils.Error.silentReport("Argument to step-all must be an integer.");
@@ -739,8 +734,7 @@ public class Main {
                         try {
                             int stateNum = Integer.parseInt(arg);
                             debugger.setCurrentState(stateNum);
-                            AnsiConsole.out.println(debugger
-                                    .printState(debugger.getCurrentState()));
+                            System.out.println(debugger.printState(debugger.getCurrentState()));
                         } catch (NumberFormatException e) {
                             org.kframework.utils.Error.silentReport("Argument to select must bean integer.");
                         } catch (IllegalArgumentException e) {
@@ -758,8 +752,7 @@ public class Main {
                         String nodeId = cmd.getOptionValue("show-node").trim();
                         try {
                             int stateNum = Integer.parseInt(nodeId);
-                            AnsiConsole.out.println(debugger
-                                    .printState(stateNum));
+                            System.out.println(debugger.printState(stateNum));
                         } catch (NumberFormatException e) {
                             org.kframework.utils.Error.silentReport("Argument to select node to show must be an integer.");
                         } catch (IllegalArgumentException e) {
@@ -774,8 +767,7 @@ public class Main {
                         try {
                             int state1 = Integer.parseInt(vals[0].trim());
                             int state2 = Integer.parseInt(vals[1].trim());
-                            AnsiConsole.out.println(debugger.printEdge(state1,
-                                    state2));
+                            System.out.println(debugger.printEdge(state1, state2));
                         } catch (ArrayIndexOutOfBoundsException e) {
                             org.kframework.utils.Error.silentReport("Must specify two nodes with an edge between them.");
                         } catch (NumberFormatException e) {
@@ -804,8 +796,7 @@ public class Main {
                         try {
                             debugger.readFromStdin(StringBuiltin.valueOf("\"" +
                                     cmd.getOptionValue("read") + "\"").stringValue());
-                            AnsiConsole.out.println(
-                                    debugger.printState(debugger.getCurrentState()));
+                            System.out.println(debugger.printState(debugger.getCurrentState()));
                         } catch (IllegalStateException e) {
                             org.kframework.utils.Error.silentReport(e.getMessage());
                         }

--- a/src/javasources/KTool/src/org/kframework/ktest/KTest.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/KTest.java
@@ -4,7 +4,6 @@ package org.kframework.ktest;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.FilenameUtils;
-import org.fusesource.jansi.AnsiConsole;
 import org.kframework.ktest.CmdArgs.CmdArg;
 import org.kframework.ktest.CmdArgs.CmdArgParser;
 import org.kframework.ktest.CmdArgs.Constants;
@@ -99,7 +98,6 @@ public class KTest {
     }
 
     public static void main(String[] args) {
-        AnsiConsole.systemInstall();
         try {
             System.exit(new KTest(args).run());
         } catch (ParseException | InvalidArgumentException | SAXException |

--- a/src/javasources/KTool/src/org/kframework/main/Main.java
+++ b/src/javasources/KTool/src/org/kframework/main/Main.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 
+import org.fusesource.jansi.AnsiConsole;
 import org.kframework.kil.visitors.exceptions.TransformerException;
 import org.kframework.utils.Error;
 import org.kframework.utils.Stopwatch;
@@ -38,6 +39,7 @@ public class Main {
     public static void main(String[] args) throws IOException, TransformerException {
         Stopwatch.instance();
         setJavaLibraryPath();
+        AnsiConsole.systemInstall();
 
         if (args.length >= 1) {
             String[] args2 = Arrays.copyOfRange(args, 1, args.length);


### PR DESCRIPTION
As discussed at #379 , I removed `AnsiConsole.out` calls and instead called `AnsiConsole.systemInstall` at K entry point. This should ensure that colorful printing will work on all platforms without any other changes.(e.g. `System.out....` calls should just handle colorful printing throughout the entire framework)

Note that this patch assumes that K tools are only called using `k3.jar`(`org.kframework.main.Main`) and not by using `main` methods of some other classes(like `krun.main`, `ktest.main` etc.) Calling other `main` methods bypasses `AnsiConsole.systemInstall` call and thus prints color codes even when printing to non-ANSI terminals.

After this patch, `AnsiConsole` will only be used in entry point of the framework:

```
➜  k git:(jansi_refactoring) ack --java AnsiConsole                                              
src/javasources/KTool/src/org/kframework/main/Main.java
8:import org.fusesource.jansi.AnsiConsole;
42:        AnsiConsole.systemInstall();
➜  k git:(jansi_refactoring) 
```
