### PR TITLE
KTEST: Support alternative krun executable. Issue #396

### DIFF
--- a/lib/ktest.xsd
+++ b/lib/ktest.xsd
@@ -3,7 +3,8 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 <xs:complexType name="program-config">
   <xs:sequence>
-    <xs:element name="krun-option" minOccurs="1" maxOccurs="unbounded" type="option" />
+    <xs:element name="krun-exec" minOccurs="0" maxOccurs="1" type="exec" />
+    <xs:element name="krun-option" minOccurs="0" maxOccurs="unbounded" type="option" />
   </xs:sequence>
   <xs:attribute name="regex" type="xs:boolean" use="optional" />
 </xs:complexType>
@@ -20,6 +21,10 @@
   <xs:attribute name="name" type="xs:string" use="required" />
   <xs:attribute name="key" type="xs:string" use="optional" />
   <xs:attribute name="value" type="xs:string" use="optional" />
+</xs:complexType>
+
+<xs:complexType name="exec">
+  <xs:attribute name="name" type="xs:string" use="required" />
 </xs:complexType>
 
 <xs:element name="tests" >

--- a/src/javasources/KTool/src/org/kframework/ktest/Config/ConfigFileParser.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Config/ConfigFileParser.java
@@ -430,10 +430,13 @@ public class ConfigFileParser {
             if (childNode.getNodeType() == Node.ELEMENT_NODE
                     && childNode.getNodeName().equals("program")) {
                 Element elem = (Element) childNode;
-                ret.put(elem.getAttribute("name"), new ProgramProfile(parseKrunOpts(
-                        elem.getChildNodes()),
-                        Boolean.parseBoolean(elem.getAttribute("regex")),
-                        parseKrunExec(elem.getChildNodes())));
+                String[] names = splitNodeValue(elem.getAttributeNode("name"));
+                for (String name : names) {
+                    ret.put(name,
+                            new ProgramProfile(parseKrunOpts(elem.getChildNodes()),
+                                    Boolean.parseBoolean(elem.getAttribute("regex")),
+                                    parseKrunExec(elem.getChildNodes())));
+                }
             }
         }
         return ret;

