### PR TITLE
fix all samples except prog-equiv

### DIFF
--- a/samples/agent/agents.k
+++ b/samples/agent/agents.k
@@ -40,11 +40,11 @@ module AGENTS
 
 // Agents
   rule [agent-creation] : <agent>...  <k>newAgent S:K => N2 ...</k> <me>N1:Int</me> 
-        ...</agent> <world>... . => SetItem(N2) ...</world> // <br/>
+        ...</agent> <world>... .Set => SetItem(N2) ...</world> // <br/>
        (. => <agent>... <me>N2</me><parent>N1</parent><k>S</k> ...</agent>) 
        when fresh(N2:Int)
   rule [agent-completion] : (<agent>... <control>.Bag</control> <me>N:Int</me>  ...</agent>=> .) 
-       <world>... (SetItem(N) => .) ...</world>
+       <world>... (SetItem(N) => .Set) ...</world>
   rule [halt-agent] : <control>...  <k>haltAgent ...</k>  ...</control> => <control> .Bag </control> 
     [transition]
   rule <k>me => N ...</k> <me>N</me>
@@ -69,12 +69,12 @@ module AGENTS
        <agent>... <me>N2</me> <k>receive => V ...</k>  ...</agent>
     [transition]
   rule [start-waiting-at-barrier] : <me>N</me> <k>barrier ...</k>
-       <barrier>true</barrier> <waiting>W (. => SetItem(N))</waiting> 
+       <barrier>true</barrier> <waiting>W (.Set => SetItem(N))</waiting> 
     when notBool(SetItem(N) in W)
   rule [lifting-barrier] : <barrier>true=>false</barrier> <waiting>W</waiting> <world>W</world> 
-    when W =/=Set .
+    when W =/=Set .Set
     [transition]
   rule [leave-barrier] : <me>N</me> <k>barrier => skip ...</k> <barrier>false</barrier>
-       <waiting>... (SetItem(N) => .) ...</waiting>
+       <waiting>... (SetItem(N) => .Set) ...</waiting>
   rule [lowering-barrier] : <barrier>false => true</barrier> <waiting>.Set</waiting>
 endmodule

--- a/samples/agent/io.k
+++ b/samples/agent/io.k
@@ -16,7 +16,7 @@ module IO
   configuration <k> $PGM:Exp </k>  
                 <in stream="stdin"> .List </in> <out stream="stdout"> .List </out>
    rule <k> read => I:Int ...</k> 
-        <in> ListItem(I) => . ...</in>
+        <in> ListItem(I) => .List ...</in>
    rule <k> print V:Val => skip ...</k> 
-        <out>... . => ListItem(V) </out>
+        <out>... .List => ListItem(V) </out>
 endmodule

--- a/samples/agent/ref.k
+++ b/samples/agent/ref.k
@@ -18,7 +18,7 @@ module REF
 
   context * HOLE := _
   rule <k> ref V:Val => N ...</k> 
-       <mem>... . => N |-> V ...</mem>  when fresh(N:Int)
+       <mem>... .Map => N |-> V ...</mem>  when fresh(N:Int)
   rule <k> * N => V ...</k> <mem>... N |-> V ...</mem> [transition]
   rule <k> * N := V => skip ...</k> <mem>... N |-> (_ => V) ...</mem> [transition]
 endmodule

--- a/samples/agent/threads.k
+++ b/samples/agent/threads.k
@@ -30,9 +30,9 @@ module THREADS
 
   rule [free-acquire] : 
        <k>acquire V:Val 
-          => skip ...</k> <holds>... . 
+          => skip ...</k> <holds>... .Map
                                      => V|->0 ...</holds> 
-       <busy>Busy (.
+       <busy>Busy (.Set
                    => SetItem(V))</busy>
     when notBool(V in Busy:Set) [transition]
   rule [reentrant-acquire] : 
@@ -49,9 +49,9 @@ module THREADS
   rule [release] : 
        <k>release V:Val 
           => skip ...</k> <holds>... (V|->0 
-                                      => .) ...</holds> 
+                                      => .Map) ...</holds> 
        <busy>... (SetItem(V)
-            => .) ...</busy>
+            => .Set) ...</busy>
 
   rule [rendezvous] : 
        <k>rendezvous V:Val 

--- a/samples/bf/bf.k
+++ b/samples/bf/bf.k
@@ -100,6 +100,6 @@ Brainfuck jumps ('[' and ']') are considered to be loops. Whenever the byte at t
   rule I:Ignore => .K
 
   rule <ptr> I:Int </ptr>
-       <array> M:Map (. => I |-> 0) </array> when notBool(I in keys M) andBool (I >=Int 0) [structural]
+       <array> M:Map (.Map => I |-> 0) </array> when notBool(I in keys(M)) andBool (I >=Int 0) [structural]
   
 endmodule

