### PR TITLE
change kompile to use unique temp files

### DIFF
--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/JavaSymbolicBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/JavaSymbolicBackend.java
@@ -49,7 +49,7 @@ public class JavaSymbolicBackend extends BasicBackend {
         }
         @Override
         public ASTNode visit(Definition node, Void _)  {
-            BinaryLoader.save(new File(context.dotk, "defx-java.bin").toString(), node);
+            BinaryLoader.save(new File(context.kompiled, "defx-java.bin").toString(), node);
 
             return node;
         }
@@ -73,7 +73,7 @@ public class JavaSymbolicBackend extends BasicBackend {
 
         assert definition.getIndex() != null;
 
-        BinaryLoader.save(new File(context.dotk,
+        BinaryLoader.save(new File(context.kompiled,
                 JavaSymbolicBackend.DEFINITION_FILENAME).toString(),
                 definition);
 

--- a/src/javasources/KTool/src/org/kframework/backend/maude/KompileBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/maude/KompileBackend.java
@@ -39,7 +39,7 @@ public class KompileBackend extends BasicBackend {
             .append("mod ").append(mainModule).append("-BUILTINS is\n").append(" including ")
             .append(mainModule).append("-BASE .\n")
             .append(builtinsFilter.getResult()).append("endm\n");
-        FileUtil.save(context.dotk.getAbsolutePath() + "/builtins.maude", builtins);
+        FileUtil.save(context.kompiled.getAbsolutePath() + "/builtins.maude", builtins);
         sw.printIntermediate("Generating equations for hooks");
         javaDef = (Definition) new DeleteFunctionRules(maudeHooks.stringPropertyNames(), context)
             .visitNode(javaDef);
@@ -65,7 +65,7 @@ public class KompileBackend extends BasicBackend {
             .append("  including ").append(mainModule).append("-BASE .\n")
             .append("  including ").append(mainModule).append("-BUILTINS .\n")
             .append("eq mainModule = '").append(mainModule).append(" .\nendm\n");
-        FileUtil.save(context.dotk.getAbsolutePath() + "/" + "main.maude", main);
+        FileUtil.save(context.kompiled.getAbsolutePath() + "/" + "main.maude", main);
     }
 
     @Override

--- a/src/javasources/KTool/src/org/kframework/backend/maude/MaudeBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/maude/MaudeBackend.java
@@ -31,7 +31,7 @@ public class MaudeBackend extends BasicBackend {
         StringBuilder maudified = maudeFilter.getResult();
         StringBuilderUtil.replaceFirst(maudified, mainModule, mainModule + "-BASE");
 
-        FileUtil.save(context.dotk.getAbsolutePath() + "/base.maude", maudified);
+        FileUtil.save(context.kompiled.getAbsolutePath() + "/base.maude", maudified);
         sw.printIntermediate("Generating Maude file");
 
         StringBuilder consTable = getLabelTable(definition);

--- a/src/javasources/KTool/src/org/kframework/backend/symbolic/SymbolicBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/symbolic/SymbolicBackend.java
@@ -65,7 +65,7 @@ public class SymbolicBackend extends BasicBackend implements Backend {
             .append(mainModule).append("-BUILTINS is\n")
             .append(" including ").append(mainModule).append("-BASE .\n")
             .append(builtinsFilter.getResult()).append("endm\n");
-        FileUtil.save(context.dotk.getAbsolutePath() + "/builtins.maude", builtins);
+        FileUtil.save(context.kompiled.getAbsolutePath() + "/builtins.maude", builtins);
         sw.printIntermediate("Generating equations for hooks");
         return super.firstStep(javaDef);
     }
@@ -90,7 +90,7 @@ public class SymbolicBackend extends BasicBackend implements Backend {
             .append("mod ").append(mainModule).append(" is \n")
             .append("  including ").append(mainModule).append("-BASE .\n")
             .append("  including ").append(mainModule).append("-BUILTINS .\n").append("endm\n");
-        FileUtil.save(context.dotk.getAbsolutePath() + "/" + "main.maude", main);
+        FileUtil.save(context.kompiled.getAbsolutePath() + "/" + "main.maude", main);
 
          UnparserFilter unparserFilter = new UnparserFilter(this.context);
          unparserFilter.visitNode(javaDef);

--- a/src/javasources/KTool/src/org/kframework/backend/unparser/AddBracketsFilter2.java
+++ b/src/javasources/KTool/src/org/kframework/backend/unparser/AddBracketsFilter2.java
@@ -18,7 +18,7 @@ public class AddBracketsFilter2 extends ParseForestTransformer {
 
     public AddBracketsFilter2(Context context) throws IOException {
         super("Add more brackets", context);
-        org.kframework.parser.concrete.KParser.ImportTbl(context.kompiled.getCanonicalPath() + "/def/Concrete.tbl");
+        org.kframework.parser.concrete.KParser.ImportTblRule(context.kompiled);
     }
 
     private Term reparsed = null;

--- a/src/javasources/KTool/src/org/kframework/krun/Main.java
+++ b/src/javasources/KTool/src/org/kframework/krun/Main.java
@@ -249,7 +249,7 @@ public class Main {
             try {
                 if (cmd.hasOption("pattern") || "search".equals(K.maude_cmd)) {
                     org.kframework.parser.concrete.KParser
-                            .ImportTbl(K.compiled_def + "/def/Concrete.tbl");
+                            .ImportTblRule(new File(K.compiled_def));
                     ASTNode pattern = DefinitionLoader.parsePattern(
                             K.pattern,
                             "Command line pattern",

--- a/src/javasources/KTool/src/org/kframework/krun/api/KRunApiDebugger.java
+++ b/src/javasources/KTool/src/org/kframework/krun/api/KRunApiDebugger.java
@@ -28,6 +28,7 @@ import edu.uci.ics.jung.graph.DirectedGraph;
 import edu.uci.ics.jung.graph.DirectedSparseGraph;
 import edu.uci.ics.jung.graph.util.Pair;
 
+import java.io.File;
 import java.util.Map.Entry;
 
 public class KRunApiDebugger implements KRunDebugger {
@@ -44,7 +45,7 @@ public class KRunApiDebugger implements KRunDebugger {
     public KRunApiDebugger(KRun krun, Term cfg, Context context) throws KRunExecutionException {
         this.context = context;
         try { 
-            org.kframework.parser.concrete.KParser.ImportTbl(K.compiled_def + "/def/Concrete.tbl");
+            org.kframework.parser.concrete.KParser.ImportTblRule(new File(K.compiled_def));
             ASTNode pattern = DefinitionLoader.parsePattern(
                     K.pattern,
                     "Command line pattern",

--- a/src/javasources/KTool/src/org/kframework/parser/DefinitionLoader.java
+++ b/src/javasources/KTool/src/org/kframework/parser/DefinitionLoader.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.kframework.compile.checks.CheckListDecl;
 import org.kframework.compile.checks.CheckSortTopUniqueness;
@@ -35,7 +36,6 @@ import org.kframework.parser.concrete.disambiguate.CorrectRewritePriorityFilter;
 import org.kframework.parser.concrete.disambiguate.FlattenListsFilter;
 import org.kframework.parser.concrete.disambiguate.GetFitnessUnitKCheckVisitor;
 import org.kframework.parser.concrete.disambiguate.GetFitnessUnitTypeCheckVisitor;
-import org.kframework.parser.concrete.disambiguate.MergeAmbFilter;
 import org.kframework.parser.concrete.disambiguate.PreferAvoidFilter;
 import org.kframework.parser.concrete.disambiguate.PriorityFilter;
 import org.kframework.parser.concrete.disambiguate.SentenceVariablesFilter;
@@ -80,7 +80,7 @@ public class DefinitionLoader {
         } else {
             javaDef = parseDefinition(mainFile, lang, autoinclude, context);
 
-            BinaryLoader.save(context.dotk.getAbsolutePath() + "/defx-" + context.kompileOptions.backend.name().toLowerCase() + ".bin", javaDef);
+            BinaryLoader.save(context.kompiled.getAbsolutePath() + "/defx-" + context.kompileOptions.backend.name().toLowerCase() + ".bin", javaDef);
         }
         return javaDef;
     }
@@ -146,23 +146,23 @@ public class DefinitionLoader {
 
             // ------------------------------------- generate files
             try {
-                ResourceExtractor.ExtractDefSDF(new File(context.dotk + "/def"));
-                ResourceExtractor.ExtractGroundSDF(new File(context.dotk + "/ground"));
+                ResourceExtractor.ExtractDefSDF(new File(context.dotk, "def"));
+                ResourceExtractor.ExtractGroundSDF(new File(context.dotk, "ground"));
     
-                ResourceExtractor.ExtractProgramSDF(new File(context.dotk + "/pgm"));
+                ResourceExtractor.ExtractProgramSDF(new File(context.dotk, "pgm"));
             } catch (IOException e) {
                 if (context.globalOptions.debug) {
                     e.printStackTrace();
                 }
                 GlobalSettings.kem.register(new KException(ExceptionType.ERROR, KExceptionGroup.INTERNAL, 
-                        "IO error detected writing to " + context.dotk.getAbsolutePath()));
+                        "IO error detected writing to " + context.kompiled.getAbsolutePath()));
             }
             // ------------------------------------- generate parser TBL
             // cache the TBL if the sdf file is the same
             if (!context.kompileOptions.backend.documentation()) {
                 String oldSdfPgm = "";
-                if (new File(context.dotk.getAbsolutePath() + "/pgm/Program.sdf").exists())
-                    oldSdfPgm = FileUtil.getFileContent(context.dotk.getAbsolutePath() + "/pgm/Program.sdf");
+                if (new File(context.kompiled, "Program.sdf").exists())
+                    oldSdfPgm = FileUtil.getFileContent(context.kompiled.getAbsolutePath() + "/Program.sdf");
 
                 StringBuilder newSdfPgmBuilder = ProgramSDF.getSdfForPrograms(def, context);
 
@@ -171,8 +171,20 @@ public class DefinitionLoader {
 
                 Stopwatch.instance().printIntermediate("File Gen Pgm");
 
-                if (!oldSdfPgm.equals(newSdfPgm) || !new File(context.dotk.getAbsoluteFile() + "/pgm/Program.tbl").exists()) {
+                if (!oldSdfPgm.equals(newSdfPgm) || !new File(context.kompiled, "Program.tbl").exists()) {
                     Sdf2Table.run_sdf2table(new File(context.dotk.getAbsoluteFile() + "/pgm"), "Program");
+                    try {
+                        FileUtils.copyFileToDirectory(new File(context.dotk, "pgm/Program.sdf"), context.kompiled);
+                        FileUtils.copyFileToDirectory(new File(context.dotk, "pgm/Program.tbl"), context.kompiled);
+                        } catch (IOException e) {
+                        if (context.globalOptions.debug) {
+                            e.printStackTrace();
+                        }
+                        GlobalSettings.kem.register(new KException(ExceptionType.ERROR, KExceptionGroup.INTERNAL, 
+                                "IO error detected writing program parser to file"));
+                        return null; //unreachable
+                    }
+                    
                     Stopwatch.instance().printIntermediate("Generate TBLPgm");
                 }
             }
@@ -184,32 +196,56 @@ public class DefinitionLoader {
             // ------------------------------------- generate parser TBL
             // cache the TBL if the sdf file is the same
             String oldSdf = "";
-            if (new File(context.dotk.getAbsolutePath() + "/def/Integration.sdf").exists())
-                oldSdf = FileUtil.getFileContent(context.dotk.getAbsolutePath() + "/def/Integration.sdf");
+            if (new File(context.kompiled, "Integration.sdf").exists())
+                oldSdf = FileUtil.getFileContent(context.kompiled.getAbsolutePath() + "/Integration.sdf");
             FileUtil.save(context.dotk.getAbsolutePath() + "/def/Integration.sdf", DefinitionSDF.getSdfForDefinition(def, context));
             FileUtil.save(context.dotk.getAbsolutePath() + "/ground/Integration.sdf", Definition2SDF.getSdfForDefinition(def, context));
             String newSdf = FileUtil.getFileContent(context.dotk.getAbsolutePath() + "/def/Integration.sdf");
 
             Stopwatch.instance().printIntermediate("File Gen Def");
 
-            if (!oldSdf.equals(newSdf) || !new File(context.dotk.getAbsoluteFile() + "/def/Concrete.tbl").exists()
-                    || !new File(context.dotk.getAbsoluteFile() + "/ground/Concrete.tbl").exists()) {
+            if (!oldSdf.equals(newSdf) || !new File(context.kompiled, "Rule.tbl").exists()
+                    || !new File(context.kompiled, "Ground.tbl").exists()) {
                 try {
                     // Sdf2Table.run_sdf2table(new File(context.dotk.getAbsoluteFile() + "/def"), "Concrete");
                     Thread t1 = Sdf2Table.run_sdf2table_parallel(new File(context.dotk.getAbsoluteFile() + "/def"), "Concrete");
                     if (!context.kompileOptions.backend.documentation()) {
                         Thread t2 = Sdf2Table.run_sdf2table_parallel(new File(context.dotk.getAbsoluteFile() + "/ground"), "Concrete");
                         t2.join();
+                        try {
+                            FileUtils.copyFile(new File(context.dotk, "ground/Concrete.tbl"), new File(context.kompiled, "Ground.tbl"));
+                        } catch (IOException e) {
+                            if (context.globalOptions.debug) {
+                                e.printStackTrace();
+                            }
+                            GlobalSettings.kem.register(new KException(ExceptionType.ERROR, KExceptionGroup.INTERNAL, 
+                                    "IO error detected writing ground parser to file"));
+                            return null; //unreachable
+                        }
                     }
                     t1.join();
+                    try {
+                        FileUtils.copyFileToDirectory(new File(context.dotk, "def/Integration.sdf"), context.kompiled);
+                        FileUtils.copyFile(new File(context.dotk, "def/Concrete.tbl"), new File(context.kompiled, "Rule.tbl"));
+                    } catch (IOException e) {
+                        if (context.globalOptions.debug) {
+                            e.printStackTrace();
+                        }
+                        GlobalSettings.kem.register(new KException(ExceptionType.ERROR, KExceptionGroup.INTERNAL, 
+                                "IO error detected writing rule parser to file"));
+                        return null; //unreachable
+                    }
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     GlobalSettings.kem.register(new KException(ExceptionType.ERROR, KExceptionGroup.CRITICAL, 
                             "Thread was interrupted trying to run SDF2Table"));
                 }
+                
+                
                 Stopwatch.instance().printIntermediate("Generate TBLDef");
             }
-            org.kframework.parser.concrete.KParser.ImportTbl(context.dotk.getAbsolutePath() + "/def/Concrete.tbl");
+            
+            org.kframework.parser.concrete.KParser.ImportTblRule(context.kompiled);
 
             Stopwatch.instance().printIntermediate("Importing Files");
             // ------------------------------------- parse configs
@@ -256,7 +292,7 @@ public class DefinitionLoader {
         def.setItems(di);
 
         // ------------------------------------- import files in Stratego
-        org.kframework.parser.concrete.KParser.ImportTbl(context.kompiled.getAbsolutePath() + "/def/Concrete.tbl");
+        org.kframework.parser.concrete.KParser.ImportTblRule(context.kompiled);
 
         // ------------------------------------- parse configs
         JavaClassesFactory.startConstruction(context);
@@ -281,7 +317,6 @@ public class DefinitionLoader {
         Document doc = XmlLoader.getXMLDoc(parsed);
         XmlLoader.addFilename(doc.getFirstChild(), filename);
         XmlLoader.reportErrors(doc);
-        FileUtil.save(context.kompiled.getAbsolutePath() + "/pgm.xml", parsed);
 
         JavaClassesFactory.startConstruction(context);
         org.kframework.kil.ASTNode config = (Term) JavaClassesFactory.getTerm((Element) doc.getFirstChild().getFirstChild().getNextSibling());
@@ -331,8 +366,6 @@ public class DefinitionLoader {
 
         XmlLoader.addFilename(doc.getFirstChild(), filename);
         XmlLoader.reportErrors(doc);
-        FileUtil.save(context.kompiled.getAbsolutePath() + "/pgm.xml", parsed);
-        XmlLoader.writeXmlFile(doc, context.kompiled + "/pattern.xml");
 
         JavaClassesFactory.startConstruction(context);
         ASTNode config = JavaClassesFactory.getTerm((Element) doc.getDocumentElement().getFirstChild().getNextSibling());
@@ -382,8 +415,6 @@ public class DefinitionLoader {
 
         // XmlLoader.addFilename(doc.getFirstChild(), filename);
         XmlLoader.reportErrors(doc);
-        FileUtil.save(context.kompiled.getAbsolutePath() + "/pgm.xml", parsed);
-        XmlLoader.writeXmlFile(doc, context.kompiled + "/pattern.xml");
 
         JavaClassesFactory.startConstruction(context);
         ASTNode config = JavaClassesFactory.getTerm((Element) doc.getDocumentElement().getFirstChild().getNextSibling());

--- a/src/javasources/KTool/src/org/kframework/parser/concrete/KParser.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete/KParser.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.parser.concrete;
 
+import java.io.File;
 import java.util.HashSet;
 
 import org.kframework.parser.concrete.lib.ConcreteMain;
@@ -37,6 +38,10 @@ public class KParser {
                 context = ConcreteMain.init();
             }
         }
+    }
+    
+    public static String ImportTblRule(File kompiled) {
+        return ImportTbl(kompiled.getAbsolutePath() + "/Rule.tbl");
     }
 
     public static String ImportTbl(String filePath) {
@@ -79,8 +84,8 @@ public class KParser {
         return null;
     }
 
-    public static String ImportTblPgm(String filePath) {
-
+    public static String ImportTblPgm(File kompiled) {
+        String filePath = kompiled.getAbsolutePath() + "/Program.tbl";
         if (!tables.contains(filePath)) {
             tables.add(filePath);
 
@@ -119,7 +124,8 @@ public class KParser {
         return null;
     }
 
-    public static String ImportTblGround(String filePath) {
+    public static String ImportTblGround(File kompiled) {
+        String filePath = kompiled.getAbsolutePath() + "/Ground.tbl";
 
         if (!tables.contains(filePath)) {
             tables.add(filePath);

--- a/src/javasources/KTool/src/org/kframework/parser/generator/ProgramSDF.java
+++ b/src/javasources/KTool/src/org/kframework/parser/generator/ProgramSDF.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.parser.generator;
 
+import java.io.File;
 import java.util.HashSet;
 import java.util.List;
 
@@ -19,7 +20,6 @@ import org.kframework.kompile.KompileOptions.Backend;
 import org.kframework.parser.concrete2.KSyntax2GrammarStatesFilter;
 import org.kframework.utils.BinaryLoader;
 import org.kframework.utils.StringUtil;
-import org.kframework.utils.general.GlobalSettings;
 
 /**
  * Collect the syntax module, call the syntax collector and print SDF for programs.
@@ -44,7 +44,8 @@ public class ProgramSDF {
         }
 
         // save the new parser info
-        BinaryLoader.save(context.dotk.getPath()+ "/pgm/newParser.bin", ks2gsf.getGrammar());
+        new File(context.kompiled, "pgm").mkdirs();
+        BinaryLoader.save(context.kompiled.getPath()+ "/pgm/newParser.bin", ks2gsf.getGrammar());
 
         StringBuilder sdf = new StringBuilder();
         sdf.append("module Program\n\n");


### PR DESCRIPTION
There was a race condition in the pdf backend if you compiled the same definition twice at the same time. I believe this to be because they share a .k directory. I am hoping that this fix, which finally implements the separation between temp files and outputs that -kompiled and .k were supposed to exhibit, will fix this problem.

I still need to test this more thoroughly. I will let you know when it's ready for review.