--- a/src/javasources/KTool/src/org/kframework/ktest/Config/ConfigFileParser.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Config/ConfigFileParser.java
@@ -363,15 +363,17 @@ public class ConfigFileParser {
     private ProgramProfile parseAllPgmsKrunOpts(NodeList nodes) {
         List<PgmArg> ret = new LinkedList<>();
         boolean regex = false;
+        String krunExec = "krun";
         for (int childNodeIdx = 0; childNodeIdx < nodes.getLength(); childNodeIdx++) {
             Node childNode = nodes.item(childNodeIdx);
             if (childNode.getNodeType() == Node.ELEMENT_NODE
                     && childNode.getNodeName().equals("all-programs")) {
                 ret.addAll(parseKrunOpts(childNode.getChildNodes()));
                 regex = Boolean.parseBoolean(((Element)childNode).getAttribute("regex"));
+                krunExec = parseKrunExec(childNode.getChildNodes());
             }
         }
-        return new ProgramProfile(ret, regex);
+        return new ProgramProfile(ret, regex, krunExec);
     }
 
     /**
@@ -397,6 +399,25 @@ public class ConfigFileParser {
     }
 
     /**
+     * Parse <krun-exec> ... </krun-exec> element in a NodeList.
+     *
+     * @param nodes NodeList to search `krun-exec' elements
+     * @return Name of krun executable (default: "krun")
+     */
+    private String parseKrunExec(NodeList nodes) {
+        String krunExec = "krun";
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node n = nodes.item(i);
+            if (n.getNodeType() == Node.ELEMENT_NODE
+                    && n.getNodeName().equals("krun-exec")) {
+                Element e = (Element) n;
+                krunExec = e.getAttribute("name");
+            }
+        }
+        return krunExec;
+    }
+
+    /**
      * Parse <program name=...> ... </program> elements in a NodeList.
      *
      * @param nodes NodeList to search `program' elements
@@ -411,7 +432,8 @@ public class ConfigFileParser {
                 Element elem = (Element) childNode;
                 ret.put(elem.getAttribute("name"), new ProgramProfile(parseKrunOpts(
                         elem.getChildNodes()),
-                        Boolean.parseBoolean(elem.getAttribute("regex"))));
+                        Boolean.parseBoolean(elem.getAttribute("regex")),
+                        parseKrunExec(elem.getChildNodes())));
             }
         }
         return ret;

--- a/src/javasources/KTool/src/org/kframework/ktest/Test/KRunProgram.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Test/KRunProgram.java
@@ -20,9 +20,10 @@ public class KRunProgram {
     public final String errorFile;
     public final String newOutputFile;
     public final boolean regex;
+    public final String krunExec;
 
     public KRunProgram(String pgmPath, String defPath, List<PgmArg> args, String inputFile, String outputFile,
-                       String errorFile, String newOutputFile, boolean regex) {
+                       String errorFile, String newOutputFile, boolean regex, String krunExec) {
         this.pgmName = FilenameUtils.getBaseName(pgmPath);
         this.pgmPath = pgmPath;
         this.defPath = defPath;
@@ -32,6 +33,7 @@ public class KRunProgram {
         this.errorFile = errorFile;
         this.newOutputFile = newOutputFile;
         this.regex = regex;
+        this.krunExec = krunExec;
     }
 
     /**
@@ -39,7 +41,7 @@ public class KRunProgram {
      */
     public String[] getKrunCmd() {
         List<String> stringArgs = new ArrayList<String>();
-        stringArgs.add(ExecNames.getKrun());
+        stringArgs.add(ExecNames.getExecutable(krunExec));
         stringArgs.add(pgmPath);
         for (int i = 0; i < args.size(); i++) {
             stringArgs.addAll(args.get(i).toStringList());

--- a/src/javasources/KTool/src/org/kframework/ktest/Test/ProgramProfile.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Test/ProgramProfile.java
@@ -22,9 +22,15 @@ public class ProgramProfile {
      */
     private boolean regex;
     
-    public ProgramProfile(List<PgmArg> args, boolean regex) {
+    /**
+     * Alternative krun executable. (It should reside in KHOME/bin directory.)
+     */
+    private String krunExec;
+
+    public ProgramProfile(List<PgmArg> args, boolean regex, String krunExec) {
         this.args = args;
         this.regex = regex;
+        this.krunExec = krunExec;
     }
     
     public List<PgmArg> getArgs() {
@@ -33,5 +39,9 @@ public class ProgramProfile {
     
     public boolean isRegex() {
         return regex;
+    }
+
+    public String getKrunExec() {
+        return krunExec;
     }
 }

--- a/src/javasources/KTool/src/org/kframework/ktest/Test/TestCase.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Test/TestCase.java
@@ -95,7 +95,7 @@ public class TestCase {
         results.add(new Annotated<>(cmdArgs.getResults(), new LocationData()));
 
         List<PgmArg> emptyOpts = Collections.emptyList();
-        ProgramProfile emptyProfile = new ProgramProfile(emptyOpts, false);
+        ProgramProfile emptyProfile = new ProgramProfile(emptyOpts, false, "krun");
 
         Map<String, ProgramProfile> emptyOptsMap = Collections.emptyMap();
 
@@ -311,7 +311,7 @@ public class TestCase {
 
                     ret.add(new KRunProgram(
                             pgmFilePath, definitionFilePath, args, inputFilePath, outputFilePath, errorFilePath,
-                            getNewOutputFilePath(outputFileName), profile.isRegex()));
+                            getNewOutputFilePath(outputFileName), profile.isRegex(), profile.getKrunExec()));
                 }
             } else {
                 ret.addAll(searchPrograms(pgmFile.getAbsolutePath()));


### PR DESCRIPTION
An alternative krun executable can be provided by using the additional `<krun-exec>` node. This option is useful especially for running `kast` instead of `krun` for certain programs. (See Issue #396.)

@dwightguth @osa1 Please review this code.
@radumereuta Please check if this change is sufficient for you.

CHANGES:
- Create additional `<krun-exec>` node (optional) in both `<all-programs>` and `<program>` nodes.
- Allow multiple programs in the `name` attributes of `<program>` node.

USAGE:

```
  <test
    definition="lang.k"
    programs="programs"
    results="results"
    extension="lang"
  >
    <all-programs>
      <krun-option name="--color" value="off" />
      <krun-option name="--output" value="none" />
    </all-programs>
    <program name="pgm1.lang pgm2.lang">
      <krun-exec name="kast" />
    </program>
  </test>
```

LIMITATIONS and CONCERNS:
- The name of the additional node `krun-exec` might be inappropriate.
- Currently, an alternative krun executable should reside in `KHOME/bin` directory as `kompile`, `krun`, and `kast`.
- It would be better to come up with a more general solution that also solves the issue #392.
