### PR TITLE
get back old ktest output mismatch error reporting (was chaged with #356)

### DIFF
--- a/src/javasources/KTool/src/org/kframework/ktest/IgnoringStringMatcher.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/IgnoringStringMatcher.java
@@ -12,22 +12,24 @@ public class IgnoringStringMatcher implements StringMatcher {
     }
 
     @Override
-    public void matches(String pattern, String actual) throws MatchFailure {
+    public void matches(final String pattern, final String actual) throws MatchFailure {
         // algorithm copied from old ktest; I'm not convinced that they work correctly in all cases
+        String pattern1 = pattern;
+        String actual1 = actual;
         if (ignoreWS) {
-            pattern = pattern.replaceAll("\\r|\\s|\\n","");
-            actual = actual.replaceAll("\\r|\\s|\\n","");
-            pattern = pattern.replaceAll("\u001B\\[[;\\d]*m", "");
-            actual = actual.replaceAll("\u001B\\[[;\\d]*m", "");
+            pattern1 = pattern1.replaceAll("\\r|\\s|\\n","");
+            actual1 = actual1.replaceAll("\\r|\\s|\\n","");
+            pattern1 = pattern1.replaceAll("\u001B\\[[;\\d]*m", "");
+            actual1 = actual1.replaceAll("\u001B\\[[;\\d]*m", "");
         } else {
-            pattern = pattern.replaceAll("\\r","");
-            actual = actual.replaceAll("\\r","");
+            pattern1 = pattern1.replaceAll("\\r","");
+            actual1 = actual1.replaceAll("\\r","");
         }
         if (ignoreBalancedParens) {
-            pattern = removeAllBalanced(pattern);
-            actual = removeAllBalanced(actual);
+            pattern1 = removeAllBalanced(pattern1);
+            actual1 = removeAllBalanced(actual1);
         }
-        if (pattern.trim().compareTo(actual.trim()) != 0) {
+        if (pattern1.trim().compareTo(actual1.trim()) != 0) {
             throw new StringMatcher.MatchFailure(
                     String.format("Expected:%n%s%n%nbut found:%n%s%n", pattern, actual));
         }


### PR DESCRIPTION
So there was a change in ktest verbose error reporting introduced in #356 . I missed that at the time and realized yesterday.

In case of output mismatch `ktest --verbose` was reporting the error like this:

```
Running [/home/omer/K/k_new_dist/k/bin/krun /home/omer/K/k_new_dist/k/tests/examples/quine-short/test.quine --output none --color off] [output: /home/omer/K/k_new_dist/k/tests/examples/quine-short/test.quine.out]
ERROR: [/home/omer/K/k_new_dist/k/bin/krun /home/omer/K/k_new_dist/k/tests/examples/quine-short/test.quine --output none --color off] output doesn't match with expected output (time: 1672 ms)                                               
Unexpected program output:
Expected:
module QUINE-SHORT

    <out stream="stdout"> .List </out>
  rule
    <prefix> Pre:String => . </prefix>
    <suffix> Suf:String => . </suffix>
    <out>... . => ListItem(Pre +String "    <prefix> \"" +String replaceAll(replaceAll(replaceAll(Pre, "\\", "\\\\"), "\n", "\\n"), "\"", "\\\"") +String "\" </prefix>\n" +String "    <suffix> \"" +String replaceAll(replaceAll(replaceAll(Suf, "\\", "\\\\"), "\n", "\\n"), "\"", "\\\"") +String "\" </suffix>\n" +String Suf) </out>
endmodule


but found:
module QUINE-SHORT

  configuration
    <out stream="stdout"> .List </out>
    <prefix> "module QUINE-SHORT\n\n  configuration\n    <out stream=\"stdout\"> .List </out>\n" </prefix>
    <suffix> "\n  rule\n    <prefix> Pre:String => . </prefix>\n    <suffix> Suf:String => . </suffix>\n    <out>... . => ListItem(Pre +String \"    <prefix> \\\"\" +String replaceAll(replaceAll(replaceAll(Pre, \"\\\\\", \"\\\\\\\\\"), \"\\n\", \"\\\\n\"), \"\\\"\", \"\\\\\\\"\") +String \"\\\" </prefix>\\n\" +String \"    <suffix> \\\"\" +String replaceAll(replaceAll(replaceAll(Suf, \"\\\\\", \"\\\\\\\\\"), \"\\n\", \"\\\\n\"), \"\\\"\", \"\\\\\\\"\") +String \"\\\" </suffix>\\n\" +String Suf) </out>\nendmodule\n" </suffix>

  rule
    <prefix> Pre:String => . </prefix>
    <suffix> Suf:String => . </suffix>
    <out>... . => ListItem(Pre +String "    <prefix> \"" +String replaceAll(replaceAll(replaceAll(Pre, "\\", "\\\\"), "\n", "\\n"), "\"", "\\\"") +String "\" </prefix>\n" +String "    <suffix> \"" +String replaceAll(replaceAll(replaceAll(Suf, "\\", "\\\\"), "\n", "\\n"), "\"", "\\\"") +String "\" </suffix>\n" +String Suf) </out>
endmodule
```

But after #356, it turned to this:

```
Running [/home/omer/K/k_new_dist/k/bin/krun /home/omer/K/k_new_dist/k/tests/examples/quine-short/test.quine --output none --color off] [output: /home/omer/K/k_new_dist/k/tests/examples/quine-short/test.quine.out]
ERROR: [/home/omer/K/k_new_dist/k/bin/krun /home/omer/K/k_new_dist/k/tests/examples/quine-short/test.quine --output none --color off] output doesn't match with expected output (time: 1651 ms)                                               
Unexpected program output:
Expected:
moduleQUINE-SHORT<outstream="stdout">.List</out>rule<prefix>Pre:String=>.</prefix><suffix>Suf:String=>.</suffix><out>....=>ListItemPre+String"<prefix>\""+StringreplaceAllreplaceAllreplaceAllPre,"\\","\\\\","\n","\\n","\"","\\\""+String"\"</prefix>\n"+String"<suffix>\""+StringreplaceAllreplaceAllreplaceAllSuf,"\\","\\\\","\n","\\n","\"","\\\""+String"\"</suffix>\n"+StringSuf</out>endmodule

but found:
moduleQUINE-SHORTconfiguration<outstream="stdout">.List</out><prefix>"moduleQUINE-SHORT\n\nconfiguration\n<outstream=\"stdout\">.List</out>\n"</prefix><suffix>"\nrule\n<prefix>Pre:String=>.</prefix>\n<suffix>Suf:String=>.</suffix>\n<out>....=>ListItemPre+String\"<prefix>\\\"\"+StringreplaceAllreplaceAllreplaceAllPre,\"\\\\\",\"\\\\\\\\\",\"\\n\",\"\\\\n\",\"\\\"\",\"\\\\\\\"\"+String\"\\\"</prefix>\\n\"+String\"<suffix>\\\"\"+StringreplaceAllreplaceAllreplaceAllSuf,\"\\\\\",\"\\\\\\\\\",\"\\n\",\"\\\\n\",\"\\\"\",\"\\\\\\\"\"+String\"\\\"</suffix>\\n\"+StringSuf</out>\nendmodule\n"</suffix>rule<prefix>Pre:String=>.</prefix><suffix>Suf:String=>.</suffix><out>....=>ListItemPre+String"<prefix>\""+StringreplaceAllreplaceAllreplaceAllPre,"\\","\\\\","\n","\\n","\"","\\\""+String"\"</prefix>\n"+String"<suffix>\""+StringreplaceAllreplaceAllreplaceAllSuf,"\\","\\\\","\n","\\n","\"","\\\""+String"\"</suffix>\n"+StringSuf</out>endmodule
```

This patch gets back the old behavior.
