### PR TITLE
Cleanup k item constructor

### DIFF
--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinIOOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinIOOperations.java
@@ -131,6 +131,6 @@ public class BuiltinIOOperations {
         Definition def = context.definition();
         KLabelConstant klabel = KLabelConstant.of(klabelString, context.definition());
         assert def.kLabels().contains(klabel) : "No KLabel in definition for errno '" + errno + "'";
-        return new KItem(klabel, KList.EMPTY, context);
+        return KItem.of(klabel, KList.EMPTY, context);
     }
 }

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinVisitorOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/BuiltinVisitorOperations.java
@@ -9,8 +9,6 @@ import org.kframework.kil.ASTNode;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.common.collect.ImmutableList;
-
 
 /**
  * Provides a builtin implementation of a K visitor.
@@ -68,7 +66,7 @@ public class BuiltinVisitorOperations extends PrePostTransformer {
 
     private Term visitNode(Term term) {
         visitParams.set(0, term);
-        term = new KItem(
+        term = KItem.of(
                 visitLabel,
                 new KList(visitParams),
                 context);
@@ -77,7 +75,7 @@ public class BuiltinVisitorOperations extends PrePostTransformer {
 
     private boolean evaluateGuard(Term term) {
         ifParams.set(0, term);
-        KItem test = new KItem(
+        KItem test = KItem.of(
                 ifLabel,
                 new KList(ifParams),
                 context);

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/FreshOperations.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/FreshOperations.java
@@ -30,7 +30,7 @@ public class FreshOperations {
             throw new UnsupportedOperationException();
         }
 
-        KItem freshFunction = new KItem(
+        KItem freshFunction = KItem.of(
                 KLabelConstant.of(name, context.definition()),
                 new KList(Lists.newArrayList((Term) IntToken.of(context.incrementCounter()))),
                 context);

--- a/src/javasources/KTool/src/org/kframework/backend/java/builtins/MetaK.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/builtins/MetaK.java
@@ -15,9 +15,7 @@ import org.kframework.backend.java.symbolic.SymbolicConstraint;
 import org.kframework.backend.java.symbolic.SymbolicUnifier;
 import org.kframework.backend.java.symbolic.UnificationFailure;
 
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 
@@ -170,6 +168,6 @@ public class MetaK {
      */
     public static KItem getKLabel(KItem kItem, TermContext context) {
         // TODO(AndreiS): handle KLabel variables
-        return new KItem(new KLabelInjection(kItem.kLabel()), KList.EMPTY, context);
+        return KItem.of(new KLabelInjection(kItem.kLabel()), KList.EMPTY, context);
     }
 }

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/Definition.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/Definition.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 
@@ -40,9 +41,9 @@ public class Definition extends JavaSymbolicObject {
     private final List<Rule> rules;
     private final List<Rule> macros;
     private final Multimap<KLabelConstant, Rule> functionRules = ArrayListMultimap.create();
+    private final Multimap<KLabelConstant, Rule> sortPredicateRules = HashMultimap.create();
     private final Set<KLabelConstant> kLabels;
     private final Set<KLabelConstant> frozenKLabels;
-    private final Set<KLabelConstant> sortPredLabels;
     private final Context context;
     private RuleIndex index;
 
@@ -52,7 +53,6 @@ public class Definition extends JavaSymbolicObject {
         macros = new ArrayList<Rule>();
         kLabels = new HashSet<KLabelConstant>();
         frozenKLabels = new HashSet<KLabelConstant>();
-        sortPredLabels = new HashSet<KLabelConstant>();
     }
 
     public void addFrozenKLabel(KLabelConstant frozenKLabel) {
@@ -79,7 +79,7 @@ public class Definition extends JavaSymbolicObject {
         if (rule.containsAttribute(Attribute.FUNCTION_KEY)) {
             functionRules.put(rule.functionKLabel(), rule);
             if (rule.isSortPredicate()) {
-                sortPredLabels.add(rule.functionKLabel());
+                sortPredicateRules.put((KLabelConstant) rule.sortPredicateArgument().kLabel(), rule);                
             }
         } else if (rule.containsAttribute(Attribute.MACRO_KEY)) {
             macros.add(rule);
@@ -105,6 +105,13 @@ public class Definition extends JavaSymbolicObject {
     public Multimap<KLabelConstant, Rule> functionRules() {
         return functionRules;
     }
+    
+    public Collection<Rule> sortPredicateRulesOn(KLabelConstant kLabel) {
+        if (sortPredicateRules.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return sortPredicateRules.get(kLabel);
+    }
 
     public Set<KLabelConstant> frozenKLabels() {
         return frozenKLabels;
@@ -114,10 +121,6 @@ public class Definition extends JavaSymbolicObject {
         return Collections.unmodifiableSet(kLabels);
     }
     
-    public Set<KLabelConstant> sortPredLabels() {
-        return sortPredLabels;
-    }
-
     public List<Rule> macros() {
         // TODO(AndreiS): fix this issue with modifiable collections
         //return Collections.unmodifiableList(macros);

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/KItem.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/KItem.java
@@ -1,10 +1,16 @@
 // Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.kil;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.kframework.backend.java.builtins.BoolToken;
 import org.kframework.backend.java.builtins.MetaK;
 import org.kframework.backend.java.builtins.SortMembership;
-import org.kframework.backend.java.symbolic.BuiltinFunction;
 import org.kframework.backend.java.symbolic.Matcher;
 import org.kframework.backend.java.symbolic.PatternMatcher;
 import org.kframework.backend.java.symbolic.SymbolicConstraint;
@@ -17,15 +23,6 @@ import org.kframework.kil.Production;
 import org.kframework.kil.loader.Context;
 import org.kframework.krun.K;
 import org.kframework.utils.errorsystem.KExceptionManager;
-
-import java.lang.reflect.InvocationTargetException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import com.google.common.collect.Sets;
 
@@ -47,6 +44,9 @@ import com.google.common.collect.Sets;
  */
 @SuppressWarnings("serial")
 public final class KItem extends Term {
+    
+    private static KItem LIST_TERMINATOR = new KItem(KLabelConstant.of("'.List{\",\"}", null), 
+            KList.EMPTY, "#ListOf#Bot{\",\"}", true);
 
     private final Term kLabel;
     private final Term kList;
@@ -54,15 +54,25 @@ public final class KItem extends Term {
     private final String sort;
     private Boolean evaluable = null;
 
-    /**
-     * Valid only if {@code kLabel} is a constructor. Must contain a sort
-     * which is subsorted or equal to {@code sort} when it is valid.
-     */
-    private final Set<String> possibleMinimalSorts;
-
-    public KItem(Term kLabel, Term kList, TermContext termContext) {
+    public static KItem of(Term kLabel, Term kList, TermContext termContext) {
+        if (kLabel.equals(LIST_TERMINATOR.kLabel())) {
+            assert kList.equals(KList.EMPTY);
+            return LIST_TERMINATOR;
+        }
+        
+        return new KItem(kLabel, kList, termContext);
+    }
+    
+    private KItem(Term kLabel, Term kList, String sort, boolean isExactSort) {
         super(Kind.KITEM);
-
+        this.kLabel = kLabel;
+        this.kList = kList;
+        this.sort = sort;
+        this.isExactSort = isExactSort;
+    }
+    
+    private KItem(Term kLabel, Term kList, TermContext termContext) {
+        super(Kind.KITEM);
         this.kLabel = kLabel;
         this.kList = kList;
 
@@ -72,9 +82,10 @@ public final class KItem extends Term {
         if (kLabel instanceof KLabelConstant && kList instanceof KList
                 && !((KList) kList).hasFrame()) {
             KLabelConstant kLabelConstant = (KLabelConstant) kLabel;
-
-            Set<String> sorts = new HashSet<>();
-            Set<String> possibleMinimalSorts = new HashSet<>();
+            List<Production> productions = kLabelConstant.productions();
+            
+            Set<String> sorts = Sets.newHashSet();
+            Set<String> possibleSorts = Sets.newHashSet();
 
             if (!K.do_kompilation) {
                 /**
@@ -87,129 +98,96 @@ public final class KItem extends Term {
                  * which are not allowed to write in the current front-end.
                  */
                 /* YilongL: user-defined sort predicate rules are interpreted as overloaded productions at runtime */
-                for (KLabelConstant sortPredLabel : definition.sortPredLabels()) {
-                    Collection<Rule> rules = definition.functionRules().get(sortPredLabel);
-                    for (Rule rule : rules) {
-                        KItem predArg = rule.getSortPredArgument();
-                        if (MetaK.matchable(kLabel, predArg.kLabel(), termContext).equals(BoolToken.TRUE)
-                                && MetaK.matchable(kList, predArg.kList(), termContext).equals(BoolToken.TRUE)) {
-                            sorts.add(rule.getPredSort());
-                            if (kLabelConstant.isConstructor()) {
-                                possibleMinimalSorts.add(rule.getPredSort());
-                            }
-                        } else if (MetaK.matchable(kLabel, predArg.kLabel(), termContext).equals(BoolToken.TRUE)
-                                && MetaK.unifiable(kList, predArg.kList(), termContext).equals(BoolToken.TRUE)) {
-                            if (kLabelConstant.isConstructor()) {
-                                possibleMinimalSorts.add(rule.getPredSort());
-                            }
-                        }
+                for (Rule rule : definition.sortPredicateRulesOn(kLabelConstant)) {
+                    if (MetaK.matchable(kList,rule.sortPredicateArgument().kList(), termContext)
+                            .equals(BoolToken.TRUE)) {
+                        sorts.add(rule.predicateSort());
+                    } else if (MetaK.unifiable(kList,rule.sortPredicateArgument().kList(), termContext)
+                            .equals(BoolToken.TRUE)) {
+                        possibleSorts.add(rule.predicateSort());
                     }
                 }
             }
 
-            List<Production> productions = kLabelConstant.productions();
-            if (productions.size() != 0) {
-                for (Production production : productions) {
-                    boolean mustMatch = true;
-                    boolean mayMatch = true;
-
+            for (Production production : productions) {
+                boolean mustMatch = true;
+                boolean mayMatch = true;
+                
+                if (((KList) kList).size() == production.getArity()) {
                     /* check if the production can match this KItem */
-                    // TODO(YilongL): I guess the only point of this check is to
-                    // distinguish between overloaded productions, however, once
-                    // we have passed the front-end the arguments of a K label
-                    // can violate its original declaration, therefore the code
-                    // below would need to be revised
-                    if (((KList) kList).size() == production.getArity()) {
-                        for (int i = 0; i < ((KList) kList).size(); ++i) {
-                            String childSort;
-                            Term childTerm = ((KList) kList).get(i);
-                            /* extract the real injected term when necessary */
-                            if (childTerm instanceof KItem){
-                                KItem kItem = (KItem) childTerm;
-                                if (isInjectionWrapper(kItem)) {
-                                    childTerm = extractInjectedTerm(kItem);
-                                }
-                            }
-                            childSort = childTerm.sort();
-
-                            if (!context.isSubsortedEq(production.getChildSort(i), childSort)) {
-                                mustMatch = false;
-
-                                if (kLabelConstant.isConstructor()) {
-                                    if (childTerm instanceof Variable) {
-                                        Set<String> set = Sets.newHashSet(production.getChildSort(i), childTerm.sort());
-                                        if (context.getCommonSubsorts(set).isEmpty()) {
-                                            mayMatch = false;
-                                        }
-                                    } else if (childTerm instanceof KItem) {
-                                        mayMatch = false;
-                                        if (((KItem) childTerm).possibleMinimalSorts() != null) {
-                                            for (String pms : ((KItem) childTerm).possibleMinimalSorts()) {
-                                                if (context.isSubsortedEq(production.getChildSort(i), pms)) {
-                                                    mayMatch = true;
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                    } else { // e.g., childTerm is a HOLE
-                                        mayMatch = false;
-                                    }
-
-                                    if (!mayMatch) {
-                                        // mayMatch == false => mustMatch == false
-                                        break;
-                                    }
-                                }
+                    int idx = 0;
+                    for (Term term : (KList) kList) {
+                        if (!mayMatch) {
+                            break;
+                        }
+    
+                        /* extract the actual term in case it's injected in klabel */
+                        if (term instanceof KItem){
+                            KItem kItem = (KItem) term;
+                            if (kItem.kLabel instanceof KLabelInjection) {
+                                term = ((KLabelInjection) kItem.kLabel).term();
                             }
                         }
+                        String childSort = term.sort();
+    
+                        if (!context.isSubsortedEq(production.getChildSort(idx), childSort)) {
+                            mustMatch = false;
+                            /*
+                             * YilongL: the following analysis can be made more
+                             * precise by considering all possible sorts of the
+                             * term; however, it would be too expensive to
+                             * compute for our purpose
+                             */
+                            mayMatch = !term.isExactSort()
+                                    && context.hasCommonSubsort(production.getChildSort(idx), childSort);
+                        }
+                        idx++;
                     }
-
-                    if (mustMatch) {
-                        sorts.add(production.getSort());
-                    }
-
-                    if (mayMatch && kLabelConstant.isConstructor()) {
-                        possibleMinimalSorts.add(production.getSort());
-                    }
+                } else {
+                    mustMatch = mayMatch = false;
                 }
-            } else {    /* productions.size() == 0 */
-                /* a list terminator does not have conses */
-                Set<String> listSorts = context.listLabels.get(kLabelConstant.label());
-                if (listSorts != null && ((KList) kList).size() == 0) {
-                    sorts.addAll(listSorts);
+
+                if (mustMatch) {
+                    sorts.add(production.getSort());
+                } else if (mayMatch) {
+                    possibleSorts.add(production.getSort());
                 }
             }
+            // YilongL: the following is not needed because LIST_TERMINATOR is cached
+//            else {    /* productions.size() == 0 */
+//                /* a list terminator does not have conses */
+//                Set<String> listSorts = context.listLabels.get(((KLabelConstant) LIST_TERMINATOR.kLabel).label());
+//                if (listSorts != null) {
+//                    sorts.addAll(listSorts);
+//                }
+//            }
 
             /* no production matches this KItem */
             if (sorts.isEmpty()) {
                 sorts.add(kind.toString());
             }
 
-            sort = context.getGLBSort(sorts);
+            /*
+             * YilongL: we are taking the GLB of all sorts because it is the
+             * most precise sort information we can get without losing
+             * information. e.g. sorts = [Types, #ListOfId{","}, Exps] => sort =
+             * #ListOfId{","}. On the other hand, if the GLB doesn't exist, then
+             * we must have an ambiguous grammar with which this KItem cannot be
+             * correctly parsed.
+             */
+            sort = sorts.size() == 1 ? sorts.iterator().next() : context.getGLBSort(sorts);
             assert sort != null && !sort.equals("null"):
                     "The greatest lower bound (GLB) of sorts " + sorts + "doesn't exist!";
-            /* this sort is exact if the KLabel is a constructor and there are no possible smaller sorts */
-            isExactSort = kLabelConstant.isConstructor() && sorts.containsAll(possibleMinimalSorts);
-
-            if (kLabelConstant.isConstructor()) {
-                possibleMinimalSorts.add(sort);
-                Set<String> nonMinimalSorts = new HashSet<String>();
-                for (String s1 : possibleMinimalSorts) {
-                    for (String s2 : possibleMinimalSorts) {
-                        if (context.isSubsorted(s1, s2)) {
-                            nonMinimalSorts.add(s1);
-                        }
-                    }
-                }
-                possibleMinimalSorts.removeAll(nonMinimalSorts);
-                this.possibleMinimalSorts = possibleMinimalSorts;
-            } else {
-                this.possibleMinimalSorts = null;
+            /* the sort is exact iff the klabel is a constructor and there is no other possible sort */
+            isExactSort = kLabelConstant.isConstructor() && possibleSorts.isEmpty();
+        } else {    
+            /* not a KLabelConstant or the kList contains a frame variable */
+            if (kLabel instanceof KLabelInjection) {
+                assert kList.equals(KList.EMPTY);
             }
-        } else {    /* not a KLabelConstant or the kList contains a frame variable */
+            
             sort = kind.toString();
             isExactSort = false;
-            possibleMinimalSorts = null;
         }
     }
 
@@ -432,11 +410,8 @@ public final class KItem extends Term {
      *         otherwise, null;
      */
     public Set<String> possibleMinimalSorts() {
-        if (possibleMinimalSorts != null) {
-            return Collections.unmodifiableSet(possibleMinimalSorts);
-        } else {
-            return null;
-        }
+        // TODO(YilongL): reconsider the use of this method when doing test generation
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -485,32 +460,6 @@ public final class KItem extends Term {
     @Override
     public ASTNode accept(Transformer transformer) {
         return transformer.transform(this);
-    }
-
-    /**
-     * Checks if the specified KItem is merely used as a wrapper for a non-K
-     * term.
-     *
-     * @param kItem
-     *            the specified KItem
-     * @return {@code true} if the specified KItem is an injection wrapper;
-     *         otherwise, {@code false}
-     */
-    public static boolean isInjectionWrapper(KItem kItem) {
-        return kItem.kLabel.getClass() == KLabelInjection.class && kItem.kList instanceof KList
-                && ((KList) kItem.kList).getContents().isEmpty();
-    }
-
-    /**
-     * Extracts the injected non-K term inside the specified KItem.
-     *
-     * @param kItem
-     *            the specified KItem
-     * @return the injected term
-     */
-    public static Term extractInjectedTerm(KItem kItem) {
-        assert isInjectionWrapper(kItem);
-        return ((KLabelInjection) kItem.kLabel).term();
     }
 
 }

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/KLabelConstant.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/KLabelConstant.java
@@ -41,7 +41,9 @@ public class KLabelConstant extends KLabel {
 
     private KLabelConstant(String label, Definition definition) {
         this.label = label;
-        productions = ImmutableList.copyOf(definition.context().productionsOf(label));
+        productions = definition != null ?
+                ImmutableList.<Production>copyOf(definition.context().productionsOf(label)) : 
+                ImmutableList.<Production>of();
         
         // TODO(YilongL): urgent; how to detect KLabel clash?
 

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/KLabelInjection.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/KLabelInjection.java
@@ -20,7 +20,7 @@ public class KLabelInjection extends KLabel {
      * Returns an injection of the term into a {@link org.kframework.backend.java.kil.KItem}.
      */
     public static KItem injectionOf(Term term, TermContext context) {
-        return new KItem(new KLabelInjection(term), KList.EMPTY, context);
+        return KItem.of(new KLabelInjection(term), KList.EMPTY, context);
     }
 
     private final Term term;

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/Rule.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/Rule.java
@@ -178,7 +178,7 @@ public class Rule extends JavaSymbolicObject {
     /**
      * Gets the predicate sort if this rule is a sort predicate rule.
      */
-    public String getPredSort() {
+    public String predicateSort() {
         assert isSortPredicate;
         
         return predSort;
@@ -187,7 +187,7 @@ public class Rule extends JavaSymbolicObject {
     /**
      * Gets the argument of the sort predicate if this rule is a sort predicate rule. 
      */
-    public KItem getSortPredArgument() {
+    public KItem sortPredicateArgument() {
         assert isSortPredicate;
 
         return sortPredArg;

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/BinderSubstitutionTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/BinderSubstitutionTransformer.java
@@ -56,7 +56,7 @@ public class BinderSubstitutionTransformer extends SubstitutionTransformer {
                         Term freshBoundVars = boundVars.substitute(freshSubstitution, context);
                         Term freshbindingExp = bindingExp.substitute(freshSubstitution, context);
                         kList = new KList(ImmutableList.<Term>of(freshBoundVars,freshbindingExp));
-                        kItem = new KItem(kLabel, kList, context);
+                        kItem = KItem.of(kLabel, kList, context);
 //                    }
                 }
             }

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/CopyOnWriteTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/CopyOnWriteTransformer.java
@@ -154,7 +154,7 @@ public class CopyOnWriteTransformer implements Transformer {
         Term kLabel = (Term) kItem.kLabel().accept(this);
         Term kList = (Term) kItem.kList().accept(this);
         if (kLabel != kItem.kLabel() || kList != kItem.kList()) {
-            kItem = new KItem(kLabel, kList, context);
+            kItem = KItem.of(kLabel, kList, context);
         }
         return kItem;
     }

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/KILtoBackendJavaKILTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/KILtoBackendJavaKILTransformer.java
@@ -167,7 +167,7 @@ public class KILtoBackendJavaKILTransformer extends CopyOnWriteTransformer {
         if (kList instanceof Variable) {
             kList = new KList((Variable) kList);
         }
-        return new KItem(kLabel, kList, TermContext.of(globalContext));
+        return KItem.of(kLabel, kList, TermContext.of(globalContext));
     }
     
     @Override
@@ -377,7 +377,7 @@ public class KILtoBackendJavaKILTransformer extends CopyOnWriteTransformer {
                             new ArrayList<Term>(),
                             elementsRight));
                     for (Term baseTerm : baseTerms) {
-                        result = new KItem(
+                        result = KItem.of(
                                 KLabelConstant.of(DataStructureSort.DEFAULT_LIST_LABEL, definition),
                                 new KList(ImmutableList.of(result, baseTerm)),
                                 TermContext.of(globalContext));
@@ -420,7 +420,7 @@ public class KILtoBackendJavaKILTransformer extends CopyOnWriteTransformer {
 
             Term result = baseTerms.get(0);
             for (int i = 1; i < baseTerms.size(); ++i) {
-                result = new KItem(
+                result = KItem.of(
                         KLabelConstant.of(DataStructureSort.DEFAULT_SET_LABEL, definition),
                         new KList(ImmutableList.of(result, baseTerms.get(i))),
                         TermContext.of(globalContext));
@@ -464,7 +464,7 @@ public class KILtoBackendJavaKILTransformer extends CopyOnWriteTransformer {
 
             Term result = baseTerms.get(0);
             for (int i = 1; i < baseTerms.size(); ++i) {
-                result = new KItem(
+                result = KItem.of(
                         KLabelConstant.of(DataStructureSort.DEFAULT_MAP_LABEL, definition),
                         new KList(ImmutableList.of(result, baseTerms.get(i))),
                         TermContext.of(globalContext));

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicConstraint.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicConstraint.java
@@ -26,7 +26,6 @@ import org.kframework.backend.java.util.GappaServer;
 import org.kframework.backend.java.util.Utils;
 import org.kframework.backend.java.util.Z3Wrapper;
 import org.kframework.kil.ASTNode;
-import org.kframework.kil.visitors.exceptions.ParseFailedException;
 import org.kframework.krun.K;
 
 import java.util.ArrayList;
@@ -269,9 +268,9 @@ public class SymbolicConstraint extends JavaSymbolicObject {
                     }
                     return true;
                 } else {
-                    return definition.context().getCommonSubsorts(ImmutableSet.<String>of(
+                    return definition.context().hasCommonSubsort(
                         (leftHandSide).sort(),
-                        (rightHandSide).sort())).isEmpty();
+                        (rightHandSide).sort());
                 }
             }
         }

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -21,8 +21,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.kframework.backend.java.builtins.FreshOperations;
-import org.kframework.backend.java.builtins.IntToken;
-import org.kframework.backend.java.builtins.StringToken;
 import org.kframework.backend.java.indexing.Index;
 import org.kframework.backend.java.indexing.IndexingPair;
 import org.kframework.backend.java.indexing.RuleIndex;

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/UserSubstitutionTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/UserSubstitutionTransformer.java
@@ -2,17 +2,13 @@
 package org.kframework.backend.java.symbolic;
 
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
-import org.kframework.backend.java.builtins.BuiltinSubstitutionOperations;
 import org.kframework.backend.java.builtins.FreshOperations;
 import org.kframework.backend.java.kil.*;
 import org.kframework.backend.java.kil.KLabel;
 import org.kframework.backend.java.kil.KLabelConstant;
-import org.kframework.backend.java.kil.KLabelInjection;
 import org.kframework.backend.java.kil.KList;
-import org.kframework.backend.java.kil.KSequence;
 import org.kframework.backend.java.kil.Term;
 import org.kframework.kil.*;
 
@@ -119,7 +115,7 @@ public class UserSubstitutionTransformer extends PrePostTransformer {
                     }
 
                     kList = new KList(ImmutableList.copyOf(termList));
-                    kItem = new KItem(kLabel, kList, context);
+                    kItem = KItem.of(kLabel, kList, context);
                     return new DoneTransforming(kItem);
                 }
             }

--- a/src/javasources/KTool/src/org/kframework/backend/java/util/GappaPrinter.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/util/GappaPrinter.java
@@ -106,7 +106,7 @@ public class GappaPrinter extends BottomUpVisitor {
                         String newlabel = reverseComparisonOps.get(label);
                         if (newlabel != null) {
                             klabelCt = KLabelConstant.of(newlabel, constraint.termContext().definition());
-                            equalityLHS = new KItem(klabelCt, (KList) ((KItem) equalityLHS).kList(), constraint.termContext());
+                            equalityLHS = KItem.of(klabelCt, (KList) ((KItem) equalityLHS).kList(), constraint.termContext());
                             equalityRHS = BoolToken.TRUE;
                         }
                     }

--- a/src/javasources/KTool/src/org/kframework/backend/java/util/GroupProductionsBySort.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/util/GroupProductionsBySort.java
@@ -68,7 +68,7 @@ public class GroupProductionsBySort {
                 for (ProductionItem prodItem : prod.getItems())
                     if (prodItem instanceof Sort)
                         items.add(Variable.getFreshVariable(((Sort) prodItem).getName()));
-                KItem kitem = new KItem(klabelOfProd.get(prod), new KList(items), context);
+                KItem kitem = KItem.of(klabelOfProd.get(prod), new KList(items), context);
                 freshTerms.add(kitem);
             }
         }

--- a/src/javasources/KTool/src/org/kframework/backend/java/util/TestCaseGenerationUtil.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/util/TestCaseGenerationUtil.java
@@ -173,7 +173,7 @@ public class TestCaseGenerationUtil {
         // TODO(YilongL): This is cheating; fix it!
         switch (sort) {
         case "Block":
-            return new KItem(KLabelConstant.of("'{}", termContext.definition()), KList.EMPTY, termContext);
+            return KItem.of(KLabelConstant.of("'{}", termContext.definition()), KList.EMPTY, termContext);
             
         case "BExp":
             return BoolToken.TRUE;

--- a/src/javasources/KTool/src/org/kframework/compile/transformers/CompleteSortLatice.java
+++ b/src/javasources/KTool/src/org/kframework/compile/transformers/CompleteSortLatice.java
@@ -120,7 +120,7 @@ public class CompleteSortLatice extends CopyOnWriteTransformer {
             }
 
             // TODO(AndreiS): subsort queries should implement lazy subsort computation
-            context.finalizeSubsorts();
+            context.computeSubsortTransitiveClosure();
         } while (change);
 
         /*

--- a/src/javasources/KTool/src/org/kframework/kil/loader/CollectSubsortsVisitor.java
+++ b/src/javasources/KTool/src/org/kframework/kil/loader/CollectSubsortsVisitor.java
@@ -18,7 +18,7 @@ public class CollectSubsortsVisitor extends BasicVisitor {
 
     public Void visit(Definition def, Void _) {
         super.visit(def, _);
-        context.finalizeSubsorts();
+        context.computeSubsortTransitiveClosure();
         return null;
     }
 

--- a/src/javasources/KTool/src/org/kframework/kil/loader/Context.java
+++ b/src/javasources/KTool/src/org/kframework/kil/loader/Context.java
@@ -88,6 +88,7 @@ public class Context implements Serializable {
     public Map<String, String> cellSorts = new HashMap<String, String>();
     public Map<String, Production> listConses = new HashMap<String, Production>();
     public Map<String, Set<String>> listLabels = new HashMap<String, Set<String>>();
+    public Map<String, String> listLabelSeparator = new HashMap<>();
     public Map<String, ASTNode> locations = new HashMap<String, ASTNode>();
     public Map<String, Set<Production>> associativity = new HashMap<String, Set<Production>>();
     
@@ -205,6 +206,7 @@ public class Context implements Serializable {
         String separator = ((UserList) p.getItems().get(0)).getSeparator();
         String label = MetaK.getListUnitLabel(separator);
         Set<String> s = listLabels.get(label);
+        listLabelSeparator.put(label, separator);
         if (s == null)
             listLabels.put(label, s = new HashSet<String>());
         s.add(p.getSort());

--- a/src/javasources/KTool/src/org/kframework/kil/loader/Context.java
+++ b/src/javasources/KTool/src/org/kframework/kil/loader/Context.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.kil.loader;
 
+import org.kframework.compile.transformers.CompleteSortLatice;
 import org.kframework.compile.utils.ConfigurationStructureMap;
 import org.kframework.compile.utils.MetaK;
 import org.kframework.kil.ASTNode;
@@ -39,6 +40,7 @@ import java.util.Set;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 
@@ -154,11 +156,12 @@ public class Context implements Serializable {
     }
 
     private void initSubsorts() {
-        subsorts.addRelation(KSorts.KLIST, "K");
-        subsorts.addRelation(KSorts.KLIST, "KResult");
-        subsorts.addRelation("K", "KResult");
-        subsorts.addRelation("K", KSorts.KITEM);
-        subsorts.addRelation("Bag", "BagItem");
+        subsorts.addElement(KSorts.KLABEL);
+        subsorts.addRelation(KSorts.KLIST, KSorts.K);
+        subsorts.addRelation(KSorts.KLIST, KSorts.KRESULT);
+        subsorts.addRelation(KSorts.K, KSorts.KRESULT);
+        subsorts.addRelation(KSorts.K, KSorts.KITEM);
+        subsorts.addRelation(KSorts.BAG, KSorts.BAG_ITEM);
     }
 
     // TODO(dwightguth): remove these fields and replace with injected dependencies
@@ -257,32 +260,78 @@ public class Context implements Serializable {
     }
 
     /**
-     * find the LUB of a list of sorts
+     * Finds the LUB (Least Upper Bound) of a given set of sorts.
+     * 
+     * @param sorts
+     *            the given set of sorts
+     * @return the sort which is the LUB of the given set of sorts on success;
+     *         otherwise {@code null}
      */
     public String getLUBSort(Set<String> sorts) {
         return subsorts.getLUB(sorts);
     }
     
+    /**
+     * Finds the LUB (Least Upper Bound) of a given set of sorts.
+     * 
+     * @param sorts
+     *            the given set of sorts
+     * @return the sort which is the LUB of the given set of sorts on success;
+     *         otherwise {@code null}
+     */
     public String getLUBSort(String... sorts) {
         return subsorts.getLUB(Sets.newHashSet(sorts));
     }
 
     /**
-     * find the GLB of a list of sorts
+     * Finds the GLB (Greatest Lower Bound) of a given set of sorts.
+     * 
+     * @param sorts
+     *            the given set of sorts
+     * @return the sort which is the GLB of the given set of sorts on success;
+     *         otherwise {@code null}
      */
     public String getGLBSort(Set<String> sorts) {
         return subsorts.getGLB(sorts);
     }
     
     /**
-     * Finds the most general common subsorts of a given set of sorts
+     * Finds the GLB (Greatest Lower Bound) of a given set of sorts.
      * 
      * @param sorts
      *            the given set of sorts
-     * @return an immutable set of the most general common subsorts
+     * @return the sort which is the GLB of the given set of sorts on success;
+     *         otherwise {@code null}
      */
-    public Set<String> getCommonSubsorts(Set<String> sorts) {
-        return subsorts.getMaximalLowerBounds(sorts);
+    public String getGLBSort(String... sorts) {
+        return subsorts.getGLB(Sets.newHashSet(sorts));
+    }
+    
+    /**
+     * Checks if there is any well-defined common subsort of a given set of
+     * sorts.
+     * 
+     * @param sorts
+     *            the given set of sorts
+     * @return {@code true} if there is at least one well-defined common
+     *         subsort; otherwise, {@code false}
+     */
+    public boolean hasCommonSubsort(String... sorts) {
+        Set<String> maximalLowerBounds = subsorts.getMaximalLowerBounds(Lists.newArrayList(sorts));
+        
+        if (maximalLowerBounds.isEmpty()) {
+            return false;
+        } else if (maximalLowerBounds.size() == 1) {
+            String sort = maximalLowerBounds.iterator().next();
+            /* checks if the only common subsort is undefined */
+            if (sort.equals(CompleteSortLatice.BOTTOM_SORT_NAME)
+                    || isListSort(sort)
+                    && getListElementSort(sort).equals(CompleteSortLatice.BOTTOM_SORT_NAME)) {
+                return false;
+            }
+        }
+        
+        return true;
     }
 
     public void addPriority(String bigPriority, String smallPriority) {
@@ -372,7 +421,11 @@ public class Context implements Serializable {
         subsorts.addRelation(bigSort, smallSort);
     }
 
-    public void finalizeSubsorts() {
+    /**
+     * Computes the transitive closure of the subsort relation to make it
+     * becomes a partial order set.
+     */
+    public void computeSubsortTransitiveClosure() {
         List<String> circuit = subsorts.checkForCycles();
         if (circuit != null) {
             String msg = "Circularity detected in subsorts: ";

--- a/src/javasources/KTool/src/org/kframework/utils/Poset.java
+++ b/src/javasources/KTool/src/org/kframework/utils/Poset.java
@@ -10,22 +10,40 @@ import java.util.List;
 import java.util.Set;
 import java.util.Stack;
 
+import org.apache.commons.collections15.set.UnmodifiableSet;
+import com.google.common.collect.ArrayTable;
+import com.google.common.collect.Table;
+
 public class Poset implements Serializable {
 
+    private boolean cacheEnabled = false;
+    
     private java.util.Set<Tuple> relations = new HashSet<Tuple>();
     private java.util.Set<String> elements = new HashSet<String>();
     
+    /**
+     * Cached the query of maximal lower bounds of any two elements in this
+     * {@code Poset}.
+     */
+    private Table<String, String, Set<String>> maximalLowerBounds;
+        
     /**
      * Returns a unmodifiable view of elements in this poset.
      */
     public java.util.Set<String> getElements() {
         return java.util.Collections.unmodifiableSet(elements);
     }
+    
+    public void addElement(String element) {
+        elements.add(element);
+        invalidateCache();
+    }
 
     public void addRelation(String big, String small) {
         relations.add(new Tuple(big, small));
         elements.add(big);
         elements.add(small);
+        invalidateCache();
     }
 
     public boolean isInRelation(String big, String small) {
@@ -116,11 +134,13 @@ public class Poset implements Serializable {
      * 
      */
     public String getGLB(Set<String> subset) {
-        if (subset == null || subset.size() == 0)
+        if (subset == null || subset.size() == 0) {
             return null;
-        if (subset.size() == 1)
+        }
+        if (subset.size() == 1) {
             return subset.iterator().next();
-        List<String> candidates = new ArrayList<String>();
+        }
+        List<String> lowerBounds = new ArrayList<String>();
         for (String elem : elements) {
             boolean isLTESubset = true;
             for (String subsetElem : subset) {
@@ -130,18 +150,36 @@ public class Poset implements Serializable {
                 }
             }
             if (isLTESubset) {
-                candidates.add(elem);
+                lowerBounds.add(elem);
             }
         }
-        if (candidates.size() == 0)
+        if (lowerBounds.size() == 0) {
             return null;
-        String glb = candidates.get(0);
-        for (int i = 1; i < candidates.size(); ++i) {
-            if (isInRelation(candidates.get(i), glb)) {
-                glb = candidates.get(i);
+        }
+        
+        String candidate = null;
+        for (String lowerBound : lowerBounds) {
+            if (candidate == null) {
+                candidate = lowerBound;
+            } else {
+                if (isInRelation(lowerBound, candidate)) {
+                    candidate = lowerBound;
+                } else if (!isInRelation(candidate, lowerBound)) {
+                    /* no relation between lowerBound and candidate; none of them is the GLB */
+                    candidate = null;
+                }
             }
         }
-        return glb;
+        /* if there is a GLB, it must be candidate */
+        if (candidate != null) {
+            for (String lowerBound : lowerBounds) {
+                if (lowerBound != candidate && !isInRelation(candidate, lowerBound)) {
+                    candidate = null;
+                    break;
+                }
+            }
+        }
+        return candidate;
     }
     
     /**
@@ -151,14 +189,26 @@ public class Poset implements Serializable {
      *            the subset of elements
      * @return an immutable set of the maximal lower bounds
      */
-    public Set<String> getMaximalLowerBounds(Set<String> subset) {
+    public Set<String> getMaximalLowerBounds(List<String> subset) {
         assert elements.containsAll(subset);
          
         if (subset == null || subset.size() == 0) {
             return Collections.emptySet();
         }
         if (subset.size() == 1) {
-            return Collections.singleton(subset.iterator().next());
+            return Collections.singleton(subset.get(0));
+        }
+        
+        if (subset.size() == 2) {
+            if (!cacheEnabled) {
+                initializeCache();
+            }
+            String arg0 = subset.get(0);
+            String arg1 = subset.get(1);
+            Set<String> mlbs = maximalLowerBounds.get(arg0, arg1);
+            if (mlbs != null) {
+                return mlbs;
+            }
         }
 
         /* find lower bounds of the given subset */
@@ -177,26 +227,46 @@ public class Poset implements Serializable {
         }
         
         /* find maximal lower bounds from the candidate lower bounds */
-        if (lowerBounds.size() == 0) {
-            return Collections.emptySet();
-        }
-        Set<String> nonMaximalLBs = new HashSet<String>();
-        for (String lb1 : lowerBounds) {
-            // if lb1 has been identified as non-maximal, elements less than
-            // that must have been also identified as non-maximal in the same
-            // outer loop
-            if (!nonMaximalLBs.contains(lb1)) {
-                for (String lb2 : lowerBounds) {
-                    if (isInRelation(lb1, lb2)) {
-                        nonMaximalLBs.add(lb2);
+        if (!lowerBounds.isEmpty()) {
+            Set<String> nonMaximalLBs = new HashSet<String>();
+            for (String lb1 : lowerBounds) {
+                // if lb1 has been identified as non-maximal, elements less than
+                // that must have been also identified as non-maximal in the same
+                // outer loop
+                if (!nonMaximalLBs.contains(lb1)) {
+                    for (String lb2 : lowerBounds) {
+                        if (isInRelation(lb1, lb2)) {
+                            nonMaximalLBs.add(lb2);
+                        }
                     }
                 }
             }
-        }
         
-        lowerBounds.removeAll(nonMaximalLBs);
-        return Collections.unmodifiableSet(lowerBounds);
+            lowerBounds.removeAll(nonMaximalLBs);
+        }
+
+        /* make it immutable */
+        lowerBounds = UnmodifiableSet.decorate(lowerBounds);
+
+        /* cache the result for the most common use case */
+        if (subset.size() == 2) {
+            String arg0 = subset.get(0);
+            String arg1 = subset.get(1);
+            maximalLowerBounds.put(arg0, arg1, lowerBounds);
+            maximalLowerBounds.put(arg1, arg0, lowerBounds);
+        }
+        return lowerBounds;
     }
+    
+    private void invalidateCache() {
+        cacheEnabled = false;
+        maximalLowerBounds = null;
+    }
+    
+    private void initializeCache() {
+        cacheEnabled = true;
+        maximalLowerBounds = ArrayTable.create(elements, elements);
+    }    
 
     private class Tuple implements Serializable {
         private String big, small;

--- a/src/javasources/KTool/src/org/kframework/utils/Poset.java
+++ b/src/javasources/KTool/src/org/kframework/utils/Poset.java
@@ -95,11 +95,13 @@ public class Poset implements Serializable {
      * 
      */
     public String getLUB(Set<String> subset) {
-        if (subset == null || subset.size() == 0)
+        if (subset == null || subset.size() == 0) {
             return null;
-        if (subset.size() == 1)
+        }
+        if (subset.size() == 1) {
             return subset.iterator().next();
-        List<String> candidates = new ArrayList<String>();
+        }
+        List<String> upperBounds = new ArrayList<String>();
         for (String elem : elements) {
             boolean isGTESubset = true;
             for (String subsetElem : subset) {
@@ -109,18 +111,36 @@ public class Poset implements Serializable {
                 }
             }
             if (isGTESubset) {
-                candidates.add(elem);
+                upperBounds.add(elem);
             }
         }
-        if (candidates.size() == 0)
+        if (upperBounds.size() == 0) {
             return null;
-        String lub = candidates.get(0);
-        for (int i = 1; i < candidates.size(); ++i) {
-            if (isInRelation(lub, candidates.get(i))) {
-                lub = candidates.get(i);
+        }
+
+        String candidate = null;
+        for (String upperBound : upperBounds) {
+            if (candidate == null) {
+                candidate = upperBound;
+            } else {
+                if (isInRelation(candidate, upperBound)) {
+                    candidate = upperBound;
+                } else if (!isInRelation(upperBound, candidate)) {
+                    /* no relation between upperBound and candidate; none of them is the LUB */
+                    candidate = null;
+                }
             }
         }
-        return lub;
+        /* if there is a LUB, it must be candidate */
+        if (candidate != null) {
+            for (String upperBound : upperBounds) {
+                if (upperBound != candidate && !isInRelation(upperBound, candidate)) {
+                    candidate = null;
+                    break;
+                }
+            }
+        }
+        return candidate;
     }
 
     /**

--- a/src/javasources/KTool/test/org/kframework/utils/PosetTest.java
+++ b/src/javasources/KTool/test/org/kframework/utils/PosetTest.java
@@ -1,0 +1,68 @@
+// Copyright (c) 2014 K Team. All Rights Reserved.
+package org.kframework.utils;
+
+import junit.framework.Assert;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+public class PosetTest {
+    
+    private Poset poset;
+    
+    @Before
+    public void setUp() {
+        poset = new Poset();
+        poset.addRelation("Top", "A0");
+        poset.addRelation("Top", "A1");
+        poset.addRelation("Top", "A2");
+        poset.addRelation("A0", "B0");
+        poset.addRelation("A1", "B0");
+        poset.addRelation("A2", "B0");
+        poset.addRelation("A0", "B1");
+        poset.addRelation("A1", "B1");
+        poset.addRelation("A2", "B1");
+        poset.addRelation("B0", "Bot");
+        poset.addRelation("B1", "Bot");
+        poset.transitiveClosure();
+    }
+
+    @Test
+    public void testGetMaximalLowerBounds() throws Exception {
+        Assert.assertEquals(Sets.newHashSet("B0", "B1"), 
+                poset.getMaximalLowerBounds(Lists.newArrayList("A0", "A1", "A2")));
+    }
+    
+    @Test
+    public void testGetGLB() throws Exception {
+        // multiple lower bounds, but no GLB
+        Assert.assertNull(poset.getGLB(Sets.newHashSet("A0", "A1", "A2")));
+        
+        // create a GLB for A0, A1, and A2
+        poset.addRelation("A0", "GLB");
+        poset.addRelation("A1", "GLB");
+        poset.addRelation("A2", "GLB");
+        poset.addRelation("GLB", "B0");
+        poset.addRelation("GLB", "B1");
+        poset.transitiveClosure();
+        Assert.assertEquals("GLB", poset.getGLB(Sets.newHashSet("A0", "A1", "A2")));
+    }
+    
+    @Test
+    public void testGetLUB() throws Exception {
+        // multiple upper bounds, but no LUB
+        Assert.assertNull(poset.getLUB(Sets.newHashSet("B0", "B1")));
+        
+        // create a LUB for B0, B1
+        poset.addRelation("A0", "LUB");
+        poset.addRelation("A1", "LUB");
+        poset.addRelation("A2", "LUB");
+        poset.addRelation("LUB", "B0");
+        poset.addRelation("LUB", "B1");
+        poset.transitiveClosure();
+        Assert.assertEquals("LUB", poset.getLUB(Sets.newHashSet("B0", "B1")));
+    }
+}


### PR DESCRIPTION
Clean up dead code introduced in test generation; remove performance bottleneck of the new rewrite algorithm.
