### PR TITLE
Remove the extra start non-terminal from the parser.

### DIFF
--- a/src/javasources/KTool/src/org/kframework/parser/concrete2/Parser.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete2/Parser.java
@@ -655,19 +655,8 @@ public class Parser {
      * @return the result of parsing, as a Term
      */
     public Term parse(NonTerminal nt, int position) {
-        // This code assumes that ordering info in the grammar are between MIN_VALUE+1 and MAX_VALUE-2
-        // TODO: can we do away with the <start> non-terminal?
-        NonTerminal startNt = new NonTerminal("<start>");
-        NonTerminalState state = new NonTerminalState("<start>", startNt, nt, false);
-        startNt.entryState.next.add(state);
-        state.next.add(startNt.exitState);
-
-        startNt.entryState.orderingInfo = new State.OrderingInfo(Integer.MIN_VALUE);
-        startNt.exitState.orderingInfo = new State.OrderingInfo(Integer.MAX_VALUE);
-        state.orderingInfo = new State.OrderingInfo(Integer.MAX_VALUE - 1);
-
         activateStateCall(s.stateCalls.get(new StateCall.Key(s.ntCalls.get(
-            new NonTerminalCall.Key(startNt, position)), position, startNt.entryState)),
+            new NonTerminalCall.Key(nt, position)), position, nt.entryState)),
             Function.IDENTITY);
 
         for (StateReturn stateReturn;


### PR DESCRIPTION
After reviewing the changes necessary, I am happy to report that it was much simpler than I thought and (unlike I had feared) simply removing the code didn't adverse reactions or change the interface at all.
