### PR TITLE
Updating the README for developers to better explain that JAVA_HOME 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -65,11 +65,15 @@
 	<target name="makeversion">
 		<property name="version.file" value="./lib/version.txt" />
 
-		<exec executable="git" outputproperty="version.out">
+		<exec executable="git" outputproperty="version.out" failifexecutionfails="false">
 			<arg value="rev-parse" />
 			<arg value="--short" />
 			<arg value="HEAD^" />
 		</exec>
+		
+		<condition property="version.out" value="Failed to execute Git in command line.">
+			<isset property="version.out" />
+		</condition>
 
 		<tstamp>
 			<format property="date" pattern="EEE MMM d HH:mm:ss z yyyy" />

--- a/src/README
+++ b/src/README
@@ -3,7 +3,7 @@
 
 2. Prerequisites
 
-2.1 Java Development Kit (tested with JDK7 or higher)
+2.1 Java Development Kit (required JDK7 or higher)
 You can follow the instructions here: 
 http://docs.oracle.com/javase/7/docs/webnotes/install/index.html depending on 
 the type of your machine.
@@ -17,7 +17,14 @@ Linux and Mac:
 Windows:
     Go to http://ant.apache.org/bindownload.cgi and download the zip with the 
     binary distribution. Unzip it in your desired location and follow the 
-    instalation instructions from the 'INSTALL' file.
+    installation instructions from the 'INSTALL' file.
+
+Ant usually requires setting an environment variable 'JAVA_HOME' pointing
+to the installation directory of the JDK (not to be mistaken with JRE).
+	
+2.3 Git - command line
+Having a GUI client is not enough. Most distributions have an installation
+option to make git accessible in the command line too.
 
 You can test if it works by calling 'ant' in a Terminal.
 
@@ -28,14 +35,14 @@ your $PATH with <checkout-dir>/bin (strongly recommended, but optional).
 
 4. Work on Java code
 We here only give instructions for Eclipse, but similar instructions apply
-for other ISEs.  Open eclipse and set your workspace to src/javasources.  Go to
+for other IDEs.  Open Eclipse and set your workspace to src/javasources.  Go to
 File->Import->General->Existing projects into workspace, and select
 the project src/javasources/KTool.  If you need to edit SDF-related code,
 you should install the Spoofax plugin and then also import
 src/javasources/parsers/Concrete.
 
 5. Work on Maude code
-Modify the Maude files found in lib/maude/lib.  No need for recompilation.
+Modify the Maude files found in lib/maude/lib. No need for recompilation.
 
 6. Build the final release directory/archives
 Call 'ant release' in the base directory.  This will create a k directory in
@@ -48,5 +55,19 @@ Assuming k/bin is in your path, you can compile definitions using
 the 'kompile' command.  To execute a program you can use 'krun'.
 
 8. Troubleshooting
-If everything fails, try 'ant clean' and rebuild the entire project.
+Common error messages:
+
+- Unable to find a javac compiler;
+  com.sun.tools.javac.Main is not on the classpath.
+  Perhaps JAVA_HOME does not point to the JDK.
++ Make sure JAVA_HOME points to the JDK and not the JRE directory.
+
+-  Execute failed: java.io.IOException: Cannot run program "git":
+   CreateProcess error=2, The system cannot find the file specified
++  Git is not accessible in the command line. Please reinstall git and make
+   make sure to check to option to make it available in the command line.
+
+Sometimes javac dependency resolution fails to recognize changed files and
+would fail to build. Try 'ant clean' and rebuild the entire project.
+
 If that still doesn't work, please contact a K developer.


### PR DESCRIPTION
environment variable is required to point to the JDK installation directory.
Also specify that git needs to run in the command line. The GUI is not enough.

This is in response to issues #365 and #366 