--- a/samples/imp-hoare/imp.k
+++ b/samples/imp-hoare/imp.k
@@ -18,7 +18,7 @@ module IMP-SYNTAX
                  > left:
 		   AExp "+" AExp              [left, strict]
                  | AExp "-" AExp              [left, strict]
-                 | "(" AExp ")"               [bracket]
+                 > "(" AExp ")"               [bracket]
   syntax BExp  ::= Bool
                  | AExp "<=" AExp             [seqstrict, latex({#1}\leq{#2})]
                  | AExp "==" AExp             [strict]
@@ -116,20 +116,20 @@ module IMP
   rule <k> lvalue(array(L:Int, Size:Int)[I:Int]) => loc(L +Int I) ...</k> 
        <store>... L |-> _:Int ...</store>
 
-  rule S1 S2 => S1 ~> S2  [structural]
+  rule S1:Stmt S2:Stmt => S1 ~> S2  [structural]
   rule if (true)  S else _ => S
   rule if (false) _ else S => S
   rule while (B) S => if (B) {S while (B) S} else {}  [structural]
 // Pgm
   rule <k> int (X:Id,Xs:AExps => Xs); _:Pre _:Post _:Stmt </k> 
-       <env> Rho:Map (. => X |-> L) </env>
-       <store>... . => (L |-> 0) </store>
+       <env> Rho:Map (.Map => X |-> L) </env>
+       <store>... .Map => (L |-> 0) </store>
        when notBool (X in keys(Rho)) andBool fresh(L:Int)
 
   // symbolic arrays
   rule <k> int (X:Id [S:#Int] ,Xs:Ids => Xs); _:Pre _:Post St:Stmt </k>
-       <env> Rho:Map (. => X |-> L) </env>
-       <store>... (. => L |-> array(AL, S) AL |-> #symArray(X) ) </store>
+       <env> Rho:Map (.Map => X |-> L) </env>
+       <store>... (.Map => L |-> array(AL, S) AL |-> #symArray(X) ) </store>
        when notBool (X in keys(Rho)) andBool fresh(L:Int) andBool fresh(AL:Int)
 
   rule int .AExps ; P:Pre P':Post S:Stmt => P ~> P' ~> S [structural]
@@ -244,12 +244,12 @@ module IMP
 
 //@ Utils              
   syntax Bool ::= "mapLeftEq" "(" Map "," Map ")" [function]
-  rule mapLeftEq(X:Int |-> V1:Int Rest:Map, Left:Map X |-> V2 Right:Map) => V1 ==Int V2 andBool mapLeftEq(Rest, Left Right)
-  rule mapLeftEq(X:Int |-> array(AL:Int, Sz:Int) Rest:Map, Left:Map X |-> array(AL, Sz) Right:Map) => mapLeftEq(Rest, Left Right)
-  rule mapLeftEq(X:Int |-> A:Array Rest:Map, Left:Map X |-> A Right:Map) => mapLeftEq(Rest, Left Right)
+  rule mapLeftEq(X:Int |-> V1:Int Rest:Map, X |-> V2 Rest2:Map) => V1 ==Int V2 andBool mapLeftEq(Rest, Rest2)
+  rule mapLeftEq(X:Int |-> array(AL:Int, Sz:Int) Rest:Map, X |-> array(AL, Sz) Rest2:Map) => mapLeftEq(Rest, Rest2)
+  rule mapLeftEq(X:Int |-> A:Array Rest:Map, X |-> A Rest2:Map) => mapLeftEq(Rest, Rest2)
   rule mapLeftEq(. , _) => true
   rule mapLeftEq(X:Int |-> _:Int _:Map, Right:Map) => false when notBool(X in keys(Right))
-  rule mapLeftEq(M:Map, .) => false when notBool(isEmptySet(keys(M)))
+  rule mapLeftEq(M:Map, .) => false when notBool(keys(M) ==Set .Set)
 
 //@ Compiler issues
   // subsort issue? 

--- a/samples/imp-reachability/imp.k
+++ b/samples/imp-reachability/imp.k
@@ -15,7 +15,7 @@ module IMP-SYNTAX
                  > left:
 		   AExp "+" AExp              [left, strict]
                  | AExp "-" AExp              [left, strict]
-                 | "(" AExp ")"               [bracket]
+                 > "(" AExp ")"               [bracket]
   syntax BExp  ::= Bool
                  | AExp "<=" AExp             [seqstrict, latex({#1}\leq{#2})]
                  | "!" BExp                   [strict]
@@ -87,12 +87,12 @@ The initial semantics of IMP.
   rule {S} => S  [structural]
 // Stmt
   rule <k> X = I:Int; => . ...</k> <state>... X |-> (_ => I) ...</state>
-  rule S1 S2 => S1 ~> S2  [structural]
+  rule S1:Stmt S2:Stmt => S1 ~> S2  [structural]
 //  rule if (true)  S else _ => S
 //  rule if (false) _ else S => S
   rule while (B) S => if (B) {S while (B) S} else {}  [transition]
 // Pgm
-  rule <k> int (X:Id,Xs:Ids => Xs);_ </k> <state> Rho:Map (. => X|->0) </state>
+  rule <k> int (X:Id,Xs:Ids => Xs);_ </k> <state> Rho:Map (.Map => X|->0) </state>
     when notBool (X in keys(Rho))
   rule int .Ids; S => S  [structural]
 

--- a/samples/imp-symbolic/imp.k
+++ b/samples/imp-symbolic/imp.k
@@ -70,7 +70,7 @@ module IMP
   rule {S} => S  [structural]
 // Stmt
   rule <k> X = I:Int; => . ...</k> <state>... X |-> (_ => I) ...</state>
-  rule S1 S2 => S1 ~> S2  [structural]
+  rule S1:Stmt S2:Stmt => S1 ~> S2  [structural]
 //  rule if (true)  S else _ => S
 //  rule if (false) _ else S => S
   rule while (B) S => if (B) {S while (B) S} else {}  [structural]

--- a/samples/tests/config.xml
+++ b/samples/tests/config.xml
@@ -25,5 +25,64 @@
   </test>
 
   <include file="../java_rewrite_engine/tests/config.xml" directory="java_rewrite_engine" />
+
+  <!-- BF -->
+  <test
+      definition="bf/bf.k"
+      programs="../bf/programs"
+      results="../../tests/examples/bf"
+      extension="bf"
+      >
+    <all-programs>
+      <krun-option name="--output" value="none" />
+      <krun-option name="--color" value="off" />
+    </all-programs>
+  </test>
+
+  <!-- IMP-SYMBOLIC -->
+  <test
+      definition="imp-symbolic/imp.k"
+      programs="../imp-symbolic/programs"
+      results="../imp-symbolic/programs"
+      extension="imp"
+      >
+    <all-programs>
+      <krun-option name="--search" />
+      <krun-option name="--parser" value="kast --parser ground"/>
+      <krun-option name="--color" value="off" />
+    </all-programs>
+  </test>
+
+  <!-- IMP-HOARE -->
+  <test
+      definition="imp-hoare/imp.k"
+      programs="../imp-hoare/programs"
+      results="../imp-hoare/programs"
+      extension="imp"
+      >
+    <all-programs>
+      <krun-option name="--output" value="none" />
+      <krun-option name="--color" value="off" />
+    </all-programs>
+  </test>
+
+  <!-- IMP-REACHABILITY -->
+  <test
+      definition="imp-reachability/imp.k"
+      programs="../imp-reachability"
+      results="../imp-reachability"
+      extension="imp"
+      exclude="pgm-1.imp pgm-2.imp pgm-3.imp"
+      >
+    <all-programs>
+      <krun-option name="--search" />
+      <krun-option name="--depth" value="5" />
+      <krun-option name="--parser" value="kast --parser ground" />
+      <krun-option name="--color" value="off" />
+    </all-programs>
+  </test>
+
+  <include file="../wcet/tests/config.xml" directory="wcet" />
+
 </tests>
 

--- a/samples/tests/old_config.xml
+++ b/samples/tests/old_config.xml
@@ -25,62 +25,6 @@
     </program>
   </test>
 
-  <!-- BF -->
-  <test
-      definition="bf/bf.k"
-      programs="../bf/programs"
-      results="../../tests/examples/bf"
-      extension="bf"
-      >
-    <all-programs>
-      <krun-option name="--output" value="none" />
-      <krun-option name="--color" value="off" />
-    </all-programs>
-  </test>
-
-  <!-- IMP-SYMBOLIC -->
-  <test
-      definition="imp-symbolic/imp.k"
-      programs="../imp-symbolic/programs"
-      results="../imp-symbolic/programs"
-      extension="imp"
-      >
-    <all-programs>
-      <krun-option name="--search" />
-      <krun-option name="--parser" value="kast --parser ground"/>
-      <krun-option name="--color" value="off" />
-    </all-programs>
-  </test>
-
-  <!-- IMP-HOARE -->
-  <test
-      definition="imp-hoare/imp.k"
-      programs="../imp-hoare/programs"
-      results="../imp-hoare/programs"
-      extension="imp"
-      >
-    <all-programs>
-      <krun-option name="--output" value="none" />
-      <krun-option name="--color" value="off" />
-    </all-programs>
-  </test>
-
-  <!-- IMP-REACHABILITY -->
-  <test
-      definition="imp-reachability/imp.k"
-      programs="../imp-reachability"
-      results="../imp-reachability"
-      extension="imp"
-      exclude="pgm-1.imp pgm-2.imp pgm-3.imp"
-      >
-    <all-programs>
-      <krun-option name="--search" />
-      <krun-option name="--depth" value="5" />
-      <krun-option name="--parser" value="kast --parser ground" />
-      <krun-option name="--color" value="off" />
-    </all-programs>
-  </test>
-
   <!-- Program Equivalence -->
   <test
       definition="prog-equiv/imp/peq.k"
@@ -112,6 +56,5 @@
     </all-programs>
   </test>
 
-  <include file="../wcet/tests/config.xml" directory="wcet" />
 </tests>
 

--- a/samples/wcet/wcet.k
+++ b/samples/wcet/wcet.k
@@ -141,7 +141,7 @@ module WCET
 
   rule load(B:Block Bs:Blocks) => load(B) ~> load(Bs)
   rule <k> load(X:Id : Is:Insts) => . ...</k>
-       <pgm>... . => X |-> (Is) ...</pgm>
+       <pgm>... .Map => X |-> (Is) ...</pgm>
   /*@ Note here that the \texttt{pgm} cell is only loaded with the contents of the current block.
   We will see the significance of this momentarily.*/
 
@@ -160,19 +160,19 @@ module WCET
   //@ And an immediate evaluates to its own declared value.
 
   rule <k> add r I:Int , I2:Int , I3:Int => time(add) ...</k>
-       <reg> R:Map => R[I2 +Int I3 / I] </reg>
+       <reg> R:Map => R[I2 +Int I3 <- I] </reg>
   rule <k> sub r I:Int , I2:Int , I3:Int => time(sub) ...</k>
-       <reg> R:Map => R[I2 -Int I3 / I] </reg>
+       <reg> R:Map => R[I2 -Int I3 <- I] </reg>
   rule <k> mul r I:Int , I2:Int , I3:Int => time(mul) ...</k>
-       <reg> R:Map => R[I2 *Int I3 / I] </reg>
+       <reg> R:Map => R[I2 *Int I3 <- I] </reg>
   rule <k> div r I:Int , I2:Int , I3:Int => time(div) ...</k>
-       <reg> R:Map => R[I2 /Int I3 / I] </reg>
+       <reg> R:Map => R[I2 /Int I3 <- I] </reg>
   rule <k> or r I:Int , I2:Int , I3:Int => time(or) ...</k>
-       <reg> R:Map => R[I2 |Int I3 / I] </reg>
+       <reg> R:Map => R[I2 |Int I3 <- I] </reg>
   rule <k> and r I:Int , I2:Int , I3:Int => time(and) ...</k>
-       <reg> R:Map => R[I2 &Int I3 / I] </reg>
+       <reg> R:Map => R[I2 &Int I3 <- I] </reg>
   rule <k> not r I:Int , I2:Int => time(not) ...</k>
-       <reg> R:Map => R[~Int I2 / I] </reg>
+       <reg> R:Map => R[~Int I2 <- I] </reg>
   /*@ The first instructions of the language are defined above. Once the arguments are evaluated,
   the arithmetic operation is performed and the result is stored in the target register. Then the
   time of the instruction is made to elapse. The auxiliary operation \texttt{time} elapses time
@@ -180,12 +180,12 @@ module WCET
 
   rule <k> load r I:Int , I2:Int => time(load) ...</k>
        <mem>... I2 |-> I3:Int ...</mem>
-       <reg> R:Map => R[I3 / I] </reg>
+       <reg> R:Map => R[I3 <- I] </reg>
   /*@ The \texttt{mem} cell contains memory. An integer location in memory is evaluated, indexed in
   memory, and the value found there is put in a register.*/
 
   rule <k> store I:Int , I2:Int => time(store) ...</k>
-       <mem> M:Map => M[I2 / I] </mem>
+       <mem> M:Map => M[I2 <- I] </mem>
   /*@ \texttt{store} evaluates two arguments. The first expresses the location in memory to write 
   to, and the second expresses the value to write there. Once evaluated, we update the \texttt{mem}
   cell with the value in memory.*/
@@ -214,22 +214,22 @@ module WCET
 
   rule <k> read r I:Int , X:Id => time(read) ...</k>
        <status>... X |-> I2:Int ...</status>
-       <reg> Reg:Map => Reg[I2 / I] </reg>
+       <reg> Reg:Map => Reg[I2 <- I] </reg>
   /*@ An I/O read looks up the current value of the data in the \texttt{status} cell, then
   writes it to a register.*/
 
   rule <k> write X:Id , I:Int => time(write) ...</k>
-       <status> Status:Map => Status[I / X] </status>
+       <status> Status:Map => Status[I <- X] </status>
   //@ \texttt{write} evaluates a value, then writes it to the \texttt{status} cell.
 
   rule <k> rw r I:Int , X:Id , I3:Int => time(rw) ...</k>
        <status>... X |-> (I2:Int => I3) ...</status>
-       <reg> Reg:Map => Reg[I2 / I] </reg>
+       <reg> Reg:Map => Reg[I2 <- I] </reg>
   //@ \texttt{rw} simply combines these two instructions together.
 
   syntax K ::= (Id, Int, Int)
   rule <k> int X:Id , I:Int , I2:Int => time(int) ...</k>
-       <timers>... . => ListItem((X, I +Int Time, I2)) </timers>
+       <timers>... .List => ListItem((X, I +Int Time, I2)) </timers>
        <wcet> Time:Int </wcet>
   /*@ \texttt{int} schedules an interrupt $I$ cycles after executing, to execute periodically every
   $I2$ cycles thereafter. The \texttt{timers} cell stores the currently activated interrupts in a
@@ -237,7 +237,7 @@ module WCET
 
   syntax K ::= (K, Int)
   rule <k> rfi ~> _ => time(rfi) ~> K </k>
-       <stack> ListItem((K:K, Priority:Int)) => . ...</stack>
+       <stack> ListItem((K:K, Priority:Int)) => .List ...</stack>
        <priority> _ => Priority </priority>
   /*@ To return from an interrupt, we restore the previously executing code from the \texttt{stack}
   cell, which also contains the previously-executing priority to restore to the \texttt{priority}
@@ -246,16 +246,16 @@ module WCET
   priority 0.*/
 
   syntax K ::= time(OpCode)
-  rule <k> time(O:OpCode) => waitFor(Timing(O)) ...</k>
+  rule <k> time(O:OpCode) => waitFor(Timing[O]) ...</k>
        <timing> Timing:Map </timing>
   /*@ For modularity, we allow the time each instruction executes for to be specified dynamically
   in the \texttt{timing} cell.*/
 
   syntax K ::= waitFor(Int)
-  rule <k> waitFor(I:Int) => updateStatus(I2) ~> updateTimers(L) ~> interrupt(L, lengthList L) ...</k>
+  rule <k> waitFor(I:Int) => updateStatus(I2) ~> updateTimers(L) ~> interrupt(L, size(L)) ...</k>
        <br/>
        <wcet> I2:Int => I2 +Int I </wcet>
-       <timers> L:List => . </timers>
+       <timers> L:List => .List </timers>
   /*@ The \texttt{wcet} cell stores the length of time the program has already been running for, in
   total. When time passes, two types of asynchronous events can occur. The first is a write on an
   I/O line, provided in advance in the \texttt{input} cell. The second is the firing of a timer 
@@ -264,11 +264,11 @@ module WCET
   syntax K ::= updateStatus(Int)
   syntax K ::= (Int, Map)
   rule <k> updateStatus(Start:Int) ...</k>
-       <input> ListItem((I2:Int, M:Map)) => . ...</input>
+       <input> ListItem((I2:Int, M:Map)) => .List ...</input>
        <wcet> I:Int </wcet>
        <status> Status:Map => Status[M] </status> when I >=Int I2 andBool I2 >=Int Start
   rule <k> updateStatus(Start:Int) => . ...</k>
-       <input> ListItem((I2:Int, _)) ...</input>
+       <input> ListItem((I2:Int, _:Map)) ...</input>
        <wcet> I:Int </wcet> when notBool(I >=Int I2 andBool I >=Int Start)
   rule <k> updateStatus(_) => . ...</k>
        <input> .List </input>
@@ -277,21 +277,21 @@ module WCET
   ocurring before or after the time window of the instruction are ignored.*/
 
   syntax K ::= updateTimers(List)
-  rule <k> updateTimers((ListItem((X:Id, Expires:Int, Interval:Int)) => .) _) ...</k>
+  rule <k> updateTimers((ListItem((X:Id, Expires:Int, Interval:Int)) => .List) _) ...</k>
        <br/>
        <wcet> I:Int </wcet>
-       <timers>... . => ListItem((X, Expires, Interval)) </timers> when I <Int Expires orBool Interval ==Int 0
+       <timers>... .List => ListItem((X, Expires, Interval)) </timers> when I <Int Expires orBool Interval ==Int 0
   rule <k> updateTimers(ListItem((X:Id, (Expires:Int => Expires +Int Interval), Interval:Int)) _) ...</k>
        <br/>
        <wcet> I:Int </wcet>
-       <interrupts>... . => SetItem(X) </interrupts> when I >=Int Expires andBool Interval =/=Int 0
+       <interrupts>... .Set => SetItem(X) </interrupts> when I >=Int Expires andBool Interval =/=Int 0
   rule updateTimers(.List) => .
   /*@ Essentially, updateTimers updates the \texttt{interrupts} cell with all the interrupts that
   have been triggered by the previous instruction. When an interrupt is triggered, the tuple
   containing info on the interrupt is updated with a new expiration time.*/
 
   syntax K ::= interrupt(List, Int)
-  rule <k> interrupt((ListItem((X:Id, _, _)) => .) _, (N:Int => N -Int 1)) ...</k>
+  rule <k> interrupt((ListItem((X:Id, _, _)) => .List) _, (N:Int => N -Int 1)) ...</k>
        <br/>
        <interrupts> S:Set </interrupts>
        <priority> Priority:Int </priority> when notBool(X in S) orBool N <=Int Priority
@@ -299,7 +299,7 @@ module WCET
        <priority> Priority:Int => N </priority>
        <br/>
        <interrupts> S:Set => S -Set SetItem(X) </interrupts>
-       <stack> . => ListItem((K, Priority)) ...</stack> when N >Int Priority andBool X in S
+       <stack> .List => ListItem((K, Priority)) ...</stack> when N >Int Priority andBool X in S
   rule <k> interrupt(.List, _) => . ...</k>
   /*@ Essentially, interrupt fires exactly one pending interrupt, removing it from the
   \texttt{interrupts} cell. This only occurs if there is a pending interrupt to fire and its

--- a/src/javasources/KTool/src/org/kframework/backend/BasicBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/BasicBackend.java
@@ -68,7 +68,7 @@ public abstract class BasicBackend implements Backend {
         steps.add(new AddSupercoolDefinition(context));
         steps.add(new AddHeatingConditions(context));
         steps.add(new AddSuperheatRules(context));
-        steps.add(new DesugarStreams(context, true));
+        steps.add(new DesugarStreams(context));
         steps.add(new ResolveFunctions(context));
         steps.add(new AddKCell(context));
         steps.add(new AddStreamCells(context));
@@ -89,7 +89,7 @@ public abstract class BasicBackend implements Backend {
         steps.add(new ResolveBuiltins(context));
         steps.add(new ResolveListOfK(context));
         steps.add(new FlattenSyntax(context));
-        steps.add(new ResolveBlockingInput(context, true));
+        steps.add(new ResolveBlockingInput(context));
         steps.add(new InitializeConfigurationStructure(context));
         steps.add(new AddKStringConversion(context));
         steps.add(new AddKLabelConstant(context));

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/JavaSymbolicBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/JavaSymbolicBackend.java
@@ -116,7 +116,7 @@ public class JavaSymbolicBackend extends BasicBackend {
         //steps.add(new AddSupercoolDefinition(context));
         steps.add(new AddHeatingConditions(context));
         //steps.add(new AddSuperheatRules(context));
-        steps.add(new DesugarStreams(context, true));
+        steps.add(new DesugarStreams(context));
         steps.add(new ResolveFunctions(context));
         steps.add(new AddKCell(context));
         steps.add(new AddStreamCells(context));
@@ -139,7 +139,7 @@ public class JavaSymbolicBackend extends BasicBackend {
         steps.add(new AddInjections(context));
 
         steps.add(new FlattenSyntax(context));
-        steps.add(new ResolveBlockingInput(context, true));
+        steps.add(new ResolveBlockingInput(context));
         steps.add(new InitializeConfigurationStructure(context));
         //steps.add(new AddKStringConversion(context));
         //steps.add(new AddKLabelConstant(context));

--- a/src/javasources/KTool/src/org/kframework/backend/kore/KoreBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/kore/KoreBackend.java
@@ -114,7 +114,7 @@ public class KoreBackend extends BasicBackend {
         steps.add(new AddSupercoolDefinition(context));
         steps.add(new AddHeatingConditions(context));
         steps.add(new AddSuperheatRules(context));
-        steps.add(new DesugarStreams(context, false));
+        steps.add(new DesugarStreams(context));
         steps.add(new ResolveFunctions(context));
         steps.add(new AddKCell(context));
         steps.add(new AddStreamCells(context));
@@ -129,7 +129,7 @@ public class KoreBackend extends BasicBackend {
         }
         steps.add(new ResolveBinder(context));
         steps.add(new ResolveAnonymousVariables(context));
-        steps.add(new ResolveBlockingInput(context, false));
+        steps.add(new ResolveBlockingInput(context));
         steps.add(new AddK2SMTLib(context));
         steps.add(new AddPredicates(context));
         steps.add(new ResolveSyntaxPredicates(context));

--- a/src/javasources/KTool/src/org/kframework/backend/symbolic/SymbolicBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/symbolic/SymbolicBackend.java
@@ -132,7 +132,7 @@ public class SymbolicBackend extends BasicBackend implements Backend {
         steps.add(new AddHeatingConditions(context));
         steps.add(new AddSuperheatRules(context));
         steps.add(new ResolveSymbolicInputStream(context)); // symbolic step
-        steps.add(new DesugarStreams(context, false));
+        steps.add(new DesugarStreams(context));
         steps.add(new ResolveFunctions(context));
         steps.add(new TagUserRules(context)); // symbolic step
         steps.add(new ReachabilityRuleToKRule(context)); // symbolic step 
@@ -147,13 +147,13 @@ public class SymbolicBackend extends BasicBackend implements Backend {
         steps.add(new AddTopCellRules(context));
         steps.add(new ResolveBinder(context));
         steps.add(new ResolveAnonymousVariables(context));
-        steps.add(new ResolveBlockingInput(context, false));
+        steps.add(new FlattenSyntax(context));
+        steps.add(new ResolveBlockingInput(context));
         steps.add(new AddK2SMTLib(context));
         steps.add(new AddPredicates(context));
         steps.add(new ResolveSyntaxPredicates(context));
         steps.add(new ResolveBuiltins(context));
         steps.add(new ResolveListOfK(context));
-        steps.add(new FlattenSyntax(context));
         steps.add(new InitializeConfigurationStructure(context));
         steps.add(new AddKStringConversion(context));
         steps.add(new AddKLabelConstant(context));

--- a/src/javasources/KTool/src/org/kframework/compile/transformers/DesugarStreams.java
+++ b/src/javasources/KTool/src/org/kframework/compile/transformers/DesugarStreams.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 public class DesugarStreams extends CopyOnWriteTransformer {
     
     ArrayList<String> channels = new ArrayList<String>();
-    boolean newList;
 
     public DesugarStreams(org.kframework.kil.loader.Context context) {
         super("Desugar streams", context);
@@ -45,22 +44,12 @@ public class DesugarStreams extends CopyOnWriteTransformer {
     private Term makeStreamList(String stream, Cell node) {
         Term contents = node.getContents();
         
-        List result;
         Term addAtBeginning = null;
         Term addAtEnd = null;
-        if (newList) {
-            result = null;
-        } else if (contents instanceof List) {
-            result = ((List)contents).shallowCopy();
-        } else {
-            result = new List();
-            result.getContents().add(contents);
-        }
         java.util.List<Term> items = new ArrayList<Term>();
         if ("stdin".equals(stream)) {
 //            eq evalCleanConf(T, "stdin") = mkCollection(List, (T, ioBuffer(stdinVariable), noIOVariable, stdinStream)) .
-            if (!newList) items.addAll(result.getContents());
-            else addAtBeginning = contents;
+            addAtBeginning = contents;
 //            syntax List ::= "#buffer" "(" K ")"           [cons(List1IOBufferSyn)]
             TermCons buffer = new TermCons("Stream", "Stream1IOBufferSyn", context);
             java.util.List<Term> bufferTerms = new ArrayList<Term>();
@@ -68,7 +57,7 @@ public class DesugarStreams extends CopyOnWriteTransformer {
             buffer.setContents(bufferTerms);
             items.add(newListItem(buffer));
             
-            items.add(new Variable("$noIO", (!newList ? "ListItem" : "List")));//          eq noIOVariable = mkVariable('$noIO,List) .
+            items.add(new Variable("$noIO", ("List")));//          eq noIOVariable = mkVariable('$noIO,List) .
             
 //            syntax List ::= "#istream" "(" Int ")"        [cons(List1InputStreamSyn)]
             TermCons stdinStream = new TermCons("Stream", "Stream1InputStreamSyn", context);
@@ -86,7 +75,7 @@ public class DesugarStreams extends CopyOnWriteTransformer {
             stdoutStream.setContents(stdinStreamTerms);
             items.add(newListItem(stdoutStream));
             
-            items.add(new Variable("$noIO", (!newList ? "ListItem" : "List")));//          eq noIOVariable = mkVariable('$noIO,List) .
+            items.add(new Variable("$noIO", ("List")));//          eq noIOVariable = mkVariable('$noIO,List) .
 
 //            syntax List ::= "#buffer" "(" K ")"           [cons(List1IOBufferSyn)]
             TermCons buffer = new TermCons("Stream", "Stream1IOBufferSyn", context);
@@ -95,8 +84,7 @@ public class DesugarStreams extends CopyOnWriteTransformer {
             buffer.setContents(bufferTerms);
             items.add(newListItem(buffer));
 
-            if (!newList) items.addAll(result.getContents());
-            else addAtEnd = contents;
+            addAtEnd = contents;
         }
         if(channels.indexOf(stream) == -1){
             GlobalSettings.kem.register(new KException(ExceptionType.ERROR, 
@@ -104,29 +92,20 @@ public class DesugarStreams extends CopyOnWriteTransformer {
                     "Make sure you give the correct stream names: " + channels.toString(), 
                     getName(), node.getFilename(), node.getLocation()));
         }
-        if (newList) {
-            DataStructureSort myList = context.dataStructureListSortOf(DataStructureSort.DEFAULT_LIST_SORT);
-            Term newItems = DataStructureSort.listOf(context, items.toArray(new Term[] {}));
-            if (addAtBeginning != null) {
-                newItems = KApp.of(KLabelConstant.of(myList.constructorLabel(), context), addAtBeginning, newItems);
-            }
-            if (addAtEnd != null) {
-                newItems = KApp.of(KLabelConstant.of(myList.constructorLabel(), context), newItems, addAtEnd);
-            }
-            return newItems;
-        } else {
-            result.setContents(items);
-            return result;
+        DataStructureSort myList = context.dataStructureListSortOf(DataStructureSort.DEFAULT_LIST_SORT);
+        Term newItems = DataStructureSort.listOf(context, items.toArray(new Term[] {}));
+        if (addAtBeginning != null) {
+            newItems = KApp.of(KLabelConstant.of(myList.constructorLabel(), context), addAtBeginning, newItems);
         }
+        if (addAtEnd != null) {
+            newItems = KApp.of(KLabelConstant.of(myList.constructorLabel(), context), newItems, addAtEnd);
+        }
+        return newItems;
     }
 
     private Term newListItem(Term element) {
-        if (newList) {
-            DataStructureSort myList = context.dataStructureListSortOf(DataStructureSort.DEFAULT_LIST_SORT);
-            return KApp.of(KLabelConstant.of(myList.elementLabel(), context), element);
-        } else {
-            return new ListItem(element);
-        }
+        DataStructureSort myList = context.dataStructureListSortOf(DataStructureSort.DEFAULT_LIST_SORT);
+        return KApp.of(KLabelConstant.of(myList.elementLabel(), context), element);
     }        
 
     @Override

--- a/src/javasources/KTool/src/org/kframework/compile/transformers/DesugarStreams.java
+++ b/src/javasources/KTool/src/org/kframework/compile/transformers/DesugarStreams.java
@@ -16,12 +16,11 @@ public class DesugarStreams extends CopyOnWriteTransformer {
     ArrayList<String> channels = new ArrayList<String>();
     boolean newList;
 
-    public DesugarStreams(org.kframework.kil.loader.Context context, boolean newList) {
+    public DesugarStreams(org.kframework.kil.loader.Context context) {
         super("Desugar streams", context);
         
         channels.add("stdin");
         channels.add("stdout");
-        this.newList = newList;
     }
     
     @Override

--- a/src/javasources/KTool/src/org/kframework/kcheck/RLBackend.java
+++ b/src/javasources/KTool/src/org/kframework/kcheck/RLBackend.java
@@ -331,7 +331,7 @@ public class RLBackend extends BasicBackend implements Backend {
         steps.add(new AddHeatingConditions(context));
         steps.add(new AddSuperheatRules(context));
         // steps.add(new ResolveSymbolicInputStream(context)); // symbolic step
-        steps.add(new DesugarStreams(context, false));
+        steps.add(new DesugarStreams(context));
         steps.add(new ResolveFunctions(context));
         steps.add(new TagUserRules(context)); // symbolic step
         steps.add(new AddKCell(context));
@@ -354,7 +354,7 @@ public class RLBackend extends BasicBackend implements Backend {
         steps.add(new AddTopCellRules(context));
         steps.add(new ResolveBinder(context));
         steps.add(new ResolveAnonymousVariables(context));
-        steps.add(new ResolveBlockingInput(context, false));
+        steps.add(new ResolveBlockingInput(context));
         steps.add(new AddK2SMTLib(context));
         steps.add(new AddPredicates(context));
         steps.add(new ResolveSyntaxPredicates(context));


### PR DESCRIPTION
- symbolic backend test doesn't work still
- agent is broken because it relies on search and substitution
- prog-equiv is broken because it declares new constructors of sort Map

@andreiarusoaie we will not delay the merge trying to fix the symbolic backend, so if you want it to continue to work moving forward I suggest you fix it within unified-builtins2 while we are still waiting to merge.
@dlucanu your code in peq.k uses features of the framework that are being removed by this branch. You will no longer be able to declare new constructors of sorts Map, List, and Set. We will not delay the merge trying to fix this definition, so if you want it to continue to be regression tested moving forward, you will need to figure out how to fix the definition.
