### PR TITLE
Patch for Issue #425

### DIFF
--- a/src/javasources/KTool/src/org/kframework/backend/latex/LatexFilter.java
+++ b/src/javasources/KTool/src/org/kframework/backend/latex/LatexFilter.java
@@ -197,14 +197,12 @@ public class LatexFilter extends BackendFilter {
             return null;
         }
         if (hasBR) {
-            if (parens) result.append("\\left(");
             result.append("\\begin{array}{@{}c@{}}");
         }
         List<Term> contents = col.getContents();
         printList(contents, "\\mathrel{}");
         if (hasBR) {
             result.append("\\end{array}");
-            if (parens) result.append("\\right)");
         }
         return null;
     }


### PR DESCRIPTION
Removing brackets for `<br/>` as normal brackets can be used for disambiguation.

@grosu please check tutorial/1_k/5_types/lesson_6 — it is the only example from the tutorial using `<br>` in rules. I think it does not need additional parens so I did not add them.

@denis-bogdanas please check it works for you now. It is true that in the style you're using the rules are easier to delimit, but in the poster style the rule keyword gets aligned to the center of the rule (if  `<br/> is at the top), which made rules using`<br/>` harder to delimit.
