### PR TITLE
Rename TermContext to State

### DIFF
--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinBitVectorOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinBitVectorOperations.java
@@ -3,7 +3,7 @@ package org.kframework.backend.java.builtins;
 
 import org.kframework.backend.java.kil.BuiltinList;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 
 import java.util.List;
 
@@ -18,7 +18,7 @@ public final class BuiltinBitVectorOperations {
 
     private BuiltinBitVectorOperations() { }
 
-    public static BitVector construct(IntToken bitwidth, IntToken value, TermContext context) {
+    public static BitVector construct(IntToken bitwidth, IntToken value, State context) {
         try {
             return BitVector.of(value.bigIntegerValue(), bitwidth.intValue());
         } catch (ArithmeticException e) {
@@ -26,23 +26,23 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static IntToken bitwidth(BitVector term, TermContext context) {
+    public static IntToken bitwidth(BitVector term, State context) {
         return IntToken.of(term.bitwidth());
     }
 
-    public static BoolToken zero(BitVector term, TermContext context) {
+    public static BoolToken zero(BitVector term, State context) {
         return BoolToken.of(term.isZero());
     }
 
-    public static IntToken svalue(BitVector term, TermContext context) {
+    public static IntToken svalue(BitVector term, State context) {
         return IntToken.of(term.signedValue());
     }
 
-    public static IntToken uvalue(BitVector term, TermContext context) {
+    public static IntToken uvalue(BitVector term, State context) {
         return IntToken.of(term.unsignedValue());
     }
 
-    public static BitVector add(BitVector term1, BitVector term2, TermContext context) {
+    public static BitVector add(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.add(term2);
         } else {
@@ -50,7 +50,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BitVector sub(BitVector term1, BitVector term2, TermContext context) {
+    public static BitVector sub(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.sub(term2);
         } else {
@@ -58,7 +58,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BitVector mul(BitVector term1, BitVector term2, TermContext context) {
+    public static BitVector mul(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.mul(term2);
         } else {
@@ -66,7 +66,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BuiltinList sadd(BitVector term1, BitVector term2, TermContext context) {
+    public static BuiltinList sadd(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.sadd(term2);
         } else {
@@ -74,7 +74,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BuiltinList uadd(BitVector term1, BitVector term2, TermContext context) {
+    public static BuiltinList uadd(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.uadd(term2);
         } else {
@@ -82,7 +82,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BuiltinList ssub(BitVector term1, BitVector term2, TermContext context) {
+    public static BuiltinList ssub(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.ssub(term2);
         } else {
@@ -90,7 +90,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BuiltinList usub(BitVector term1, BitVector term2, TermContext context) {
+    public static BuiltinList usub(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.usub(term2);
         } else {
@@ -98,7 +98,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BuiltinList smul(BitVector term1, BitVector term2, TermContext context) {
+    public static BuiltinList smul(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.smul(term2);
         } else {
@@ -106,7 +106,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BuiltinList umul(BitVector term1, BitVector term2, TermContext context) {
+    public static BuiltinList umul(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.umul(term2);
         } else {
@@ -114,7 +114,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static Term sdiv(BitVector term1, BitVector term2, TermContext context) {
+    public static Term sdiv(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.sdiv(term2);
         } else {
@@ -122,7 +122,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static Term udiv(BitVector term1, BitVector term2, TermContext context) {
+    public static Term udiv(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.udiv(term2);
         } else {
@@ -130,7 +130,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static Term srem(BitVector term1, BitVector term2, TermContext context) {
+    public static Term srem(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.srem(term2);
         } else {
@@ -138,7 +138,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static Term urem(BitVector term1, BitVector term2, TermContext context) {
+    public static Term urem(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.urem(term2);
         } else {
@@ -146,7 +146,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BitVector and(BitVector term1, BitVector term2, TermContext context) {
+    public static BitVector and(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.and(term2);
         } else {
@@ -154,7 +154,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BitVector or(BitVector term1, BitVector term2, TermContext context) {
+    public static BitVector or(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.or(term2);
         } else {
@@ -162,7 +162,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BitVector xor(BitVector term1, BitVector term2, TermContext context) {
+    public static BitVector xor(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.xor(term2);
         } else {
@@ -170,19 +170,19 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BitVector shl(BitVector term1, IntToken term2, TermContext context) {
+    public static BitVector shl(BitVector term1, IntToken term2, State context) {
         return term1.shl(term2);
     }
 
-    public static BitVector ashr(BitVector term1, IntToken term2, TermContext context) {
+    public static BitVector ashr(BitVector term1, IntToken term2, State context) {
         return term1.ashr(term2);
     }
 
-    public static BitVector lshr(BitVector term1, IntToken term2, TermContext context) {
+    public static BitVector lshr(BitVector term1, IntToken term2, State context) {
         return term1.lshr(term2);
     }
 
-    public static BoolToken slt(BitVector term1, BitVector term2, TermContext context) {
+    public static BoolToken slt(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.slt(term2);
         } else {
@@ -190,7 +190,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BoolToken ult(BitVector term1, BitVector term2, TermContext context) {
+    public static BoolToken ult(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.ult(term2);
         } else {
@@ -198,7 +198,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BoolToken sle(BitVector term1, BitVector term2, TermContext context) {
+    public static BoolToken sle(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.sle(term2);
         } else {
@@ -206,7 +206,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BoolToken ule(BitVector term1, BitVector term2, TermContext context) {
+    public static BoolToken ule(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.ule(term2);
         } else {
@@ -214,7 +214,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BoolToken sgt(BitVector term1, BitVector term2, TermContext context) {
+    public static BoolToken sgt(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.sgt(term2);
         } else {
@@ -222,7 +222,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BoolToken ugt(BitVector term1, BitVector term2, TermContext context) {
+    public static BoolToken ugt(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.ugt(term2);
         } else {
@@ -230,7 +230,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BoolToken sge(BitVector term1, BitVector term2, TermContext context) {
+    public static BoolToken sge(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.sge(term2);
         } else {
@@ -238,7 +238,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BoolToken uge(BitVector term1, BitVector term2, TermContext context) {
+    public static BoolToken uge(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.uge(term2);
         } else {
@@ -246,7 +246,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BoolToken eq(BitVector term1, BitVector term2, TermContext context) {
+    public static BoolToken eq(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.eq(term2);
         } else {
@@ -254,7 +254,7 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BoolToken ne(BitVector term1, BitVector term2, TermContext context) {
+    public static BoolToken ne(BitVector term1, BitVector term2, State context) {
         if (term1.bitwidth() == term2.bitwidth()) {
             return term1.ne(term2);
         } else {
@@ -262,11 +262,11 @@ public final class BuiltinBitVectorOperations {
         }
     }
 
-    public static BuiltinList toDigits(BitVector term, IntToken bitwidth, TermContext context) {
+    public static BuiltinList toDigits(BitVector term, IntToken bitwidth, State context) {
         return new BuiltinList(term.toDigits(bitwidth.intValue()));
     }
 
-    public static BitVector fromDigits(BuiltinList digitList, IntToken bitwidth, TermContext context) {
+    public static BitVector fromDigits(BuiltinList digitList, IntToken bitwidth, State context) {
         if (!digitList.hasFrame()) {
             List<BitVector> digits;
             try {

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinBoolOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinBoolOperations.java
@@ -2,7 +2,7 @@
 package org.kframework.backend.java.builtins;
 
 
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 
 /**
  * Table of {@code public static} methods on builtin boolean values.
@@ -11,31 +11,31 @@ import org.kframework.backend.java.kil.TermContext;
  */
 public class BuiltinBoolOperations {
 
-    public static BoolToken not(BoolToken term, TermContext context) {
+    public static BoolToken not(BoolToken term, State context) {
         return BoolToken.of(!term.booleanValue());
     }
 
-    public static BoolToken and(BoolToken term1, BoolToken term2, TermContext context) {
+    public static BoolToken and(BoolToken term1, BoolToken term2, State context) {
         return BoolToken.of(term1.booleanValue() && term2.booleanValue());
     }
 
-    public static BoolToken or(BoolToken term1, BoolToken term2, TermContext context) {
+    public static BoolToken or(BoolToken term1, BoolToken term2, State context) {
         return BoolToken.of(term1.booleanValue() || term2.booleanValue());
     }
 
-    public static BoolToken xor(BoolToken term1, BoolToken term2, TermContext context) {
+    public static BoolToken xor(BoolToken term1, BoolToken term2, State context) {
         return BoolToken.of(term1.booleanValue() ^ term2.booleanValue());
     }
 
-    public static BoolToken implies(BoolToken term1, BoolToken term2, TermContext context) {
+    public static BoolToken implies(BoolToken term1, BoolToken term2, State context) {
         return BoolToken.of(!term1.booleanValue() || term2.booleanValue());
     }
 
-    public static BoolToken eq(BoolToken term1, BoolToken term2, TermContext context) {
+    public static BoolToken eq(BoolToken term1, BoolToken term2, State context) {
         return BoolToken.of(term1.booleanValue() == term2.booleanValue());
     }
 
-    public static BoolToken ne(BoolToken term1, BoolToken term2, TermContext context) {
+    public static BoolToken ne(BoolToken term1, BoolToken term2, State context) {
         return BoolToken.of(term1.booleanValue() != term2.booleanValue());
     }
 

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinFloatOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinFloatOperations.java
@@ -16,7 +16,7 @@ import org.kframework.krun.K;
  */
 public class BuiltinFloatOperations {
 
-    public static Term add(Term term1, Term term2, TermContext context) {
+    public static Term add(Term term1, Term term2, State context) {
         if (term1.equals(UninterpretedToken.of("#Float","0.0")))
             return term2;
         if (term2.equals(UninterpretedToken.of("#Float","0.0")))
@@ -24,7 +24,7 @@ public class BuiltinFloatOperations {
         return null;
     }
 
-     public static Term sub(Term term1, Term term2, TermContext context) {
+     public static Term sub(Term term1, Term term2, State context) {
         if (term1.equals(UninterpretedToken.of("#Float","0.0"))) {
             return new KItem(
                     KLabelConstant.of("'--Float_",context),
@@ -36,7 +36,7 @@ public class BuiltinFloatOperations {
         return null;
     }
 
-     public static Term mul(Term term1, Term term2, TermContext context) {
+     public static Term mul(Term term1, Term term2, State context) {
         if (term1.equals(UninterpretedToken.of("#Float","0.0")) ||
                 term2.equals(UninterpretedToken.of("#Float","0.0")))
             return UninterpretedToken.of("#Float","0.0");
@@ -105,7 +105,7 @@ public class BuiltinFloatOperations {
     }
 */
 
-    public static Term unaryMinus(Term term, TermContext context) {
+    public static Term unaryMinus(Term term, State context) {
         if (term instanceof KItem) {
             Term kLabel = ((KItem) term).kLabel();
             Term kList = ((KItem) term).kList();
@@ -126,12 +126,12 @@ public class BuiltinFloatOperations {
         return UninterpretedToken.of(sort, value);
     }
 
-    public static BoolToken eq(Term term1, Term term2, TermContext context) {
+    public static BoolToken eq(Term term1, Term term2, State context) {
         if (term1.equals(term2)) return BoolToken.TRUE;
         return null;
     }
 
-    public static BoolToken gt(Term term1, Term term2, TermContext context) {
+    public static BoolToken gt(Term term1, Term term2, State context) {
         if (!K.smt.equals("gappa")) return null;
         GappaPrinter gappaPrinter = GappaPrinter.toGappaGround(term1);
         if (gappaPrinter.getException() != null) {
@@ -151,7 +151,7 @@ public class BuiltinFloatOperations {
         return null;
     }
 
-    public static BoolToken ge(Term term1, Term term2, TermContext context) {
+    public static BoolToken ge(Term term1, Term term2, State context) {
         if (!K.smt.equals("gappa")) return null;
         GappaPrinter gappaPrinter = GappaPrinter.toGappaGround(term1);
         if (gappaPrinter.getException() != null) {
@@ -171,7 +171,7 @@ public class BuiltinFloatOperations {
         return null;
     }
 
-    public static BoolToken lt(Term term1, Term term2, TermContext context) {
+    public static BoolToken lt(Term term1, Term term2, State context) {
         if (!K.smt.equals("gappa")) return null;
         GappaPrinter gappaPrinter = GappaPrinter.toGappaGround(term1);
         if (gappaPrinter.getException() != null) {
@@ -191,7 +191,7 @@ public class BuiltinFloatOperations {
         return null;
     }
 
-    public static BoolToken le(Term term1, Term term2, TermContext context) {
+    public static BoolToken le(Term term1, Term term2, State context) {
         if (!K.smt.equals("gappa")) return null;
         GappaPrinter gappaPrinter = GappaPrinter.toGappaGround(term1);
         if (gappaPrinter.getException() != null) {

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinIOOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinIOOperations.java
@@ -16,19 +16,19 @@ import org.kframework.krun.api.io.FileSystem;
  */
 public class BuiltinIOOperations {
 
-    public static FileSystem fs(TermContext context) {
+    public static FileSystem fs(State context) {
         return context.fileSystem();
     }
 
-    public static Definition definition(TermContext context) {
+    public static Definition definition(State context) {
         return context.definition();
     }
 
-    public static Context context(TermContext context) {
+    public static Context context(State context) {
         return context.definition().context();
     }
 
-    public static Term open(StringToken term1, StringToken term2, TermContext context) {
+    public static Term open(StringToken term1, StringToken term2, State context) {
         try {
             return IntToken.of(fs(context).open(term1.stringValue(), term2.stringValue()));
         } catch (IOException e) {
@@ -36,7 +36,7 @@ public class BuiltinIOOperations {
         }
     }
 
-    public static Term tell(IntToken term, TermContext context) {
+    public static Term tell(IntToken term, State context) {
         try {
             return IntToken.of(fs(context).get(term.longValue()).tell());
         } catch (IOException e) {
@@ -44,7 +44,7 @@ public class BuiltinIOOperations {
         }
     }
 
-    public static Term getc(IntToken term, TermContext context) {
+    public static Term getc(IntToken term, State context) {
         try {
             return IntToken.of(fs(context).get(term.longValue()).getc() & 0xff);
         } catch (IOException e) {
@@ -52,7 +52,7 @@ public class BuiltinIOOperations {
         }
     }
 
-    public static Term read(IntToken term1, IntToken term2, TermContext context) {
+    public static Term read(IntToken term1, IntToken term2, State context) {
         try {
             return StringToken.of(fs(context).get(term1.longValue()).read(term2.intValue()));
         } catch (IOException e) {
@@ -60,7 +60,7 @@ public class BuiltinIOOperations {
         }
     }
 
-    public static Term close(IntToken term, TermContext context) {
+    public static Term close(IntToken term, State context) {
         try {
             fs(context).close(term.longValue());
             return new KItem(new KLabelInjection(new KSequence()), new KList(), context);
@@ -69,7 +69,7 @@ public class BuiltinIOOperations {
         }
     }
 
-    public static Term seek(IntToken term1, IntToken term2, TermContext context) {
+    public static Term seek(IntToken term1, IntToken term2, State context) {
         try {
             fs(context).get(term1.longValue()).seek(term2.longValue());
             return new KItem(new KLabelInjection(new KSequence()), new KList(), context);
@@ -78,7 +78,7 @@ public class BuiltinIOOperations {
         }
     }
 
-    public static Term putc(IntToken term1, IntToken term2, TermContext context) {
+    public static Term putc(IntToken term1, IntToken term2, State context) {
         try {
             fs(context).get(term1.longValue()).putc(term2.unsignedByteValue());
             return new KItem(new KLabelInjection(new KSequence()), new KList(), context);
@@ -87,7 +87,7 @@ public class BuiltinIOOperations {
         }
     }
 
-    public static Term write(IntToken term1, StringToken term2, TermContext context) {
+    public static Term write(IntToken term1, StringToken term2, State context) {
         try {
             fs(context).get(term1.longValue()).write(term2.byteArrayValue());
             return new KItem(new KLabelInjection(new KSequence()), new KList(), context);
@@ -98,7 +98,7 @@ public class BuiltinIOOperations {
         }
     }
 
-    public static Term parse(StringToken term1, StringToken term2, TermContext context) {
+    public static Term parse(StringToken term1, StringToken term2, State context) {
         try {
             RunProcess rp = new RunProcess();
             org.kframework.kil.Term kast = rp.runParser(K.parser, term1.stringValue(), true, term2.stringValue(), context(context));
@@ -110,10 +110,10 @@ public class BuiltinIOOperations {
         }
     }
 
-    private static KItem processIOException(String errno, TermContext context) {
+    private static KItem processIOException(String errno, State context) {
         String klabelString = "'#" + errno;
         Definition def = context.definition();
-        KLabelConstant klabel = KLabelConstant.of(klabelString, TermContext.of(def));
+        KLabelConstant klabel = KLabelConstant.of(klabelString, State.of(def));
         assert def.kLabels().contains(klabel) : "No KLabel in definition for errno '" + errno + "'";
         return new KItem(klabel, new KList(), context);
     }

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinIntOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinIntOperations.java
@@ -2,7 +2,7 @@
 package org.kframework.backend.java.builtins;
 
 
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 
 /**
  * Table of {@code public static} methods on builtin integers.
@@ -11,91 +11,91 @@ import org.kframework.backend.java.kil.TermContext;
  */
 public class BuiltinIntOperations {
 
-    public static IntToken add(IntToken term1, IntToken term2, TermContext context) {
+    public static IntToken add(IntToken term1, IntToken term2, State context) {
         return IntToken.of(term1.bigIntegerValue().add(term2.bigIntegerValue()));
     }
 
-    public static IntToken sub(IntToken term1, IntToken term2, TermContext context) {
+    public static IntToken sub(IntToken term1, IntToken term2, State context) {
         return IntToken.of(term1.bigIntegerValue().subtract(term2.bigIntegerValue()));
     }
 
-    public static IntToken mul(IntToken term1, IntToken term2, TermContext context) {
+    public static IntToken mul(IntToken term1, IntToken term2, State context) {
         return IntToken.of(term1.bigIntegerValue().multiply(term2.bigIntegerValue()));
     }
 
-    public static IntToken div(IntToken term1, IntToken term2, TermContext context) {
+    public static IntToken div(IntToken term1, IntToken term2, State context) {
         return IntToken.of(term1.bigIntegerValue().divide(term2.bigIntegerValue()));
     }
 
-    public static IntToken rem(IntToken term1, IntToken term2, TermContext context) {
+    public static IntToken rem(IntToken term1, IntToken term2, State context) {
         return IntToken.of(term1.bigIntegerValue().remainder(term2.bigIntegerValue()));
     }
 
-    public static IntToken mod(IntToken term1, IntToken term2, TermContext context) {
+    public static IntToken mod(IntToken term1, IntToken term2, State context) {
         return IntToken.of(term1.bigIntegerValue().mod(term2.bigIntegerValue()));
     }
 
-    public static IntToken pow(IntToken term1, IntToken term2, TermContext context) {
+    public static IntToken pow(IntToken term1, IntToken term2, State context) {
         return IntToken.of(term1.bigIntegerValue().pow(term2.bigIntegerValue().intValue()));
     }
 
-    public static IntToken shl(IntToken term1, IntToken term2, TermContext context) {
+    public static IntToken shl(IntToken term1, IntToken term2, State context) {
         return IntToken.of(term1.bigIntegerValue().shiftLeft(term2.bigIntegerValue().intValue()));
     }
 
-    public static IntToken shr(IntToken term1, IntToken term2, TermContext context) {
+    public static IntToken shr(IntToken term1, IntToken term2, State context) {
         return IntToken.of(term1.bigIntegerValue().shiftRight(term2.bigIntegerValue().intValue()));
     }
 
-    public static IntToken not(IntToken term, TermContext context) {
+    public static IntToken not(IntToken term, State context) {
         return IntToken.of(term.bigIntegerValue().not());
     }
 
-    public static IntToken and(IntToken term1, IntToken term2, TermContext context) {
+    public static IntToken and(IntToken term1, IntToken term2, State context) {
         return IntToken.of(term1.bigIntegerValue().and(term2.bigIntegerValue()));
     }
 
-    public static IntToken or(IntToken term1, IntToken term2, TermContext context) {
+    public static IntToken or(IntToken term1, IntToken term2, State context) {
         return IntToken.of(term1.bigIntegerValue().or(term2.bigIntegerValue()));
     }
 
-    public static IntToken xor(IntToken term1, IntToken term2, TermContext context) {
+    public static IntToken xor(IntToken term1, IntToken term2, State context) {
         return IntToken.of(term1.bigIntegerValue().xor(term2.bigIntegerValue()));
     }
 
-    public static IntToken min(IntToken term1, IntToken term2, TermContext context) {
+    public static IntToken min(IntToken term1, IntToken term2, State context) {
         return IntToken.of(term1.bigIntegerValue().min(term2.bigIntegerValue()));
     }
 
-    public static IntToken max(IntToken term1, IntToken term2, TermContext context) {
+    public static IntToken max(IntToken term1, IntToken term2, State context) {
         return IntToken.of(term1.bigIntegerValue().max(term2.bigIntegerValue()));
     }
 
-    public static IntToken abs(IntToken term, TermContext context) {
+    public static IntToken abs(IntToken term, State context) {
         return IntToken.of(term.bigIntegerValue().abs());
     }
 
-    public static BoolToken eq(IntToken term1, IntToken term2, TermContext context) {
+    public static BoolToken eq(IntToken term1, IntToken term2, State context) {
         return BoolToken.of(term1.bigIntegerValue().compareTo(term2.bigIntegerValue()) == 0);
     }
 
-    public static BoolToken ne(IntToken term1, IntToken term2, TermContext context) {
+    public static BoolToken ne(IntToken term1, IntToken term2, State context) {
         return BoolToken.of(term1.bigIntegerValue().compareTo(term2.bigIntegerValue()) != 0);
     }
 
-    public static BoolToken gt(IntToken term1, IntToken term2, TermContext context) {
+    public static BoolToken gt(IntToken term1, IntToken term2, State context) {
         return BoolToken.of(term1.bigIntegerValue().compareTo(term2.bigIntegerValue()) > 0);
     }
 
-    public static BoolToken ge(IntToken term1, IntToken term2, TermContext context) {
+    public static BoolToken ge(IntToken term1, IntToken term2, State context) {
         return BoolToken.of(term1.bigIntegerValue().compareTo(term2.bigIntegerValue()) >= 0);
     }
 
-    public static BoolToken lt(IntToken term1, IntToken term2, TermContext context) {
+    public static BoolToken lt(IntToken term1, IntToken term2, State context) {
         return BoolToken.of(term1.bigIntegerValue().compareTo(term2.bigIntegerValue()) < 0);
     }
 
-    public static BoolToken le(IntToken term1, IntToken term2, TermContext context) {
+    public static BoolToken le(IntToken term1, IntToken term2, State context) {
         return BoolToken.of(term1.bigIntegerValue().compareTo(term2.bigIntegerValue()) <= 0);
     }
 

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinListOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinListOperations.java
@@ -3,7 +3,7 @@ package org.kframework.backend.java.builtins;
 
 import org.kframework.backend.java.kil.BuiltinList;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.backend.java.kil.Variable;
 
 import java.util.ArrayList;
@@ -17,7 +17,7 @@ import java.util.List;
  */
 public class BuiltinListOperations {
 
-    public static BuiltinList construct(BuiltinList term1, BuiltinList term2, TermContext context) {
+    public static BuiltinList construct(BuiltinList term1, BuiltinList term2, State context) {
         Variable frame = null;
         List<Term> elementsLeft = new ArrayList<>();
         List<Term> elementsRight = new ArrayList<>();

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinMapOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinMapOperations.java
@@ -4,7 +4,7 @@ package org.kframework.backend.java.builtins;
 import org.kframework.backend.java.kil.BuiltinMap;
 import org.kframework.backend.java.kil.BuiltinSet;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.backend.java.kil.Variable;
 
 import java.util.HashMap;
@@ -20,7 +20,7 @@ import java.util.Set;
  */
 public class BuiltinMapOperations {
 
-    public static BuiltinSet keys(BuiltinMap term, TermContext context) {
+    public static BuiltinSet keys(BuiltinMap term, State context) {
         if (!term.hasFrame()) {
             Set<Term> elements = new HashSet<Term>(term.getEntries().keySet());
             return new BuiltinSet(elements);
@@ -29,7 +29,7 @@ public class BuiltinMapOperations {
         }
     }
 
-    public static BuiltinMap construct(BuiltinMap term1, BuiltinMap term2, TermContext context) {
+    public static BuiltinMap construct(BuiltinMap term1, BuiltinMap term2, State context) {
         Variable frame = null;
         if (term1.hasFrame() && term2.hasFrame()) {
             throw new IllegalArgumentException(
@@ -46,7 +46,7 @@ public class BuiltinMapOperations {
 
     }
 
-    public static BuiltinMap update(BuiltinMap term, Term key, Term value, TermContext context) {
+    public static BuiltinMap update(BuiltinMap term, Term key, Term value, State context) {
         if (!term.hasFrame()) {
             Map<Term, Term> entries = new HashMap<>(term.getEntries());
             entries.put(key, value);

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinSetOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinSetOperations.java
@@ -3,7 +3,7 @@ package org.kframework.backend.java.builtins;
 
 import org.kframework.backend.java.kil.BuiltinSet;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.backend.java.kil.Variable;
 
 import java.util.HashSet;
@@ -17,7 +17,7 @@ import java.util.Set;
  */
 public class BuiltinSetOperations {
 
-    public static BuiltinSet construct(BuiltinSet term1, BuiltinSet term2, TermContext context) {
+    public static BuiltinSet construct(BuiltinSet term1, BuiltinSet term2, State context) {
         Variable frame = null;
         if (term1.hasFrame() && term2.hasFrame()) {
             throw new IllegalArgumentException(
@@ -33,7 +33,7 @@ public class BuiltinSetOperations {
         return new BuiltinSet(elements, frame);
     }
 
-    public static BuiltinSet difference(BuiltinSet term1, BuiltinSet term2, TermContext context) {
+    public static BuiltinSet difference(BuiltinSet term1, BuiltinSet term2, State context) {
         if (!term1.isGround()) {
             throw new IllegalArgumentException("first argument " + term1 + " is not ground");
         }
@@ -46,7 +46,7 @@ public class BuiltinSetOperations {
         return new BuiltinSet(elements);
     }
 
-    public static BoolToken in(Term term1, BuiltinSet term2, TermContext context) {
+    public static BoolToken in(Term term1, BuiltinSet term2, State context) {
         if (!term1.isGround()) {
             throw new IllegalArgumentException("first argument " + term1 + " is not ground");
         }

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinStringOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinStringOperations.java
@@ -165,7 +165,7 @@ public class BuiltinStringOperations {
      * @param replacement
      *            the string to replace it with
      * @param context
-     *            the term context
+     *            the state
      * @return the text with any replacements processed
      */
     public static StringToken replaceAll(StringToken text,
@@ -188,7 +188,7 @@ public class BuiltinStringOperations {
      * @param max
      *            the maximum number of occurrences to be replaced
      * @param context
-     *            the term context
+     *            the state
      * @return the text with any replacements processed
      */
     public static StringToken replace(StringToken text,
@@ -209,7 +209,7 @@ public class BuiltinStringOperations {
      * @param replacement
      *            the string to replace it with
      * @param context
-     *            the term context
+     *            the state
      * @return the text with any replacements processed
      */
     public static StringToken replaceFirst(StringToken text,
@@ -227,7 +227,7 @@ public class BuiltinStringOperations {
      * @param substr
      *            the substring to search for
      * @param context
-     *            the term context
+     *            the state
      * @return the number of occurrences
      */
     public static IntToken countOccurences(StringToken text,

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinStringOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinStringOperations.java
@@ -4,7 +4,7 @@ package org.kframework.backend.java.builtins;
 import java.math.BigInteger;
 
 import org.apache.commons.lang3.StringUtils;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.utils.StringUtil;
 
 /**
@@ -15,46 +15,46 @@ import org.kframework.utils.StringUtil;
 
 public class BuiltinStringOperations {
 
-    public static StringToken add(StringToken term1, StringToken term2, TermContext context) {
+    public static StringToken add(StringToken term1, StringToken term2, State context) {
         return StringToken.of(term1.stringValue() + term2.stringValue());
     }
 
-    public static BoolToken eq(StringToken term1, StringToken term2, TermContext context) {
+    public static BoolToken eq(StringToken term1, StringToken term2, State context) {
         return BoolToken.of(term1.stringValue().compareTo(term2.stringValue()) == 0);
     }
 
-    public static BoolToken ne(StringToken term1, StringToken term2, TermContext context) {
+    public static BoolToken ne(StringToken term1, StringToken term2, State context) {
         return BoolToken.of(term1.stringValue().compareTo(term2.stringValue()) != 0);
     }
 
-    public static BoolToken gt(StringToken term1, StringToken term2, TermContext context) {
+    public static BoolToken gt(StringToken term1, StringToken term2, State context) {
         return BoolToken.of(term1.stringValue().compareTo(term2.stringValue()) > 0);
     }
 
-    public static BoolToken ge(StringToken term1, StringToken term2, TermContext context) {
+    public static BoolToken ge(StringToken term1, StringToken term2, State context) {
         return BoolToken.of(term1.stringValue().compareTo(term2.stringValue()) >= 0);
     }
 
-    public static BoolToken lt(StringToken term1, StringToken term2, TermContext context) {
+    public static BoolToken lt(StringToken term1, StringToken term2, State context) {
         return BoolToken.of(term1.stringValue().compareTo(term2.stringValue()) < 0);
     }
 
-    public static BoolToken le(StringToken term1, StringToken term2, TermContext context) {
+    public static BoolToken le(StringToken term1, StringToken term2, State context) {
         return BoolToken.of(term1.stringValue().compareTo(term2.stringValue()) <= 0);
     }
 
-    public static IntToken len(StringToken term, TermContext context) {
+    public static IntToken len(StringToken term, State context) {
         return IntToken.of(term.stringValue().codePointCount(0, term.stringValue().length()));
     }
 
-    public static IntToken ord(StringToken term, TermContext context) {
+    public static IntToken ord(StringToken term, State context) {
         if (term.stringValue().codePointCount(0, term.stringValue().length()) != 1) {
             throw new IllegalArgumentException();
         }
         return IntToken.of(term.stringValue().codePointAt(0));
     }
 
-    public static StringToken chr(IntToken term, TermContext context) {
+    public static StringToken chr(IntToken term, State context) {
         //safe because we know it's in the unicode code range or it will throw
         int codePoint = term.intValue();
         StringUtil.throwIfSurrogatePair(codePoint);
@@ -62,37 +62,37 @@ public class BuiltinStringOperations {
         return StringToken.of(new String(chars));
     }
 
-    public static StringToken substr(StringToken term, IntToken start, IntToken end, TermContext context) {
+    public static StringToken substr(StringToken term, IntToken start, IntToken end, State context) {
         int beginOffset = term.stringValue().offsetByCodePoints(0, start.intValue());
         int endOffset = term.stringValue().offsetByCodePoints(0, end.intValue());
         return StringToken.of(term.stringValue().substring(beginOffset, endOffset));
     }
 
-    public static IntToken find(StringToken term1, StringToken term2, IntToken idx, TermContext context) {
+    public static IntToken find(StringToken term1, StringToken term2, IntToken idx, State context) {
         int offset = term1.stringValue().offsetByCodePoints(0, idx.intValue());
         int foundOffset = term1.stringValue().indexOf(term2.stringValue(), offset);
         return IntToken.of((foundOffset == -1 ? -1 : term1.stringValue().codePointCount(0, foundOffset)));
     }
 
-    public static IntToken rfind(StringToken term1, StringToken term2, IntToken idx, TermContext context) {
+    public static IntToken rfind(StringToken term1, StringToken term2, IntToken idx, State context) {
         int offset = term1.stringValue().offsetByCodePoints(0, idx.intValue());
         int foundOffset = term1.stringValue().lastIndexOf(term2.stringValue(), offset);
         return IntToken.of((foundOffset == -1 ? -1 : term1.stringValue().codePointCount(0, foundOffset)));
     }
 
-    public static IntToken findChar(StringToken term1, StringToken term2, IntToken idx, TermContext context) {
+    public static IntToken findChar(StringToken term1, StringToken term2, IntToken idx, State context) {
         int offset = term1.stringValue().offsetByCodePoints(0, idx.intValue());
         int foundOffset = StringUtil.indexOfAny(term1.stringValue(), term2.stringValue(), offset);
         return IntToken.of((foundOffset == -1 ? -1 : term1.stringValue().codePointCount(0, foundOffset)));
     }
 
-    public static IntToken rfindChar(StringToken term1, StringToken term2, IntToken idx, TermContext context) {
+    public static IntToken rfindChar(StringToken term1, StringToken term2, IntToken idx, State context) {
         int offset = term1.stringValue().offsetByCodePoints(0, idx.intValue());
         int foundOffset = StringUtil.lastIndexOfAny(term1.stringValue(), term2.stringValue(), offset);
         return IntToken.of((foundOffset == -1 ? -1 : term1.stringValue().codePointCount(0, foundOffset)));
     }
 
-    public static IntToken string2int(StringToken term, TermContext context) {
+    public static IntToken string2int(StringToken term, State context) {
         try {
             return IntToken.of(new BigInteger(term.stringValue()));
         } catch (NumberFormatException e) {
@@ -106,19 +106,19 @@ public class BuiltinStringOperations {
         }
     }
 
-    public static IntToken string2base(StringToken term, IntToken base, TermContext context) {
+    public static IntToken string2base(StringToken term, IntToken base, State context) {
         return IntToken.of(new BigInteger(term.stringValue(), base.intValue()));
     }
 
-    public static UninterpretedToken string2float(StringToken term, TermContext context) {
+    public static UninterpretedToken string2float(StringToken term, State context) {
         return UninterpretedToken.of("Float", term.value());
     }
 
-    public static StringToken float2string(UninterpretedToken term, TermContext context) {
+    public static StringToken float2string(UninterpretedToken term, State context) {
         return StringToken.of(term.value());
     }
 
-    public static StringToken int2string(IntToken term, TermContext context) {
+    public static StringToken int2string(IntToken term, State context) {
         return StringToken.of(term.bigIntegerValue().toString());
     }
 /*
@@ -134,7 +134,7 @@ public class BuiltinStringOperations {
         return StringToken.of(name);
     }
 */
-    public static StringToken category(StringToken term, TermContext context) {
+    public static StringToken category(StringToken term, State context) {
         if (term.stringValue().codePointCount(0, term.stringValue().length()) != 1) {
             throw new IllegalArgumentException();
         }
@@ -143,7 +143,7 @@ public class BuiltinStringOperations {
         return StringToken.of(StringUtil.getCategoryCode((byte)cat));
     }
 
-    public static StringToken directionality(StringToken term, TermContext context) {
+    public static StringToken directionality(StringToken term, State context) {
         if (term.stringValue().codePointCount(0, term.stringValue().length()) != 1) {
             throw new IllegalArgumentException();
         }
@@ -151,7 +151,7 @@ public class BuiltinStringOperations {
         return StringToken.of(StringUtil.getDirectionalityCode(cat));
     }
 
-    public static StringToken token2string(UninterpretedToken token, TermContext context) {
+    public static StringToken token2string(UninterpretedToken token, State context) {
         return StringToken.of(token.value());
     }
     
@@ -170,7 +170,7 @@ public class BuiltinStringOperations {
      */
     public static StringToken replaceAll(StringToken text,
             StringToken searchString, StringToken replacement,
-            TermContext context) {
+            State context) {
         return StringToken.of(StringUtils.replace(text.stringValue(),
                 searchString.stringValue(), replacement.stringValue()));
     }
@@ -193,7 +193,7 @@ public class BuiltinStringOperations {
      */
     public static StringToken replace(StringToken text,
             StringToken searchString, StringToken replacement, IntToken max,
-            TermContext context) {
+            State context) {
         return StringToken.of(StringUtils.replace(text.stringValue(),
                 searchString.stringValue(), replacement.stringValue(),
                 max.intValue()));
@@ -214,7 +214,7 @@ public class BuiltinStringOperations {
      */
     public static StringToken replaceFirst(StringToken text,
             StringToken searchString, StringToken replacement,
-            TermContext context) {
+            State context) {
         return StringToken.of(StringUtils.replaceOnce(text.stringValue(),
                 searchString.stringValue(), replacement.stringValue()));
     }
@@ -231,7 +231,7 @@ public class BuiltinStringOperations {
      * @return the number of occurrences
      */
     public static IntToken countOccurences(StringToken text,
-            StringToken substr, TermContext context) {
+            StringToken substr, State context) {
         return IntToken.of(StringUtils.countMatches(text.stringValue(),
                 substr.stringValue()));
     }

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinUnificationOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinUnificationOperations.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import org.kframework.backend.java.kil.BuiltinMap;
 import org.kframework.backend.java.kil.BuiltinMgu;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.backend.java.kil.Variable;
 
 /**
@@ -19,7 +19,7 @@ import org.kframework.backend.java.kil.Variable;
 public class BuiltinUnificationOperations {
 
     public static BuiltinMgu updateMgu(BuiltinMgu mgu, Term leftHandSide,
-            Term rightHandSide, TermContext context) {
+            Term rightHandSide, State context) {
         BuiltinMgu updatedMgu = BuiltinMgu.of(mgu.constraint(), context);
         updatedMgu.constraint().add(leftHandSide, rightHandSide);
         updatedMgu.constraint().simplify();
@@ -28,13 +28,13 @@ public class BuiltinUnificationOperations {
         return updatedMgu;
     }
 
-    public static BoolToken isUnificationFailed(BuiltinMgu mgu, TermContext context) {
+    public static BoolToken isUnificationFailed(BuiltinMgu mgu, State context) {
         mgu.constraint().simplify();
         return mgu.constraint().isFalse() ? BoolToken.TRUE : BoolToken.FALSE;
     }
 
     public static BuiltinMap applyMgu(BuiltinMgu mgu, BuiltinMap map,
-            TermContext context) {
+            State context) {
         if (!map.hasFrame()) {
             Map<Term, Term> entries = new HashMap<>();
             Map<Variable, Term> subst = mgu.constraint().substitution();

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinVisitorOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinVisitorOperations.java
@@ -43,7 +43,7 @@ public class BuiltinVisitorOperations extends PrePostTransformer {
             List<Term> ifParams,
             KLabel visitLabel,
             List<Term> visitParams,
-            TermContext context) {
+            State context) {
         super(context);
         this.ifLabel = ifLabel;
         this.ifParams = ifParams;
@@ -108,7 +108,7 @@ public class BuiltinVisitorOperations extends PrePostTransformer {
             KItem visitListTerm,
             KItem ifLabelTerm,
             KItem ifListTerm,
-            TermContext context) {
+            State context) {
         KLabel visitLabel;
         KList visitList;
         KLabel ifLabel;

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/MetaK.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/MetaK.java
@@ -8,7 +8,7 @@ import org.kframework.backend.java.kil.KLabelInjection;
 import org.kframework.backend.java.kil.KList;
 import org.kframework.backend.java.kil.MetaVariable;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.backend.java.kil.Variable;
 import org.kframework.backend.java.symbolic.PatternMatcher;
 import org.kframework.backend.java.symbolic.SymbolicConstraint;
@@ -40,7 +40,7 @@ public class MetaK {
      * @return {@link BoolToken#TRUE} if the two terms can be unified;
      *         otherwise, {@link BoolToken#FALSE}
      */
-    public static BoolToken unifiable(Term term1, Term term2, TermContext context) {
+    public static BoolToken unifiable(Term term1, Term term2, State context) {
 //        Term freshTerm1 = term1.substitute(Variable.getFreshSubstitution(term1.variableSet()), context);
 //        Term freshTerm2 = term2.substitute(Variable.getFreshSubstitution(term2.variableSet()), context);
         SymbolicConstraint constraint = new SymbolicConstraint(context);
@@ -65,7 +65,7 @@ public class MetaK {
      * @return {@link BoolToken#TRUE} if the two terms can be matched;
      *         otherwise, {@link BoolToken#FALSE}
      */
-    public static BoolToken matchable(Term subject, Term pattern, TermContext context) {
+    public static BoolToken matchable(Term subject, Term pattern, State context) {
         return PatternMatcher.matchable(subject, pattern, context) ? BoolToken.TRUE
                 : BoolToken.FALSE;
     }
@@ -85,7 +85,7 @@ public class MetaK {
      *         if the given {@code BuiltinSet} has a frame or contains not only
      *         {@code MetaVariable}s
      */
-    public static Term rename(Term term, BuiltinSet builtinSet, TermContext context) {
+    public static Term rename(Term term, BuiltinSet builtinSet, State context) {
         if (builtinSet.hasFrame() /* || !builtinSet.operations().isEmpty() */) {
             return term;
         }
@@ -111,7 +111,7 @@ public class MetaK {
      *            the term context
      * @return the resulting term after renaming
      */
-    public static Term renameVariables(Term term, TermContext context) {
+    public static Term renameVariables(Term term, State context) {
         Set<Variable> variables = term.variableSet();
         return term.substitute(Variable.getFreshSubstitution(variables), context);
     }
@@ -126,7 +126,7 @@ public class MetaK {
      *            the term context
      * @return a {@code BuiltinSet} of {@code MetaVariable}s
      */
-    public static BuiltinSet variables(Term term, TermContext context) {
+    public static BuiltinSet variables(Term term, State context) {
         Set<Term> metaVariables = new HashSet<Term>();
         for (Variable variable : term.variableSet()) {
             metaVariables.add(new MetaVariable(variable));
@@ -144,12 +144,12 @@ public class MetaK {
      *            the term context
      * @return a {@code BuiltinSet} of {@code Variable}s
      */
-    public static BuiltinSet trueVariables(Term term, TermContext context) {
+    public static BuiltinSet trueVariables(Term term, State context) {
         Set<Variable> trueVariables = term.variableSet();
         return new BuiltinSet(trueVariables);
     }
 
-    public static BuiltinMap variablesMap(Term term, TermContext context) {
+    public static BuiltinMap variablesMap(Term term, State context) {
         Set<Variable> variables = term.variableSet();
         Map<MetaVariable, Variable> result = new HashMap<>(variables.size());
         for (Variable variable : variables) {
@@ -168,7 +168,7 @@ public class MetaK {
      *            the term context
      * @return the K label
      */
-    public static KItem getKLabel(KItem kItem, TermContext context) {
+    public static KItem getKLabel(KItem kItem, State context) {
         // TODO(AndreiS): handle KLabel variables
         return new KItem(new KLabelInjection(kItem.kLabel()), new KList(), context);
     }

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/MetaK.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/MetaK.java
@@ -36,7 +36,7 @@ public class MetaK {
      * @param term2
      *            the second term
      * @param context
-     *            the term context
+     *            the state
      * @return {@link BoolToken#TRUE} if the two terms can be unified;
      *         otherwise, {@link BoolToken#FALSE}
      */
@@ -61,7 +61,7 @@ public class MetaK {
      * @param pattern
      *            the pattern term
      * @param context
-     *            the term context
+     *            the state
      * @return {@link BoolToken#TRUE} if the two terms can be matched;
      *         otherwise, {@link BoolToken#FALSE}
      */
@@ -80,7 +80,7 @@ public class MetaK {
      * @param builtinSet
      *            the given set of meta variables
      * @param context
-     *            the term context
+     *            the state
      * @return the resulting term if the renaming succeeds; or the original term
      *         if the given {@code BuiltinSet} has a frame or contains not only
      *         {@code MetaVariable}s
@@ -108,7 +108,7 @@ public class MetaK {
      * @param term
      *            the given term
      * @param context
-     *            the term context
+     *            the state
      * @return the resulting term after renaming
      */
     public static Term renameVariables(Term term, State context) {
@@ -123,7 +123,7 @@ public class MetaK {
      * @param term
      *            the given term
      * @param context
-     *            the term context
+     *            the state
      * @return a {@code BuiltinSet} of {@code MetaVariable}s
      */
     public static BuiltinSet variables(Term term, State context) {
@@ -141,7 +141,7 @@ public class MetaK {
      * @param term
      *            the given term
      * @param context
-     *            the term context
+     *            the state
      * @return a {@code BuiltinSet} of {@code Variable}s
      */
     public static BuiltinSet trueVariables(Term term, State context) {
@@ -165,7 +165,7 @@ public class MetaK {
      * @param kItem
      *            the specified {@code KItem}
      * @param context
-     *            the term context
+     *            the state
      * @return the K label
      */
     public static KItem getKLabel(KItem kItem, State context) {

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/SortMembership.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/SortMembership.java
@@ -9,7 +9,7 @@ import org.kframework.backend.java.kil.KItem;
 import org.kframework.backend.java.kil.KLabelConstant;
 import org.kframework.backend.java.kil.KList;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.backend.java.kil.Token;
 import org.kframework.kil.loader.Context;
 
@@ -58,7 +58,7 @@ public class SortMembership {
         }
     }
 
-    public static Term isBuiltin(Term term, TermContext context) {
+    public static Term isBuiltin(Term term, State context) {
         // TODO(AndreiS): fix this predicate based on sorts
         if (term.kind().isComputational()) {
             term = KCollection.downKind(term);
@@ -74,7 +74,7 @@ public class SortMembership {
         }
     }
 
-    public static Term isToken(Term term, TermContext context) {
+    public static Term isToken(Term term, State context) {
         // TODO(AndreiS): fix this predicate based on sorts
         if (term.kind().isComputational()) {
             term = KCollection.downKind(term);

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/TermEquality.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/TermEquality.java
@@ -39,7 +39,7 @@ public class TermEquality {
      * @param e
      *            the second term
      * @param context
-     *            the term context
+     *            the state
      * @return the first term if the {@code BoolToken} represents true;
      *         otherwise, the second term
      */

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/TermEquality.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/TermEquality.java
@@ -2,19 +2,19 @@
 package org.kframework.backend.java.builtins;
 
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 
 /**
  * @author: AndreiS
  */
 public class TermEquality {
 
-    public static BoolToken eq(Term term1, Term term2, TermContext context) {
+    public static BoolToken eq(Term term1, Term term2, State context) {
         checkArguments(term1, term2);
         return term1.equals(term2) ? BoolToken.TRUE : BoolToken.FALSE;
     }
 
-    public static BoolToken ne(Term term1, Term term2, TermContext context) {
+    public static BoolToken ne(Term term1, Term term2, State context) {
         checkArguments(term1, term2);
         return term1.equals(term2) ? BoolToken.FALSE : BoolToken.TRUE;
     }
@@ -43,7 +43,7 @@ public class TermEquality {
      * @return the first term if the {@code BoolToken} represents true;
      *         otherwise, the second term
      */
-    public static Term ite(BoolToken boolToken, Term t, Term e, TermContext context) {
+    public static Term ite(BoolToken boolToken, Term t, Term e, State context) {
         if (boolToken.booleanValue()) return t;
         return e;
     }

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/BuiltinMgu.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/BuiltinMgu.java
@@ -17,7 +17,7 @@ public class BuiltinMgu extends Term {
   
     private final SymbolicConstraint constraint;
     
-    private BuiltinMgu(SymbolicConstraint constraint, TermContext context) {
+    private BuiltinMgu(SymbolicConstraint constraint, State context) {
         // YilongL: The kind of a BuiltinMgu should be Kind.KITEM rather than a
         // new created kind for two reasons: 1) an Mgu is a builtin which should
         // be subsorted into KItem; 2) if we assign Mgu its own kind, say MGU,
@@ -27,12 +27,12 @@ public class BuiltinMgu extends Term {
                 : new SymbolicConstraint(constraint, context);
     }
 
-    public static BuiltinMgu emptyMgu(TermContext context) {
+    public static BuiltinMgu emptyMgu(State context) {
         return new BuiltinMgu(null, context);
     }
 
     public static BuiltinMgu of(SymbolicConstraint constraint,
-            TermContext context) {
+            State context) {
         return new BuiltinMgu(constraint, context);
     }
     

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/ConstrainedTerm.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/ConstrainedTerm.java
@@ -45,10 +45,10 @@ public class ConstrainedTerm extends Term {
      */
     private final SymbolicConstraint lookups;
     private final SymbolicConstraint constraint;
-    private final TermContext context;
+    private final State context;
 
     public ConstrainedTerm(Term term, SymbolicConstraint lookups, SymbolicConstraint constraint,
-            TermContext context) {
+            State context) {
         super(term.kind);
         this.term = term;
         this.lookups = lookups;
@@ -56,15 +56,15 @@ public class ConstrainedTerm extends Term {
         this.context = context;
     }
 
-    public ConstrainedTerm(Term term, SymbolicConstraint constraint, TermContext context) {
+    public ConstrainedTerm(Term term, SymbolicConstraint constraint, State context) {
         this(term, new SymbolicConstraint(context), constraint, context);
     }
 
-    public ConstrainedTerm(Term term, TermContext context) {
+    public ConstrainedTerm(Term term, State context) {
         this(term, new SymbolicConstraint(context), new SymbolicConstraint(context), context);
     }
 
-    public TermContext termContext() {
+    public State state() {
         return context;
     }
 
@@ -99,7 +99,7 @@ public class ConstrainedTerm extends Term {
     */
 
     public SymbolicConstraint matchImplies(ConstrainedTerm constrainedTerm) {
-        SymbolicConstraint unificationConstraint = new SymbolicConstraint(constrainedTerm.termContext());
+        SymbolicConstraint unificationConstraint = new SymbolicConstraint(constrainedTerm.state());
         unificationConstraint.add(term, constrainedTerm.term);
         unificationConstraint.simplify();
         Set<Variable> variables = constrainedTerm.variableSet();
@@ -109,7 +109,7 @@ public class ConstrainedTerm extends Term {
             return null;
         }
 
-        SymbolicConstraint implicationConstraint = new SymbolicConstraint(constrainedTerm.termContext());
+        SymbolicConstraint implicationConstraint = new SymbolicConstraint(constrainedTerm.state());
         implicationConstraint.addAll(unificationConstraint);
         implicationConstraint.addAll(constrainedTerm.lookups);
         implicationConstraint.addAll(constrainedTerm.constraint);
@@ -171,7 +171,7 @@ public class ConstrainedTerm extends Term {
         }
 
         /* unify the subject term and the pattern term without considering those associated constraints */
-        SymbolicConstraint unificationConstraint = new SymbolicConstraint(constrainedTerm.termContext());
+        SymbolicConstraint unificationConstraint = new SymbolicConstraint(constrainedTerm.state());
         unificationConstraint.add(term, constrainedTerm.term);
         unificationConstraint.simplify();
         if (unificationConstraint.isFalse()) {

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/JavaSymbolicObject.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/JavaSymbolicObject.java
@@ -48,7 +48,7 @@ public abstract class JavaSymbolicObject extends ASTNode
      */
     public JavaSymbolicObject substituteWithBinders(
             Map<Variable, ? extends Term> substitution,
-            TermContext context) {
+            State context) {
         if (substitution.isEmpty() || isGround()) {
             return this;
         }
@@ -62,7 +62,7 @@ public abstract class JavaSymbolicObject extends ASTNode
      */
     public JavaSymbolicObject substitute(
             Map<Variable, ? extends Term> substitution,
-            TermContext context) {
+            State context) {
         if (substitution.isEmpty() || isGround()) {
             return this;
         }
@@ -75,7 +75,7 @@ public abstract class JavaSymbolicObject extends ASTNode
      * Returns a new {@code JavaSymbolicObject} instance obtained from this JavaSymbolicObject by
      * substituting variable (in a binder sensitive way) with term.
      */
-    public JavaSymbolicObject substituteWithBinders(Variable variable, Term term, TermContext context) {
+    public JavaSymbolicObject substituteWithBinders(Variable variable, Term term, State context) {
         return substituteWithBinders(Collections.singletonMap(variable, term), context);
     }
 
@@ -83,7 +83,7 @@ public abstract class JavaSymbolicObject extends ASTNode
      * Returns a new {@code JavaSymbolicObject} instance obtained from this JavaSymbolicObject by
      * substituting variable (in a binder insensitive way) with term.
      */
-    public JavaSymbolicObject substitute(Variable variable, Term term, TermContext context) {
+    public JavaSymbolicObject substitute(Variable variable, Term term, State context) {
         return substitute(Collections.singletonMap(variable, term), context);
     }
 

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/KItem.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/KItem.java
@@ -60,13 +60,13 @@ public final class KItem extends Term {
      */
     private final Set<String> possibleMinimalSorts;
 
-    public KItem(Term kLabel, Term kList, TermContext termContext) {
+    public KItem(Term kLabel, Term kList, State state) {
         super(Kind.KITEM);
 
         this.kLabel = kLabel;
         this.kList = kList;
 
-        Definition definition = termContext.definition();
+        Definition definition = state.definition();
         Context context = definition.context();
 
         if (kLabel instanceof KLabelConstant && kList instanceof KList
@@ -91,14 +91,14 @@ public final class KItem extends Term {
                     Collection<Rule> rules = definition.functionRules().get(sortPredLabel);
                     for (Rule rule : rules) {
                         KItem predArg = rule.getSortPredArgument();
-                        if (MetaK.matchable(kLabel, predArg.kLabel(), termContext).equals(BoolToken.TRUE)
-                                && MetaK.matchable(kList, predArg.kList(), termContext).equals(BoolToken.TRUE)) {
+                        if (MetaK.matchable(kLabel, predArg.kLabel(), state).equals(BoolToken.TRUE)
+                                && MetaK.matchable(kList, predArg.kList(), state).equals(BoolToken.TRUE)) {
                             sorts.add(rule.getPredSort());
                             if (kLabelConstant.isConstructor()) {
                                 possibleMinimalSorts.add(rule.getPredSort());
                             }
-                        } else if (MetaK.matchable(kLabel, predArg.kLabel(), termContext).equals(BoolToken.TRUE)
-                                && MetaK.unifiable(kList, predArg.kList(), termContext).equals(BoolToken.TRUE)) {
+                        } else if (MetaK.matchable(kLabel, predArg.kLabel(), state).equals(BoolToken.TRUE)
+                                && MetaK.unifiable(kList, predArg.kList(), state).equals(BoolToken.TRUE)) {
                             if (kLabelConstant.isConstructor()) {
                                 possibleMinimalSorts.add(rule.getPredSort());
                             }
@@ -213,7 +213,7 @@ public final class KItem extends Term {
         }
     }
 
-    public boolean isEvaluable(TermContext context) {
+    public boolean isEvaluable(State context) {
         if (evaluable != null) {
             return evaluable;
         }
@@ -246,7 +246,7 @@ public final class KItem extends Term {
      *            a term context
      * @return the evaluated result on success, or this {@code KItem} otherwise
      */
-    public Term evaluateFunction(SymbolicConstraint constraint, TermContext context) {
+    public Term evaluateFunction(SymbolicConstraint constraint, State context) {
         if (!isEvaluable(context)) {
             return this;
         }

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/KItem.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/KItem.java
@@ -243,7 +243,7 @@ public final class KItem extends Term {
      *            the existing symbolic constraint that needs to be taken into
      *            consideration when evaluating this function
      * @param context
-     *            a term context
+     *            a state
      * @return the evaluated result on success, or this {@code KItem} otherwise
      */
     public Term evaluateFunction(SymbolicConstraint constraint, State context) {

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/KLabelConstant.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/KLabelConstant.java
@@ -38,11 +38,11 @@ public class KLabelConstant extends KLabel {
      * generates this {@code KLabelConstant}
      */
     private final boolean isFunction;
-    private final TermContext termContext;
+    private final State state;
 
-    private KLabelConstant(String label, TermContext termContext) {
+    private KLabelConstant(String label, State state) {
         this.label = label;
-        productions = ImmutableList.copyOf(termContext.definition().context().productionsOf(label));
+        productions = ImmutableList.copyOf(state.definition().context().productionsOf(label));
         
         // TODO(YilongL): urgent; how to detect KLabel clash?
 
@@ -74,7 +74,7 @@ public class KLabelConstant extends KLabel {
             isFunction = true;
         }
         this.isFunction = isFunction;
-        this.termContext = termContext;
+        this.state = state;
     }
 
     /**
@@ -85,12 +85,12 @@ public class KLabelConstant extends KLabel {
      * @param label string representation of the KLabel; must not be '`' escaped;
      * @return AST term representation the the KLabel;
      */
-    public static KLabelConstant of(String label, TermContext termContext) {
+    public static KLabelConstant of(String label, State state) {
         assert label != null;
 
         KLabelConstant kLabelConstant = cache.get(label);
         if (kLabelConstant == null) {
-            kLabelConstant = new KLabelConstant(label, termContext);
+            kLabelConstant = new KLabelConstant(label, state);
             cache.put(label, kLabelConstant);
         }
         return kLabelConstant;
@@ -177,8 +177,8 @@ public class KLabelConstant extends KLabel {
         return kLabelConstant;
     }
 
-    public TermContext termContext() {
-        return termContext;
+    public State state() {
+        return state;
     }
 
     public boolean isBinder() {

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/Rule.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/Rule.java
@@ -206,7 +206,7 @@ public class Rule extends JavaSymbolicObject {
     /**
      * Returns a copy of this {@code Rule} with each {@link Variable} renamed to a fresh name.
      */
-    public Rule getFreshRule(TermContext context) {
+    public Rule getFreshRule(State context) {
         return this.substitute(Variable.getFreshSubstitution(variableSet()), context);
     }
 
@@ -231,7 +231,7 @@ public class Rule extends JavaSymbolicObject {
     }
 
     @Override
-    public Rule substitute(Map<Variable, ? extends Term> substitution, TermContext context) {
+    public Rule substitute(Map<Variable, ? extends Term> substitution, State context) {
         return (Rule) super.substitute(substitution, context);
     }
 
@@ -240,7 +240,7 @@ public class Rule extends JavaSymbolicObject {
      * term.
      */
     @Override
-    public Rule substituteWithBinders(Variable variable, Term term, TermContext context) {
+    public Rule substituteWithBinders(Variable variable, Term term, State context) {
         return (Rule) super.substituteWithBinders(variable, term, context);
     }
 

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/State.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/State.java
@@ -13,7 +13,7 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 
 /**
- * An object containing context specific to a particular configuration.
+ * This class represents a state in the transition system.
  */
 public class State extends JavaSymbolicObject {
 

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/State.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/State.java
@@ -15,15 +15,15 @@ import com.google.common.collect.Table;
 /**
  * An object containing context specific to a particular configuration.
  */
-public class TermContext extends JavaSymbolicObject {
+public class State extends JavaSymbolicObject {
 
-    private static Map<Definition, TermContext> cache1 = new HashMap<Definition, TermContext>();
-    private static Table<Definition, FileSystem, TermContext> cache2 = HashBasedTable.create();
+    private static Map<Definition, State> cache1 = new HashMap<Definition, State>();
+    private static Table<Definition, FileSystem, State> cache2 = HashBasedTable.create();
 
     private final Definition def;
     private final FileSystem fs;
     
-    private TermContext(Definition def, FileSystem fs) {
+    private State(Definition def, FileSystem fs) {
         this.def = def;
         this.fs = fs;
     }
@@ -32,23 +32,23 @@ public class TermContext extends JavaSymbolicObject {
      * Only used when the Term is part of a Definition instead of part of a
      * ConstrainedTerm.
      */
-    public static TermContext of(Definition def) {
-        TermContext termContext = cache1.get(def);
-        if (termContext == null) {
-            termContext = new TermContext(def, null);
-            cache1.put(def, termContext);
+    public static State of(Definition def) {
+        State state = cache1.get(def);
+        if (state == null) {
+            state = new State(def, null);
+            cache1.put(def, state);
         }
-        return termContext;
+        return state;
     }
 
-    public static TermContext of(Definition def, FileSystem fs) {
+    public static State of(Definition def, FileSystem fs) {
         assert fs != null;
-        TermContext termContext = cache2.get(def, fs);
-        if (termContext == null) {
-            termContext = new TermContext(def, fs);
-            cache2.put(def, fs, termContext);
+        State state = cache2.get(def, fs);
+        if (state == null) {
+            state = new State(def, fs);
+            cache2.put(def, fs, state);
         }
-        return termContext;
+        return state;
     }
 
     public Definition definition() {

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/Term.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/Term.java
@@ -103,9 +103,9 @@ public abstract class Term extends JavaSymbolicObject implements Transformable, 
      * pending functions and predicates. <br>
      * TODO(YilongL): gradually eliminate the use of this method and switch to
      * the one with constraint, i.e., {@link this#evaluate(SymbolicConstraint,
-     * TermContext)}.
+     * State)}.
      */
-    public Term evaluate(TermContext context) {
+    public Term evaluate(State context) {
         return evaluate(null, context);
     }
 
@@ -128,7 +128,7 @@ public abstract class Term extends JavaSymbolicObject implements Transformable, 
      *            the term context
      * @return the result {@code Term} instance
      */
-    public Term evaluate(SymbolicConstraint constraint, TermContext context) {
+    public Term evaluate(SymbolicConstraint constraint, State context) {
         return Evaluator.evaluate(this, constraint, context);
     }
 
@@ -136,7 +136,7 @@ public abstract class Term extends JavaSymbolicObject implements Transformable, 
      * Returns a new {@code Term} instance obtained from this term by applying a binder insensitive substitution.
      */
     @Override
-    public Term substitute(Map<Variable, ? extends Term> substitution, TermContext context) {
+    public Term substitute(Map<Variable, ? extends Term> substitution, State context) {
         return (Term) super.substitute(substitution, context);
     }
 
@@ -144,7 +144,7 @@ public abstract class Term extends JavaSymbolicObject implements Transformable, 
      * Returns a new {@code Term} instance obtained from this term by applying a binder-aware substitution.
      */
     @Override
-    public Term substituteWithBinders(Map<Variable, ? extends Term> substitution, TermContext context) {
+    public Term substituteWithBinders(Map<Variable, ? extends Term> substitution, State context) {
         return (Term) super.substituteWithBinders(substitution, context);
     }
 
@@ -157,7 +157,7 @@ public abstract class Term extends JavaSymbolicObject implements Transformable, 
      * pending functions are omitted by this method. In this case, use the
      * {@code evaluate} method instead.
      */
-    public Term substituteAndEvaluate(Map<Variable, ? extends Term> substitution, TermContext context) {
+    public Term substituteAndEvaluate(Map<Variable, ? extends Term> substitution, State context) {
         // TODO(AndreiS): assert that there are not any unevaluated functions in this term
         if (substitution.isEmpty() || isGround()) {
             return this;
@@ -173,7 +173,7 @@ public abstract class Term extends JavaSymbolicObject implements Transformable, 
      * term.
      */
     @Override
-    public Term substituteWithBinders(Variable variable, Term term, TermContext context) {
+    public Term substituteWithBinders(Variable variable, Term term, State context) {
         return (Term) super.substituteWithBinders(variable, term, context);
     }
 

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/Term.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/Term.java
@@ -125,7 +125,7 @@ public abstract class Term extends JavaSymbolicObject implements Transformable, 
      *            the symbolic constraint of the {@link ConstrainedTerm} which
      *            contains this {@code Term}
      * @param context
-     *            the term context
+     *            the state
      * @return the result {@code Term} instance
      */
     public Term evaluate(SymbolicConstraint constraint, State context) {

--- a/src/javasources/KTool/src/org/kframework/backend/java/ksimulation/Adjuster.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/ksimulation/Adjuster.java
@@ -69,21 +69,21 @@ public class Adjuster {
                 specside.constraint().rename(specside.term().variableSet());
         
         org.kframework.backend.java.kil.Term newImplTerm = 
-                implside.term().substituteWithBinders(implVars, implside.termContext());
+                implside.term().substituteWithBinders(implVars, implside.state());
         
         @SuppressWarnings("unchecked")
         Term newImplContent = ((Cell<Term>)newImplTerm).getContent();
         
         org.kframework.backend.java.kil.Term newSpecTerm = 
-                specside.term().substituteWithBinders(specVars, specside.termContext());
+                specside.term().substituteWithBinders(specVars, specside.state());
         
         @SuppressWarnings("unchecked")
         Term newSepcContent = ((Cell<Term>)newSpecTerm).getContent();
 
         SymbolicConstraint newImplside = 
-                implside.constraint().substituteWithBinders(implVars, implside.termContext());
+                implside.constraint().substituteWithBinders(implVars, implside.state());
         SymbolicConstraint newSpecside = 
-                specside.constraint().substituteWithBinders(specVars, specside.termContext());
+                specside.constraint().substituteWithBinders(specVars, specside.state());
 
         
 

--- a/src/javasources/KTool/src/org/kframework/backend/java/ksimulation/Waitor.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/ksimulation/Waitor.java
@@ -12,7 +12,6 @@ import org.kframework.krun.KRunExecutionException;
 import org.kframework.krun.ioserver.filesystem.portable.PortableFileSystem;
 import org.kframework.backend.java.kil.ConstrainedTerm;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
 
 public class Waitor extends Thread{
     
@@ -62,13 +61,13 @@ public class Waitor extends Thread{
         
         
         Term term = Term.of(implTerm, impl.getDefinition());
-        TermContext termContext = TermContext.of(impl.getDefinition(), new PortableFileSystem());
-        ConstrainedTerm implConstraint = new ConstrainedTerm(term, termContext);
+        org.kframework.backend.java.kil.State state = org.kframework.backend.java.kil.State.of(impl.getDefinition(), new PortableFileSystem());
+        ConstrainedTerm implConstraint = new ConstrainedTerm(term, state);
         pair[0] = implConstraint;
         
         term = Term.of(specTerm, spec.getDefinition());
-        termContext = TermContext.of(spec.getDefinition(), new PortableFileSystem());
-        ConstrainedTerm specConstraint = new ConstrainedTerm(term, termContext);
+        state = org.kframework.backend.java.kil.State.of(spec.getDefinition(), new PortableFileSystem());
+        ConstrainedTerm specConstraint = new ConstrainedTerm(term, state);
         pair[1] = specConstraint;
         
         

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/BinderSubstitutionTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/BinderSubstitutionTransformer.java
@@ -16,7 +16,7 @@ import java.util.Set;
  */
 public class BinderSubstitutionTransformer extends SubstitutionTransformer {
 
-    public BinderSubstitutionTransformer(Map<Variable, ? extends Term> substitution, TermContext context) {
+    public BinderSubstitutionTransformer(Map<Variable, ? extends Term> substitution, State context) {
         super(substitution, context);
         preTransformer.addTransformer(new BinderSubstitution(context));
     }
@@ -26,7 +26,7 @@ public class BinderSubstitutionTransformer extends SubstitutionTransformer {
      *
      */
     private class BinderSubstitution extends LocalTransformer {
-        public BinderSubstitution(TermContext context) {
+        public BinderSubstitution(State context) {
             super(context);
         }
 

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/BuiltinFunction.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/BuiltinFunction.java
@@ -4,7 +4,7 @@ package org.kframework.backend.java.symbolic;
 import org.kframework.backend.java.kil.Definition;
 import org.kframework.backend.java.kil.KLabelConstant;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.kil.Attribute;
 import org.kframework.kil.Production;
 import org.kframework.krun.K;
@@ -105,7 +105,7 @@ public class BuiltinFunction {
                             for (Method method : c.getDeclaredMethods()) {
                                 if (method.getName().equals(methodName)) {
                                     table.put(
-                                            KLabelConstant.of(label, TermContext.of(definition)),
+                                            KLabelConstant.of(label, State.of(definition)),
                                             method);
                                     break;
                                 }
@@ -131,7 +131,7 @@ public class BuiltinFunction {
      * Invokes the Java implementation of a builtin (hooked) operation.
      * 
      * @param context
-     *            the {@code TermContext}
+     *            the {@code State}
      * @param label
      *            the corresponding K label of the builtin operation
      * @param arguments
@@ -140,7 +140,7 @@ public class BuiltinFunction {
      * @throws IllegalAccessException
      * @throws IllegalArgumentException
      */
-    public static Term invoke(TermContext context, KLabelConstant label, Term ... arguments)
+    public static Term invoke(State context, KLabelConstant label, Term ... arguments)
             throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
         Object[] args =  Arrays.copyOf(arguments, arguments.length + 1, Object[].class);
         args[arguments.length] =  context;

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/CopyOnWriteTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/CopyOnWriteTransformer.java
@@ -30,16 +30,16 @@ import com.google.common.collect.Multimap;
  */
 public class CopyOnWriteTransformer implements Transformer {
 
-    protected final TermContext context;
+    protected final State context;
     protected final Definition definition;
     
-    public CopyOnWriteTransformer(TermContext context) {
+    public CopyOnWriteTransformer(State context) {
         this.context = context;
         this.definition = context.definition();
     }
 
     public CopyOnWriteTransformer(Definition definition) {
-        this(TermContext.of(definition));
+        this(State.of(definition));
     }
 
     public CopyOnWriteTransformer() {

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/Evaluator.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/Evaluator.java
@@ -2,7 +2,7 @@
 package org.kframework.backend.java.symbolic;
 
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 
 
 /**
@@ -11,17 +11,17 @@ import org.kframework.backend.java.kil.TermContext;
  */
 public class Evaluator extends PrePostTransformer {
 
-    private Evaluator(SymbolicConstraint constraint, TermContext context) {
+    private Evaluator(SymbolicConstraint constraint, State context) {
         super(context);
         this.getPostTransformer().addTransformer(new LocalEvaluator(constraint, context));
     }
     
-    public static Term evaluate(Term term, TermContext context) {
+    public static Term evaluate(Term term, State context) {
         return Evaluator.evaluate(term, null, context);
     }
 
     public static Term evaluate(Term term, SymbolicConstraint constraint,
-            TermContext context) {
+            State context) {
         Evaluator evaluator = new Evaluator(constraint, context);
         return (Term) term.accept(evaluator);
     }

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/LocalEvaluator.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/LocalEvaluator.java
@@ -17,11 +17,11 @@ public class LocalEvaluator extends LocalTransformer {
      */
     private final SymbolicConstraint constraint;
 
-    public LocalEvaluator(TermContext context) {
+    public LocalEvaluator(State context) {
         this(null, context);
     }
 
-    public LocalEvaluator(SymbolicConstraint constraint, TermContext context) {
+    public LocalEvaluator(SymbolicConstraint constraint, State context) {
         super(context);
         this.constraint = constraint;
     }

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/LocalTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/LocalTransformer.java
@@ -15,13 +15,13 @@ import org.kframework.kil.ASTNode;
  */
 public class LocalTransformer implements Transformer {
 
-    protected final TermContext context;
+    protected final State context;
 
     public LocalTransformer() {
         this.context = null;
     }
 
-    public LocalTransformer(TermContext context) {
+    public LocalTransformer(State context) {
         this.context = context;
     }
 

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/PatternMatcher.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/PatternMatcher.java
@@ -71,7 +71,7 @@ public class PatternMatcher extends AbstractMatcher {
      * @param pattern
      *            the pattern
      * @param context
-     *            the term context
+     *            the state
      * @return {@code true} if the two terms can be matched; otherwise,
      *         {@code false}
      */
@@ -97,7 +97,7 @@ public class PatternMatcher extends AbstractMatcher {
      * @param rule
      *            the rule
      * @param context
-     *            the term context
+     *            the state
      * @return a list of possible instantiations of the left-hand side of the
      *         rule (each instantiation is represented as a substitution mapping
      *         variables in the pattern to sub-terms in the subject)

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/PrePostTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/PrePostTransformer.java
@@ -43,12 +43,12 @@ public abstract class PrePostTransformer extends CopyOnWriteTransformer {
     protected CombinedLocalTransformer preTransformer = new CombinedLocalTransformer();
     protected CombinedLocalTransformer postTransformer = new CombinedLocalTransformer();
 
-    public PrePostTransformer(TermContext context) {
+    public PrePostTransformer(State context) {
         super(context);
     }
 
     public PrePostTransformer(Definition definition) {
-        super(TermContext.of(definition));
+        super(State.of(definition));
     }
 
     public PrePostTransformer() {

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/StepRewriter.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/StepRewriter.java
@@ -10,7 +10,7 @@ import org.kframework.backend.java.kil.ConstrainedTerm;
 import org.kframework.backend.java.kil.Definition;
 import org.kframework.backend.java.kil.Rule;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.backend.java.kil.Variable;
 
 import com.google.common.base.Stopwatch;
@@ -73,7 +73,7 @@ public class StepRewriter {
         constrainedTermResults = new ArrayList<ConstrainedTerm>();
 
         SymbolicConstraint leftHandSideConstraint = new SymbolicConstraint(
-            constrainedTerm.termContext());
+            constrainedTerm.state());
         leftHandSideConstraint.addAll(rule.requires());
         for (Variable variable : rule.freshVariables()) {
             leftHandSideConstraint.add(variable, IntToken.fresh());
@@ -81,9 +81,9 @@ public class StepRewriter {
 
         ConstrainedTerm leftHandSide = new ConstrainedTerm(
                 rule.leftHandSide(),
-                rule.lookups().getSymbolicConstraint(constrainedTerm.termContext()),
+                rule.lookups().getSymbolicConstraint(constrainedTerm.state()),
                 leftHandSideConstraint,
-                constrainedTerm.termContext());
+                constrainedTerm.state());
 
         for (SymbolicConstraint constraint : constrainedTerm.unify(leftHandSide)) {
             constraint.addAll(rule.ensures());
@@ -92,17 +92,17 @@ public class StepRewriter {
 
             Term result = rule.rightHandSide();
             /* rename rule variables in the rule RHS */
-            result = result.substituteWithBinders(freshSubstitution, constrainedTerm.termContext());
+            result = result.substituteWithBinders(freshSubstitution, constrainedTerm.state());
             /* apply the constraints substitution on the rule RHS */
-            result = result.substituteWithBinders(constraint.substitution(), constrainedTerm.termContext());
+            result = result.substituteWithBinders(constraint.substitution(), constrainedTerm.state());
             /* evaluate pending functions in the rule RHS */
-            result = result.evaluate(constrainedTerm.termContext());
+            result = result.evaluate(constrainedTerm.state());
             /* eliminate anonymous variables */
             constraint.eliminateAnonymousVariables();
 
             /* compute all results */
             constrainedTermResults.add(new ConstrainedTerm(result, constraint,
-                constrainedTerm.termContext()));
+                constrainedTerm.state()));
         }
 
         stopwatch.stop();
@@ -115,7 +115,7 @@ public class StepRewriter {
 
         termResults = new ArrayList<Term>();
 
-        TermContext context = TermContext.of(definition);
+        State context = State.of(definition);
         ConstrainedTerm constrainedTerm = new ConstrainedTerm(term, context);
 
         SymbolicConstraint leftHandSideConstraint = new SymbolicConstraint(context);

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SubstitutionTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SubstitutionTransformer.java
@@ -7,7 +7,7 @@ import org.kframework.backend.java.kil.KCollectionFragment;
 import org.kframework.backend.java.kil.KList;
 import org.kframework.backend.java.kil.KSequence;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.backend.java.kil.Variable;
 import org.kframework.kil.ASTNode;
 
@@ -26,7 +26,7 @@ public class SubstitutionTransformer extends PrePostTransformer {
 
     private final Map<Variable, ? extends Term> substitution;
     
-    public SubstitutionTransformer(Map<Variable, ? extends Term> substitution, TermContext context) {
+    public SubstitutionTransformer(Map<Variable, ? extends Term> substitution, State context) {
         super(context);
         this.substitution = substitution;
         preTransformer.addTransformer(new LocalVariableChecker());

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicConstraint.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicConstraint.java
@@ -18,7 +18,7 @@ import org.kframework.backend.java.kil.KLabelConstant;
 import org.kframework.backend.java.kil.KList;
 import org.kframework.backend.java.kil.Kind;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.backend.java.kil.Variable;
 import org.kframework.backend.java.kil.Z3Term;
 import org.kframework.backend.java.util.GappaPrinter;
@@ -415,7 +415,7 @@ public class SymbolicConstraint extends JavaSymbolicObject {
      * It is null is this constraint is not false.
      */
     private Equality falsifyingEquality;
-    private final TermContext context;
+    private final State context;
     private final Definition definition;
 
     /**
@@ -424,13 +424,13 @@ public class SymbolicConstraint extends JavaSymbolicObject {
      */
     private final SymbolicUnifier unifier;
 
-    public SymbolicConstraint(SymbolicConstraint constraint, TermContext context) {
+    public SymbolicConstraint(SymbolicConstraint constraint, State context) {
         this(context);
         substitution.putAll(constraint.substitution);
         addAll(constraint);
     }
 
-    public SymbolicConstraint(TermContext context) {
+    public SymbolicConstraint(State context) {
         this.context = context;
         this.definition = context.definition();
         unifier = new SymbolicUnifier(this, context);
@@ -438,7 +438,7 @@ public class SymbolicConstraint extends JavaSymbolicObject {
         isNormal = true;
     }
 
-    public TermContext termContext() {
+    public State state() {
         return context;
     }
 
@@ -1062,7 +1062,7 @@ public class SymbolicConstraint extends JavaSymbolicObject {
      *            {@link SymbolicConstraint#isNormal} to be {@code false}
      */
     private void composeSubstitution(Map<Variable, Term> substMap,
-            TermContext context, boolean mayInvalidateNormality) {
+            State context, boolean mayInvalidateNormality) {
         @SuppressWarnings("unchecked")
         Map.Entry<Variable, Term>[] entries = substitution.entrySet().toArray(new Map.Entry[substitution.size()]);
         for (Map.Entry<Variable, Term> subst : entries) {
@@ -1119,7 +1119,7 @@ public class SymbolicConstraint extends JavaSymbolicObject {
      * Returns a new {@code SymbolicConstraint} instance obtained from this symbolic constraint
      * by applying substitution.
      */
-    public SymbolicConstraint substituteWithBinders(Map<Variable, ? extends Term> substitution, TermContext context) {
+    public SymbolicConstraint substituteWithBinders(Map<Variable, ? extends Term> substitution, State context) {
         if (substitution.isEmpty()) {
             return this;
         }
@@ -1131,7 +1131,7 @@ public class SymbolicConstraint extends JavaSymbolicObject {
      * Returns a new {@code SymbolicConstraint} instance obtained from this symbolic constraint by
      * substituting variable with term.
      */
-    public SymbolicConstraint substituteWithBinders(Variable variable, Term term, TermContext context) {
+    public SymbolicConstraint substituteWithBinders(Variable variable, Term term, State context) {
         return substituteWithBinders(Collections.singletonMap(variable, term), context);
     }
 
@@ -1261,7 +1261,7 @@ public class SymbolicConstraint extends JavaSymbolicObject {
         final List<KItem> result;
         private String IF_THEN_ELSE_LABEL="'#if_#then_#else_#fi";
 
-        public IfThenElseFinder(TermContext context) {
+        public IfThenElseFinder(State context) {
             result = new ArrayList<>();
             preVisitor.addVisitor(new LocalVisitor() {
                 @Override

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicConstraint.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicConstraint.java
@@ -1056,7 +1056,7 @@ public class SymbolicConstraint extends JavaSymbolicObject {
      * @param substMap
      *            the specified substitution map
      * @param context
-     *            the term context
+     *            the state
      * @param mayInvalidateNormality
      *            whether this operation may cause
      *            {@link SymbolicConstraint#isNormal} to be {@code false}

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -329,7 +329,7 @@ public class SymbolicRewriter {
      * @param rule
      *            the specified rule
      * @param state
-     *            the term context
+     *            the state
      * @return the pattern term
      */
     private ConstrainedTerm preparePattern(Rule rule, State state) {

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -32,7 +32,7 @@ import org.kframework.backend.java.kil.ConstrainedTerm;
 import org.kframework.backend.java.kil.Definition;
 import org.kframework.backend.java.kil.Rule;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.backend.java.kil.Variable;
 import org.kframework.backend.java.strategies.TransitionCompositeStrategy;
 import org.kframework.backend.java.util.TestCaseGenerationUtil;
@@ -192,7 +192,7 @@ public class SymbolicRewriter {
                 ruleStopwatch.start();
 
                 SymbolicConstraint leftHandSideConstraint = new SymbolicConstraint(
-                        constrainedTerm.termContext());
+                        constrainedTerm.state());
                 leftHandSideConstraint.addAll(rule.requires());
 
                 CellCollection newTemp = new CellCollection();
@@ -203,9 +203,9 @@ public class SymbolicRewriter {
 
                 ConstrainedTerm leftHandSideTerm = new ConstrainedTerm(
                         newRuleTerm,
-                        rule.lookups().getSymbolicConstraint(constrainedTerm.termContext()),
+                        rule.lookups().getSymbolicConstraint(constrainedTerm.state()),
                         leftHandSideConstraint,
-                        constrainedTerm.termContext());
+                        constrainedTerm.state());
 
                 SymbolicConstraint constraint = constrainedTerm.matchImplies(leftHandSideTerm);
                 if (constraint == null) {
@@ -218,16 +218,16 @@ public class SymbolicRewriter {
 
                 Term result = rule.rightHandSide();
                 /* rename rule variables in the rule RHS */
-                result = result.substituteWithBinders(freshSubstitution, constrainedTerm.termContext());
+                result = result.substituteWithBinders(freshSubstitution, constrainedTerm.state());
                 /* apply the constraints substitution on the rule RHS */
-                result = result.substituteWithBinders(constraint.substitution(), constrainedTerm.termContext());
+                result = result.substituteWithBinders(constraint.substitution(), constrainedTerm.state());
                 /* evaluate pending functions in the rule RHS */
                 //result = result.evaluate(constrainedTerm.termContext());
                 /* eliminate anonymous variables */
                 constraint.eliminateAnonymousVariables();
 
                 /* return first solution */
-                return new ConstrainedTerm(result, constraint, constrainedTerm.termContext());
+                return new ConstrainedTerm(result, constraint, constrainedTerm.state());
             }
 
         }
@@ -269,7 +269,7 @@ public class SymbolicRewriter {
                 ruleStopwatch.reset();
                 ruleStopwatch.start();
 
-                ConstrainedTerm constrainedPattern = preparePattern(rule, constrainedSubject.termContext());
+                ConstrainedTerm constrainedPattern = preparePattern(rule, constrainedSubject.state());
 
                 for (SymbolicConstraint constraint1 : getUnificationResults(constrainedSubject, constrainedPattern)) {
                     /* compute all results */
@@ -328,13 +328,13 @@ public class SymbolicRewriter {
      * 
      * @param rule
      *            the specified rule
-     * @param termContext
+     * @param state
      *            the term context
      * @return the pattern term
      */
-    private ConstrainedTerm preparePattern(Rule rule, TermContext termContext) {
+    private ConstrainedTerm preparePattern(Rule rule, State state) {
         SymbolicConstraint leftHandSideConstraint = new SymbolicConstraint(
-                termContext);
+                state);
         leftHandSideConstraint.addAll(rule.requires());
         for (Variable variable : rule.freshVariables()) {
             leftHandSideConstraint.add(variable, IntToken.fresh());
@@ -342,9 +342,9 @@ public class SymbolicRewriter {
 
         ConstrainedTerm leftHandSide = new ConstrainedTerm(
                 rule.leftHandSide(),
-                rule.lookups().getSymbolicConstraint(termContext),
+                rule.lookups().getSymbolicConstraint(state),
                 leftHandSideConstraint,
-                termContext);
+                state);
         return leftHandSide;
     }
 
@@ -376,11 +376,11 @@ public class SymbolicRewriter {
         /* rename rule variables in the constraints */
         Map<Variable, Variable> freshSubstitution = constraint.rename(rule.variableSet());
         /* rename rule variables in the rule RHS */
-        result = result.substituteWithBinders(freshSubstitution, constraint.termContext());
+        result = result.substituteWithBinders(freshSubstitution, constraint.state());
         /* apply the constraints substitution on the rule RHS */
         result = result.substituteAndEvaluate(
                 constraint.substitution(),
-                constraint.termContext());
+                constraint.state());
         /* eliminate anonymous variables */
         constraint.eliminateAnonymousVariables();
 
@@ -390,7 +390,7 @@ public class SymbolicRewriter {
         System.err.println("result constraint\n\t" + constraint1);
         System.err.println("============================================================");
          */
-        return new ConstrainedTerm(result, constraint, constraint.termContext());
+        return new ConstrainedTerm(result, constraint, constraint.state());
     }
 
     /**
@@ -415,14 +415,14 @@ public class SymbolicRewriter {
             ruleStopwatch.start();
 
             SymbolicConstraint leftHandSideConstraint = new SymbolicConstraint(
-                    constrainedTerm.termContext());
+                    constrainedTerm.state());
             leftHandSideConstraint.addAll(rule.requires());
 
             ConstrainedTerm leftHandSideTerm = new ConstrainedTerm(
                     rule.leftHandSide(),
-                    rule.lookups().getSymbolicConstraint(constrainedTerm.termContext()),
+                    rule.lookups().getSymbolicConstraint(constrainedTerm.state()),
                     leftHandSideConstraint,
-                    constrainedTerm.termContext());
+                    constrainedTerm.state());
 
             SymbolicConstraint constraint = constrainedTerm.matchImplies(leftHandSideTerm);
             if (constraint == null) {
@@ -435,16 +435,16 @@ public class SymbolicRewriter {
 
             Term result = rule.rightHandSide();
             /* rename rule variables in the rule RHS */
-            result = result.substituteWithBinders(freshSubstitution, constrainedTerm.termContext());
+            result = result.substituteWithBinders(freshSubstitution, constrainedTerm.state());
             /* apply the constraints substitution on the rule RHS */
-            result = result.substituteWithBinders(constraint.substitution(), constrainedTerm.termContext());
+            result = result.substituteWithBinders(constraint.substitution(), constrainedTerm.state());
             /* evaluate pending functions in the rule RHS */
-            result = result.evaluate(constrainedTerm.termContext());
+            result = result.evaluate(constrainedTerm.state());
             /* eliminate anonymous variables */
             constraint.eliminateAnonymousVariables();
 
             /* return first solution */
-            return new ConstrainedTerm(result, constraint, constrainedTerm.termContext());
+            return new ConstrainedTerm(result, constraint, constrainedTerm.state());
         }
 
         return null;
@@ -455,7 +455,7 @@ public class SymbolicRewriter {
     // can't be unified with the pattern.
     private Map<Variable, Term> getSubstitutionMap(ConstrainedTerm term, Rule pattern) {
         // Create the initial constraints based on the pattern
-        SymbolicConstraint termConstraint = new SymbolicConstraint(term.termContext());
+        SymbolicConstraint termConstraint = new SymbolicConstraint(term.state());
         termConstraint.addAll(pattern.requires());
         for (Variable var : pattern.freshVariables()) {
             termConstraint.add(var, IntToken.fresh());
@@ -464,9 +464,9 @@ public class SymbolicRewriter {
         // Create a constrained term from the left hand side of the pattern.
         ConstrainedTerm lhs = new ConstrainedTerm(
                 pattern.leftHandSide(),
-                pattern.lookups().getSymbolicConstraint(term.termContext()),
+                pattern.lookups().getSymbolicConstraint(term.state()),
                 termConstraint,
-                term.termContext());
+                term.state());
 
         // Collect the variables we are interested in finding
         VariableCollector visitor = new VariableCollector();
@@ -797,7 +797,7 @@ public class SymbolicRewriter {
             /* substitute the initial term to get a partially instantiated pgm */
             Term pgm = initTerm.term().substituteWithBinders(
                     tmpResults.get(i).constraint().substitution(),
-                    initTerm.termContext());
+                    initTerm.state());
 
             checker.reset();
             pgm.accept(checker);
@@ -884,7 +884,7 @@ public class SymbolicRewriter {
             /* rename rule variables */
             Map<Variable, Variable> freshSubstitution = Variable.getFreshSubstitution(rule.variableSet());
 
-            TermContext context = TermContext.of(definition, fs);
+            State context = State.of(definition, fs);
             SymbolicConstraint sideConstraint = new SymbolicConstraint(context);
             sideConstraint.addAll(rule.requires());
             ConstrainedTerm initialTerm = new ConstrainedTerm(

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicUnifier.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicUnifier.java
@@ -30,7 +30,7 @@ import org.kframework.backend.java.kil.MapUpdate;
 import org.kframework.backend.java.kil.MetaVariable;
 import org.kframework.backend.java.kil.SetUpdate;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.backend.java.kil.Token;
 import org.kframework.backend.java.kil.Variable;
 import org.kframework.kil.loader.Context;
@@ -63,11 +63,11 @@ public class SymbolicUnifier extends AbstractUnifier {
      * A conjunction of disjunctions of {@code SymbolicConstraint}s created by this unifier.
      */
     public final java.util.Collection<java.util.Collection<SymbolicConstraint>> multiConstraints;
-    private final TermContext termContext;
+    private final State state;
 
-    public SymbolicUnifier(SymbolicConstraint constraint, TermContext context) {
+    public SymbolicUnifier(SymbolicConstraint constraint, State context) {
         this.fConstraint = constraint;
-        this.termContext = context;
+        this.state = context;
         multiConstraints = new ArrayList<java.util.Collection<SymbolicConstraint>>();
     }
 
@@ -110,7 +110,7 @@ public class SymbolicUnifier extends AbstractUnifier {
         }
 
         if (term.kind() == Kind.CELL || term.kind() == Kind.CELL_COLLECTION) {
-            Context context = termContext.definition().context();
+            Context context = state.definition().context();
             term = CellCollection.upKind(term, otherTerm.kind(), context);
             otherTerm = CellCollection.upKind(otherTerm, term.kind(), context);
         }
@@ -275,7 +275,7 @@ public class SymbolicUnifier extends AbstractUnifier {
         Set<String> unifiableCellLabels = new HashSet<String>(cellCollection.labelSet());
         unifiableCellLabels.retainAll(otherCellCollection.labelSet());
 
-        Context context = termContext.definition().context();
+        Context context = state.definition().context();
         
         /*
          * CASE 1: cellCollection has no explicitly specified starred-cell;
@@ -366,7 +366,7 @@ public class SymbolicUnifier extends AbstractUnifier {
             // start searching for all possible unifiers
             do {
                 // clear the constraint before each attempt of unification
-                fConstraint = new SymbolicConstraint(termContext);
+                fConstraint = new SymbolicConstraint(state);
 
                 try {
                     for (int i = 0; i < otherCells.length; ++i) {
@@ -505,7 +505,7 @@ public class SymbolicUnifier extends AbstractUnifier {
             assert cellMap.get(cellLabel).size() == 1;
         }
         
-        Context context = termContext.definition().context();
+        Context context = state.definition().context();
         
         if (frame != null) {
             if (otherFrame != null) {
@@ -618,11 +618,11 @@ public class SymbolicUnifier extends AbstractUnifier {
                     Term boundVars = terms.get(boundVarPosition);
                     Set<Variable> variables = boundVars.variableSet();
                     Map<Variable,Variable> freshSubstitution = Variable.getFreshSubstitution(variables);
-                    Term freshBoundVars = boundVars.substituteWithBinders(freshSubstitution, termContext);
+                    Term freshBoundVars = boundVars.substituteWithBinders(freshSubstitution, state);
                     terms.set(boundVarPosition, freshBoundVars);
                     for (Integer bindingExpPosition : binderMap.get(boundVarPosition)) {
                         Term bindingExp = terms.get(bindingExpPosition-1);
-                        Term freshbindingExp = bindingExp.substituteWithBinders(freshSubstitution, termContext);
+                        Term freshbindingExp = bindingExp.substituteWithBinders(freshSubstitution, state);
                         terms.set(bindingExpPosition-1, freshbindingExp);
                     }
                 }

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/TermSubstitutionTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/TermSubstitutionTransformer.java
@@ -18,7 +18,7 @@ public class TermSubstitutionTransformer extends PrePostTransformer {
 
     private final Map<? extends Term, ? extends Term> substitution;
 
-    public TermSubstitutionTransformer(Map<? extends Term, ? extends Term> substitution, TermContext context) {
+    public TermSubstitutionTransformer(Map<? extends Term, ? extends Term> substitution, State context) {
         super(context);
         this.substitution = substitution;
 //        preTransformer.addTransformer(new LocalVariableChecker());

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/TermTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/TermTransformer.java
@@ -13,7 +13,7 @@ import org.kframework.kil.ASTNode;
  */
 public class TermTransformer extends CopyOnWriteTransformer {
 
-    public TermTransformer(TermContext context) {
+    public TermTransformer(State context) {
         super(context);
     }
 

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/UninterpretedConstraint.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/UninterpretedConstraint.java
@@ -5,7 +5,7 @@ package org.kframework.backend.java.symbolic;
 import com.google.common.base.Joiner;
 import org.kframework.backend.java.kil.JavaSymbolicObject;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.backend.java.util.Utils;
 import org.kframework.kil.ASTNode;
 
@@ -110,7 +110,7 @@ public class UninterpretedConstraint extends JavaSymbolicObject {
      *            the term context
      * @return the corresponding symbolic constraint
      */
-    public SymbolicConstraint getSymbolicConstraint(TermContext context) {
+    public SymbolicConstraint getSymbolicConstraint(State context) {
         SymbolicConstraint symbolicConstraint = new SymbolicConstraint(context);
         for (Equality equality : equalities) {
             symbolicConstraint.add(equality.leftHandSide, equality.rightHandSide);

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/UninterpretedConstraint.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/UninterpretedConstraint.java
@@ -107,7 +107,7 @@ public class UninterpretedConstraint extends JavaSymbolicObject {
      * Returns the interpreted counterpart of this constraint.
      * 
      * @param context
-     *            the term context
+     *            the state
      * @return the corresponding symbolic constraint
      */
     public SymbolicConstraint getSymbolicConstraint(State context) {

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/UseSMT.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/UseSMT.java
@@ -13,7 +13,7 @@ import com.microsoft.z3.Model;
 import org.kframework.backend.java.builtins.IntToken;
 import org.kframework.backend.java.builtins.StringToken;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.backend.java.kil.Variable;
 import org.kframework.backend.java.kil.Z3Term;
 
@@ -30,7 +30,7 @@ import org.kframework.krun.K;
 
 public class UseSMT implements Serializable {
 
-    public static BuiltinMap checkSat(Term term, TermContext termContext) {
+    public static BuiltinMap checkSat(Term term, State state) {
         if (!K.smt.equals("z3")) {
             return null;
         }

--- a/src/javasources/KTool/src/org/kframework/backend/java/util/GappaPrinter.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/util/GappaPrinter.java
@@ -105,8 +105,8 @@ public class GappaPrinter extends BottomUpVisitor {
                         String label = klabelCt.label();
                         String newlabel = reverseComparisonOps.get(label);
                         if (newlabel != null) {
-                            klabelCt = KLabelConstant.of(newlabel, klabelCt.termContext());
-                            equalityLHS = new KItem(klabelCt, (KList) ((KItem) equalityLHS).kList(), constraint.termContext());
+                            klabelCt = KLabelConstant.of(newlabel, klabelCt.state());
+                            equalityLHS = new KItem(klabelCt, (KList) ((KItem) equalityLHS).kList(), constraint.state());
                             equalityRHS = BoolToken.TRUE;
                         }
                     }

--- a/src/javasources/KTool/src/org/kframework/backend/java/util/GroupProductionsBySort.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/util/GroupProductionsBySort.java
@@ -12,7 +12,7 @@ import org.kframework.backend.java.kil.KItem;
 import org.kframework.backend.java.kil.KLabelConstant;
 import org.kframework.backend.java.kil.KList;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.backend.java.kil.Variable;
 import org.kframework.kil.Attribute;
 import org.kframework.kil.Production;
@@ -58,7 +58,7 @@ public class GroupProductionsBySort {
         prodsOfSort = sort2ProdsBuilder.build();
     }
 
-    public List<KItem> getProductionsAsTerms(String sort, TermContext context) {
+    public List<KItem> getProductionsAsTerms(String sort, State context) {
         List<KItem> freshTerms = new ArrayList<KItem>();
         List<Production> prods = prodsOfSort.get(sort);
         if (prods != null) {

--- a/src/javasources/KTool/src/org/kframework/backend/java/util/TestCaseGenerationUtil.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/util/TestCaseGenerationUtil.java
@@ -17,7 +17,7 @@ import org.kframework.backend.java.kil.KLabelConstant;
 import org.kframework.backend.java.kil.KList;
 import org.kframework.backend.java.kil.Rule;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.backend.java.kil.Variable;
 import org.kframework.kil.loader.Context;
 
@@ -169,11 +169,11 @@ public class TestCaseGenerationUtil {
         return set.size();
     }
 
-    public static Term getSimplestTermOfSort(String sort, TermContext termContext) {
+    public static Term getSimplestTermOfSort(String sort, State state) {
         // TODO(YilongL): This is cheating; fix it!
         switch (sort) {
         case "Block":
-            return new KItem(KLabelConstant.of("'{}", termContext), new KList(), termContext);
+            return new KItem(KLabelConstant.of("'{}", state), new KList(), state);
             
         case "BExp":
             return BoolToken.TRUE;

--- a/src/javasources/KTool/test/org/kframework/backend/java/builtins/BuiltinIOOperationsTest.java
+++ b/src/javasources/KTool/test/org/kframework/backend/java/builtins/BuiltinIOOperationsTest.java
@@ -5,18 +5,18 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.State;
 import org.kframework.krun.api.io.FileSystem;
 import org.mockito.Mockito;
 
 public class BuiltinIOOperationsTest {
 
-    private TermContext context;
+    private State context;
     private FileSystem fs;
 
     @Before
     public void setUp() throws Exception {
-        context = Mockito.mock(TermContext.class);
+        context = Mockito.mock(State.class);
         fs = Mockito.mock(FileSystem.class);
 
         Mockito.when(context.fileSystem()).thenReturn(fs);


### PR DESCRIPTION
ok. so I took a lighter approach. I only changed the obvious places in the documentation, i.e., those mentioning "term context".

regarding method renames, I only changed those that were talking about `termContext`, not other variants.

there are many places where the State object is still referred by `context`. While not ideal, I think it is not necessarily incorrect -- the State can be considered the context in which something happens. And it is at least better than `TermContext`.

Let's see what Jenkins says, then it may be good to have another pair of eyes check the replacements.
