### PR TITLE
Cleanup builtin map api

### DIFF
--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinMapOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinMapOperations.java
@@ -9,9 +9,7 @@ import org.kframework.backend.java.kil.Variable;
 
 import com.google.common.base.Preconditions;
 
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 
@@ -30,11 +28,11 @@ public class BuiltinMapOperations {
     }
 
     public static BuiltinMap construct(BuiltinMap term1, BuiltinMap term2, TermContext context) {
+        Preconditions.checkArgument(!term1.hasFrame() || !term2.hasFrame(), 
+                "both map arguments have frames, but the combined map cannot have two frames");
+        
         Variable frame = null;
-        if (term1.hasFrame() && term2.hasFrame()) {
-            throw new IllegalArgumentException(
-                    "both map arguments have frames, but the combined map cannot have two frames");
-        } else if (term1.hasFrame()) {
+        if (term1.hasFrame()) {
             frame = term1.frame();
         } else if (term2.hasFrame()) {
             frame = term2.frame();
@@ -48,14 +46,12 @@ public class BuiltinMapOperations {
     }
 
     public static BuiltinMap update(BuiltinMap term, Term key, Term value, TermContext context) {
-        if (!term.hasFrame()) {
-            BuiltinMap.Builder builder = BuiltinMap.builder();
-            builder.putAll(term.getEntries());
-            builder.put(key, value);
-            return builder.build();
-        } else {
-            throw new IllegalArgumentException("argument " + term + " has frame");
-        }
+        Preconditions.checkArgument(!term.hasFrame(), "argument " + term + " has frame");
+        
+        BuiltinMap.Builder builder = BuiltinMap.builder();
+        builder.putAll(term.getEntries());
+        builder.put(key, value);
+        return builder.build();
     }
 
 }

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinMapOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinMapOperations.java
@@ -7,6 +7,8 @@ import org.kframework.backend.java.kil.Term;
 import org.kframework.backend.java.kil.TermContext;
 import org.kframework.backend.java.kil.Variable;
 
+import com.google.common.base.Preconditions;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -21,12 +23,10 @@ import java.util.Set;
 public class BuiltinMapOperations {
 
     public static BuiltinSet keys(BuiltinMap term, TermContext context) {
-        if (!term.hasFrame()) {
-            Set<Term> elements = new HashSet<Term>(term.getEntries().keySet());
-            return new BuiltinSet(elements);
-        } else {
-            throw new IllegalArgumentException("argument " + term + " has frame");
-        }
+        Preconditions.checkArgument(!term.hasFrame(), "argument " + term + " has frame");
+        
+        Set<Term> elements = new HashSet<Term>(term.getEntries().keySet());
+        return new BuiltinSet(elements);
     }
 
     public static BuiltinMap construct(BuiltinMap term1, BuiltinMap term2, TermContext context) {
@@ -40,17 +40,19 @@ public class BuiltinMapOperations {
             frame = term2.frame();
         }
 
-        Map<Term, Term> entries = new HashMap<>(term1.getEntries());
-        entries.putAll(term2.getEntries());
-        return new BuiltinMap(entries, frame);
-
+        BuiltinMap.Builder builder = BuiltinMap.builder();
+        builder.putAll(term1.getEntries());
+        builder.putAll(term2.getEntries());
+        builder.setFrame(frame);
+        return builder.build();
     }
 
     public static BuiltinMap update(BuiltinMap term, Term key, Term value, TermContext context) {
         if (!term.hasFrame()) {
-            Map<Term, Term> entries = new HashMap<>(term.getEntries());
-            entries.put(key, value);
-            return new BuiltinMap(entries);
+            BuiltinMap.Builder builder = BuiltinMap.builder();
+            builder.putAll(term.getEntries());
+            builder.put(key, value);
+            return builder.build();
         } else {
             throw new IllegalArgumentException("argument " + term + " has frame");
         }

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinUnificationOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinUnificationOperations.java
@@ -11,6 +11,8 @@ import org.kframework.backend.java.kil.Term;
 import org.kframework.backend.java.kil.TermContext;
 import org.kframework.backend.java.kil.Variable;
 
+import com.google.common.base.Preconditions;
+
 /**
  * Table of {@code public static} methods on builtin unification.
  *
@@ -35,17 +37,15 @@ public class BuiltinUnificationOperations {
 
     public static BuiltinMap applyMgu(BuiltinMgu mgu, BuiltinMap map,
             TermContext context) {
-        if (!map.hasFrame()) {
-            Map<Term, Term> entries = new HashMap<>();
-            Map<Variable, Term> subst = mgu.constraint().substitution();
-            for (Map.Entry<Term, Term> entry : map.getEntries().entrySet()) {
-                Term value = entry.getValue().substituteWithBinders(subst, context);
-                entries.put(entry.getKey(), value);
-            }
-            return new BuiltinMap(entries);
-        } else {
-            throw new IllegalArgumentException("argument " + map + " has frame");
+        Preconditions.checkArgument(!map.hasFrame(), "argument " + map + " has frame");
+        
+        BuiltinMap.Builder builder = BuiltinMap.builder();
+        Map<Variable, Term> subst = mgu.constraint().substitution();
+        for (Map.Entry<Term, Term> entry : map) {
+            Term value = entry.getValue().substituteWithBinders(subst, context);
+            builder.put(entry.getKey(), value);
         }
+        return builder.build();
     }
 
 }

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/MetaK.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/MetaK.java
@@ -150,13 +150,13 @@ public class MetaK {
     }
 
     public static BuiltinMap variablesMap(Term term, TermContext context) {
+        BuiltinMap.Builder builder = BuiltinMap.builder();
         Set<Variable> variables = term.variableSet();
-        Map<MetaVariable, Variable> result = new HashMap<>(variables.size());
         for (Variable variable : variables) {
             assert variable instanceof Variable : "this function only applies on variables";
-            result.put(new MetaVariable(variable), variable);
+            builder.put(new MetaVariable(variable), variable);
         }
-        return BuiltinMap.of(result, null);
+        return builder.build();
     }
 
     /**

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/BuiltinMap.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/BuiltinMap.java
@@ -148,14 +148,11 @@ public class BuiltinMap extends Collection implements Iterable<Map.Entry<Term, T
     public static class Builder {
         
         private boolean done = false;
-        private boolean setEntries = false;
-        private boolean setFrame = false;
         
         private Map<Term, Term> entries = new HashMap<>();
         private Variable frame = null;
 
         public void put(Term key, Term value) {
-            Preconditions.checkArgument(!setEntries, "Cannot put in new key-value pair once the entries are set.");
             entries.put(key, value);
         }
         
@@ -166,10 +163,7 @@ public class BuiltinMap extends Collection implements Iterable<Map.Entry<Term, T
          * @param map
          */
         public void putAll(Map<Term, Term> map) {
-            Preconditions.checkArgument(!setEntries, "Cannot put in new key-value pair once the entries are set.");
-            for (Map.Entry<Term, Term> e : map.entrySet()) {
-                this.put(e.getKey(), e.getValue());
-            }
+            entries.putAll(map);
         }
         
         public Term remove(Term key) {
@@ -181,15 +175,14 @@ public class BuiltinMap extends Collection implements Iterable<Map.Entry<Term, T
         }
         
         /**
-         * Sets the entries without copying the contents. Once the entries are
-         * set, no more modification is allowed.
+         * Sets the entries as the given {@code BuiltinMap} without copying the
+         * contents. Once the entries are set, no more modification is allowed.
          * 
          * @param map
          */
-        public void setEntries(Map<Term, Term> map) {
-            Preconditions.checkArgument(!setEntries, "Cannot set the entries twice.");
-            setEntries = true;
-            entries = map;
+        public void setEntriesAs(BuiltinMap builtinMap) {
+            // builtinMap.entries must be an UnmodifiableMap
+            entries = builtinMap.entries;
         }
         
         /**
@@ -199,8 +192,6 @@ public class BuiltinMap extends Collection implements Iterable<Map.Entry<Term, T
          * @param frame
          */
         public void setFrame(Variable frame) {
-            Preconditions.checkArgument(!setFrame, "Cannot set the frame twice.");
-            setFrame = true;
             this.frame = frame;
         }
         

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/BuiltinMap.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/BuiltinMap.java
@@ -1,20 +1,23 @@
 // Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.kil;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.apache.commons.collections15.map.UnmodifiableMap;
 import org.kframework.backend.java.symbolic.Matcher;
-import org.kframework.backend.java.symbolic.Unifier;
 import org.kframework.backend.java.symbolic.Transformer;
+import org.kframework.backend.java.symbolic.Unifier;
 import org.kframework.backend.java.symbolic.Visitor;
 import org.kframework.backend.java.util.KSorts;
 import org.kframework.backend.java.util.Utils;
 import org.kframework.kil.ASTNode;
 import org.kframework.kil.DataStructureSort;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 
 
 /**
@@ -24,28 +27,15 @@ import com.google.common.base.Joiner;
  *
  * @author AndreiS
  */
-public class BuiltinMap extends Collection {
+public class BuiltinMap extends Collection implements Iterable<Map.Entry<Term, Term>> {
 
+    public static final BuiltinMap EMPTY_MAP = new BuiltinMap();
+    
     private final Map<Term, Term> entries;
-
-    public BuiltinMap(Map<? extends Term, ? extends Term> entries, Variable frame) {
-        super(frame, Kind.KITEM);
-        this.entries = new HashMap<Term, Term>(entries);
-    }
-
-    public BuiltinMap(Variable frame) {
-        super(frame, Kind.KITEM);
-        entries = new HashMap<Term, Term>();
-    }
-
-    public BuiltinMap(Map<? extends Term,? extends Term> entries) {
+    
+    private BuiltinMap() {
         super(null, Kind.KITEM);
-        this.entries = new HashMap<Term, Term>(entries);
-    }
-
-    public BuiltinMap() {
-        super(null, Kind.KITEM);
-        entries = new HashMap<Term, Term>();
+        entries = Collections.emptyMap();
     }
 
     public Term get(Term key) {
@@ -53,19 +43,12 @@ public class BuiltinMap extends Collection {
     }
 
     public Map<Term, Term> getEntries() {
-        return Collections.unmodifiableMap(entries);
+        return UnmodifiableMap.decorate(entries);
     }
 
-    public Term put(Term key, Term value) {
-        return entries.put(key, value);
-    }
-
-    public void putAll(Map<Term, Term> entries) {
-        this.entries.putAll(entries);
-    }
-
-    public Term remove(Term key) {
-        return entries.remove(key);
+    @Override
+    public Iterator<Map.Entry<Term, Term>> iterator() {
+        return entries.entrySet().iterator();
     }
 
     @Override
@@ -147,20 +130,112 @@ public class BuiltinMap extends Collection {
     public ASTNode accept(Transformer transformer) {
         return transformer.transform(this);
     }
+    
+    /**
+     * Private efficient constructor used by {@link BuiltinMap.Builder}.
+     * @param entries
+     * @param frame
+     */
+    private BuiltinMap(UnmodifiableMap<Term, Term> entries, Variable frame) {
+        super(frame, Kind.KITEM);
+        this.entries = entries;
+    }
 
-    public static BuiltinMap of(Map<? extends Term, ? extends Term> entries, Term frame) {
-        if (frame == null) {
-            return new BuiltinMap(entries);
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        
+        private boolean done = false;
+        private boolean setEntries = false;
+        private boolean setFrame = false;
+        
+        private Map<Term, Term> entries = new HashMap<>();
+        private Variable frame = null;
+
+        public void put(Term key, Term value) {
+            Preconditions.checkArgument(!setEntries, "Cannot put in new key-value pair once the entries are set.");
+            entries.put(key, value);
         }
-        if (frame instanceof Variable)
-            return new BuiltinMap(entries, (Variable) frame);
-        if (frame instanceof BuiltinMap) {
-            BuiltinMap builtinMap = (BuiltinMap) frame;
-            builtinMap = new BuiltinMap(builtinMap.entries, builtinMap.frame);
-            builtinMap.entries.putAll(entries);
-            return builtinMap;
+        
+        /**
+         * Copies all key-value pairs of the given map into the BuiltinMap being
+         * built.
+         * 
+         * @param map
+         */
+        public void putAll(Map<Term, Term> map) {
+            Preconditions.checkArgument(!setEntries, "Cannot put in new key-value pair once the entries are set.");
+            for (Map.Entry<Term, Term> e : map.entrySet()) {
+                entries.put(e.getKey(), e.getValue());
+            }
         }
-        assert false : "Frame can only be substituted by a Variable or a BuiltinMap, or deleted.";
-        return null;
+        
+        public Term remove(Term key) {
+            return entries.remove(key);
+        }
+        
+        public Map<Term, Term> getEntries() {
+            return UnmodifiableMap.decorate(entries);
+        }
+        
+        /**
+         * Sets the entries without copying the contents. Once the entries are
+         * set, no more modification is allowed.
+         * 
+         * @param map
+         */
+        public void setEntries(Map<Term, Term> map) {
+            Preconditions.checkArgument(!setEntries, "Cannot set the entries twice.");
+            setEntries = true;
+            entries = map;
+        }
+        
+        /**
+         * Sets the frame of the BuiltinMap being built. Once the frame is set,
+         * it cannot be changed.
+         * 
+         * @param frame
+         */
+        public void setFrame(Variable frame) {
+            Preconditions.checkArgument(!setFrame, "Cannot set the frame twice.");
+            setFrame = true;
+            this.frame = frame;
+        }
+        
+        /**
+         * Concatenates the BuiltinMap being built with another term, which can only
+         * be a {@code Variable} or {@code BuiltinMap}.
+         * 
+         * @param term
+         */
+        public void concat(Term term) {
+            if (term == null) {
+                return;
+            }
+            
+            if (term instanceof Variable) {
+                setFrame((Variable) term);
+            } else if (term instanceof BuiltinMap) {
+                BuiltinMap map = (BuiltinMap) term;
+                putAll(map.entries);
+                if (map.frame != null) {
+                    setFrame(map.frame);
+                }
+            } else {
+                assert false : "The concatenated term must be a Variable or BuiltinMap; found: " + term;
+            }
+        }
+        
+        public BuiltinMap build() {
+            Preconditions.checkArgument(!done, "Only one BuiltinMap can be built from a builder.");
+            done = true;
+            // YilongL: Guava's ImmutableMap.copyOf(entries) is not smart enough
+            // to avoid actually copying the entries, because entries is not an
+            // ImmutableMap yet; using Apache's decorate method because it would
+            // avoid creating nesting wrappers
+            return new BuiltinMap((UnmodifiableMap<Term, Term>) UnmodifiableMap.decorate(entries), frame);
+        }
     }
 }

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/BuiltinMap.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/BuiltinMap.java
@@ -168,7 +168,7 @@ public class BuiltinMap extends Collection implements Iterable<Map.Entry<Term, T
         public void putAll(Map<Term, Term> map) {
             Preconditions.checkArgument(!setEntries, "Cannot put in new key-value pair once the entries are set.");
             for (Map.Entry<Term, Term> e : map.entrySet()) {
-                entries.put(e.getKey(), e.getValue());
+                this.put(e.getKey(), e.getValue());
             }
         }
         

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/ConstrainedTerm.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/ConstrainedTerm.java
@@ -357,7 +357,7 @@ public class ConstrainedTerm extends JavaSymbolicObject {
                             for (Map.Entry<Variable, Term> entry : cnstr.substitution().entrySet())
                                 templCnstr.add(entry.getKey(), entry.getValue());
 
-                            for (Map.Entry<Term, Term> mapItem : map.getEntries().entrySet()) {
+                            for (Map.Entry<Term, Term> mapItem : map) {
                                 UninterpretedConstraint uninterpretedCnstr = templCnstr.deepCopy();
                                 uninterpretedCnstr.add(key, mapItem.getKey());
                                 uninterpretedCnstrs.add(uninterpretedCnstr);

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/MapUpdate.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/MapUpdate.java
@@ -46,29 +46,29 @@ public class MapUpdate extends Term implements DataStructureUpdate {
         if (!(map instanceof BuiltinMap)) {
             return this;
         }
-
         BuiltinMap builtinMap = ((BuiltinMap) map);
 
-        Map<Term, Term> entries = new HashMap<Term, Term>(builtinMap.getEntries());
+        BuiltinMap.Builder builder = BuiltinMap.builder();
+        builder.putAll(builtinMap.getEntries());
         Set<Term> keysToRemove = new HashSet<Term>();
         for (Iterator<Term> iterator = removeSet.iterator(); iterator.hasNext();) {
             Term nextKey = iterator.next();
-            if (entries.remove(nextKey) != null) {
+            if (builder.remove(nextKey) != null) {
                 keysToRemove.add(nextKey);
             }
         }
 
         if (removeSet.size() > keysToRemove.size()) {
+            // TODO(YilongL): why not return Bottom when there is no frame
             return new MapUpdate(builtinMap, Sets.difference(removeSet, keysToRemove), updateMap);
         }
 
-        entries.putAll(updateMap);
+        builder.putAll(updateMap);
 
         if (builtinMap.hasFrame()) {
-            return new BuiltinMap(entries, builtinMap.frame());
-        } else {
-            return new BuiltinMap(entries);
+            builder.setFrame(builtinMap.frame());
         }
+        return builder.build();
     }
 
     public Term map() {

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/BottomUpVisitor.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/BottomUpVisitor.java
@@ -38,7 +38,7 @@ public class BottomUpVisitor implements Visitor {
 
     @Override
     public void visit(BuiltinMap builtinMap) {
-        for (java.util.Map.Entry<Term, Term> entry : builtinMap.getEntries().entrySet()) {
+        for (java.util.Map.Entry<Term, Term> entry : builtinMap) {
             entry.getKey().accept(this);
             entry.getValue().accept(this);
         }

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/CopyOnWriteTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/CopyOnWriteTransformer.java
@@ -388,7 +388,7 @@ public class CopyOnWriteTransformer implements Transformer {
                 if (!changed) {
                     // the only change is the frame
                     changed = true;
-                    builder.setEntries(builtinMap.getEntries());
+                    builder.setEntriesAs(builtinMap);
                 }
                 builder.concat(transformedFrame);
             } else {

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/CopyOnWriteTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/CopyOnWriteTransformer.java
@@ -355,42 +355,52 @@ public class CopyOnWriteTransformer implements Transformer {
 
     @Override
     public ASTNode transform(BuiltinMap builtinMap) {
-        BuiltinMap transformedMap = null;
-        if (builtinMap.hasFrame()) {
-            Term frame = (Term) builtinMap.frame().accept(this);
-            if (frame != builtinMap.frame()) {
-                transformedMap = BuiltinMap.of(Collections.<Term, Term>emptyMap(), frame);
-            }
-        }
-
-        for(Map.Entry<Term, Term> entry : builtinMap.getEntries().entrySet()) {
+        boolean changed = false;
+        BuiltinMap.Builder builder = BuiltinMap.builder();
+        
+        for (Map.Entry<Term, Term> entry : builtinMap) {
             Term key = (Term) entry.getKey().accept(this);
             Term value = (Term) entry.getValue().accept(this);
-
-            if (transformedMap == null && (key != entry.getKey() || value != entry.getValue())) {
-                if (builtinMap.hasFrame()) {
-                    transformedMap = new BuiltinMap(builtinMap.frame());
-                } else {
-                    transformedMap = new BuiltinMap();
-                }
-                for(Map.Entry<Term, Term> copyEntry : builtinMap.getEntries().entrySet()) {
-                    if (copyEntry.equals(entry)) {
+            
+            // first time encounter a changed entry
+            if (!changed && (key != entry.getKey() || value != entry.getValue())) {
+                changed = true;
+                // copy previous entries into the BuiltinMap being built
+                for (Map.Entry<Term, Term> copy : builtinMap) {
+                    if (copy.equals(entry)) {
+                        // cannot rely on reference identity check here
                         break;
                     }
-                    transformedMap.put(copyEntry.getKey(), copyEntry.getValue());
+                    builder.put(copy.getKey(), copy.getValue());
                 }
             }
-
-            if (transformedMap != null) {
-                transformedMap.put(key, value);
+            
+            if (changed) {
+                builder.put(key, value);
             }
         }
-
-        if (transformedMap != null) {
-            return transformedMap;
+        
+        // at this point, if changed is false, the BuiltinMap being built is still empty
+        if (builtinMap.hasFrame()) {
+            Variable oldFrame = builtinMap.frame();
+            Term transformedFrame = (Term) oldFrame.accept(this);
+            if (transformedFrame != oldFrame) {
+                if (!changed) {
+                    // the only change is the frame
+                    changed = true;
+                    builder.setEntries(builtinMap.getEntries());
+                }
+                builder.concat(transformedFrame);
+            } else {
+                builder.setFrame(oldFrame);
+            }
         } else {
-            return builtinMap;
+            // do nothing; if changed == true then all entries are already
+            // copied; if changed == false then we will simply return the
+            // original map later
         }
+        
+        return changed ? builder.build() : builtinMap;
     }
 
     @Override

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/KILtoBackendJavaKILTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/KILtoBackendJavaKILTransformer.java
@@ -431,7 +431,6 @@ public class KILtoBackendJavaKILTransformer extends CopyOnWriteTransformer {
                 node.elements().entrySet()) {
             Term key = (Term) this.visitNode(entry.getKey());
             Term value = (Term) this.visitNode(entry.getValue());
-//            entries.(key, value);
             builder.put(key, value);
         }
 

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/KILtoBackendJavaKILTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/KILtoBackendJavaKILTransformer.java
@@ -426,12 +426,13 @@ public class KILtoBackendJavaKILTransformer extends CopyOnWriteTransformer {
 
     @Override
     public ASTNode visit(org.kframework.kil.MapBuiltin node, Void _)  {
-        HashMap<Term, Term> entries = new HashMap<Term, Term>(node.elements().size());
+        BuiltinMap.Builder builder = BuiltinMap.builder();
         for (Map.Entry<org.kframework.kil.Term, org.kframework.kil.Term> entry :
                 node.elements().entrySet()) {
             Term key = (Term) this.visitNode(entry.getKey());
             Term value = (Term) this.visitNode(entry.getValue());
-            entries.put(key, value);
+//            entries.(key, value);
+            builder.put(key, value);
         }
 
         if (node.isLHSView()) {
@@ -440,21 +441,22 @@ public class KILtoBackendJavaKILTransformer extends CopyOnWriteTransformer {
                 if (base instanceof MapUpdate) {
                     MapUpdate mapUpdate = (MapUpdate) base;
                     /* TODO(AndreiS): check key uniqueness */
-                    entries.putAll(mapUpdate.updateMap());
-                    return new MapUpdate(mapUpdate.map(), mapUpdate.removeSet(), entries);
+                    builder.putAll(mapUpdate.updateMap());
+                    return new MapUpdate(mapUpdate.map(), mapUpdate.removeSet(), builder.getEntries());
                 } else {
                     /* base instanceof Variable */
-                    return new BuiltinMap(entries, (Variable) base);
+                    builder.setFrame((Variable) base);
+                    return builder.build();
                 }
             } else {
-                return new BuiltinMap(entries);
+                return builder.build();
             }
         } else {
             ArrayList<Term> baseTerms = new ArrayList<>(node.baseTerms().size());
             for (org.kframework.kil.Term term : node.baseTerms()) {
                 baseTerms.add((Term) this.visitNode(term));
             }
-            baseTerms.add(new BuiltinMap(entries));
+            baseTerms.add(builder.build());
 
             Term result = baseTerms.get(0);
             for (int i = 1; i < baseTerms.size(); ++i) {
@@ -474,7 +476,7 @@ public class KILtoBackendJavaKILTransformer extends CopyOnWriteTransformer {
 //        for(org.kframework.kil.Term term: node.getContents()){
 //           Term backendTerm = this.transformTerm(term,this.definition);
 //        }
-        return new BuiltinMap();
+        return BuiltinMap.EMPTY_MAP;
     }
 
     @Override

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/PrePostVisitor.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/PrePostVisitor.java
@@ -43,7 +43,7 @@ public class PrePostVisitor implements Visitor {
         preVisitor.resetProceed();
         builtinMap.accept(preVisitor);
         if (!preVisitor.isProceed()) return;
-        for (Map.Entry<Term, Term> entry : builtinMap.getEntries().entrySet()) {
+        for (Map.Entry<Term, Term> entry : builtinMap) {
             entry.getKey().accept(this);
             entry.getValue().accept(this);
         }

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/UseSMT.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/UseSMT.java
@@ -35,7 +35,7 @@ public class UseSMT implements Serializable {
             return null;
         }
 
-        BuiltinMap result = new BuiltinMap();   
+        BuiltinMap.Builder resultBuilder = BuiltinMap.builder();
         try {
             com.microsoft.z3.Context context = new com.microsoft.z3.Context();
             KILtoZ3 transformer = new KILtoZ3(Collections.<Variable>emptySet(), context);
@@ -46,8 +46,6 @@ public class UseSMT implements Serializable {
             
             
             if(solver.Check() == Status.SATISFIABLE){
-                
-                Map<Term,Term> entries = new HashMap<Term,Term>();
                 
                 Model model = solver.Model();
                 FuncDecl[] consts = model.ConstDecls();
@@ -60,7 +58,7 @@ public class UseSMT implements Serializable {
                     
                     IntToken avalue = IntToken.of(Integer.parseInt(resultFrg.toString()));
                     
-                    result.put((Term)akey,(Term)avalue);
+                    resultBuilder.put((Term)akey, (Term)avalue);
                 }
                 
                 
@@ -72,6 +70,6 @@ public class UseSMT implements Serializable {
             // TODO(AndreiS): fix this translation and the exceptions
             e.printStackTrace();
         }
-        return result;
+        return resultBuilder.build();
     }
 }


### PR DESCRIPTION
@andreistefanescu @dwightguth please review.

1) Use builder pattern to avoid unnecessary defensive-copying in both the `transform` methods and `BuiltinMap` constructors;
2) Make `BuiltinMap` immutable.

P.S.
I made a stupid mistake in profiling the rewrite engine when I tried to use persistent map for `BuiltinMap` in https://github.com/kframework/k/pull/531. The performance is actually worse (5~10% slower) since there are usually a lots of lookups and very few updates. The speedup of update by persistent data structure doesn't out-weigh the slowdown of lookup (even with reasonably large `store` cell). Therefore, the use of persistent data structure only makes sense for `KSequence` and, maybe, `KList`, whose structures change very frequently.
