### PR TITLE
Improving the variable type inferencer to better handle overloaded operators.

### DIFF
--- a/src/javasources/KTool/src/org/kframework/parser/DefinitionLoader.java
+++ b/src/javasources/KTool/src/org/kframework/parser/DefinitionLoader.java
@@ -475,7 +475,7 @@ public class DefinitionLoader {
         config = new TypeSystemFilter(context).visitNode(config);
         config = new VariableTypeInferenceFilter(context).visitNode(config);
         // config = new PriorityFilter().visitNode(config);
-        config = new BestFitFilter(new GetFitnessUnitTypeCheckVisitor(context), context).visitNode(config);
+        // config = new BestFitFilter(new GetFitnessUnitTypeCheckVisitor(context), context).visitNode(config);
         config = new TypeInferenceSupremumFilter(context).visitNode(config);
         config = new BestFitFilter(new GetFitnessUnitKCheckVisitor(context), context).visitNode(config);
         // config = new PreferAvoidFilter().visitNode(config);

--- a/src/javasources/KTool/src/org/kframework/parser/concrete/disambiguate/CollectExpectedVariablesVisitor.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete/disambiguate/CollectExpectedVariablesVisitor.java
@@ -91,11 +91,12 @@ public class CollectExpectedVariablesVisitor extends BasicVisitor {
         public CollectExpectedVariablesVisitor get(Term t) {
             for (Term trm : this.keySet()) {
                 if (trm instanceof Variable && t instanceof Variable)
-                    return this.get(trm);
+                    return super.get(trm);
                 if (trm instanceof TermCons && t instanceof TermCons)
                     if (context.isSubsortedEq((TermCons) trm, (TermCons) t) ||
                         context.isSubsortedEq((TermCons) t, (TermCons) trm)) {
-                        return get(trm);
+                        //System.out.println("Found dito: " + ((TermCons) trm).getProduction());
+                        return super.get(trm);
                     }
             }
             // couldn't find anything that looks alike, create a new instance of the visitor

--- a/src/javasources/KTool/src/org/kframework/parser/concrete/disambiguate/CollectExpectedVariablesVisitor.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete/disambiguate/CollectExpectedVariablesVisitor.java
@@ -95,7 +95,6 @@ public class CollectExpectedVariablesVisitor extends BasicVisitor {
                 if (trm instanceof TermCons && t instanceof TermCons)
                     if (context.isSubsortedEq((TermCons) trm, (TermCons) t) ||
                         context.isSubsortedEq((TermCons) t, (TermCons) trm)) {
-                        System.out.println("Found the same viz for: " + ((TermCons) t).getProduction());
                         return get(trm);
                     }
             }

--- a/src/javasources/KTool/src/org/kframework/parser/concrete/disambiguate/TypeInferenceSupremumFilter.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete/disambiguate/TypeInferenceSupremumFilter.java
@@ -15,7 +15,6 @@ import org.kframework.kil.Term;
 import org.kframework.kil.TermCons;
 import org.kframework.kil.Terminal;
 import org.kframework.kil.UserList;
-import org.kframework.kil.Variable;
 import org.kframework.kil.loader.Context;
 import org.kframework.kil.visitors.ParseForestTransformer;
 import org.kframework.kil.visitors.exceptions.ParseFailedException;

--- a/src/javasources/KTool/src/org/kframework/parser/concrete/disambiguate/TypeInferenceSupremumFilter.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete/disambiguate/TypeInferenceSupremumFilter.java
@@ -53,23 +53,13 @@ public class TypeInferenceSupremumFilter extends ParseForestTransformer {
                         Production tcBig = ((TermCons) tm2).getProduction();
                         for (Term tm22 : group) {
                             Production tcSmall = ((TermCons) tm22).getProduction();
-                            if (tm2 != tm22 && isSubsorted(tcBig, tcSmall)) {
+                            if (tm2 != tm22 && context.isSubsortedEq(tcBig, tcSmall)) {
                                 min = false;
                                 break;
                             }
                         }
                         if (min)
                             maxterms.add(tm2);
-                    }
-                } else if (t instanceof Variable) {
-                    // for variables only, find maximum
-                    for (Term t1 : group) {
-                        boolean max = true;
-                        for (Term t2 : group)
-                            if (t1 != t2 && context.isSubsorted(t2.getSort(), t1.getSort()))
-                                max = false;
-                        if (max)
-                            maxterms.add(t1);
                     }
                 } else
                     maxterms.addAll(group);
@@ -84,36 +74,7 @@ public class TypeInferenceSupremumFilter extends ParseForestTransformer {
         return super.visit(amb, _);
     }
 
-    private boolean isSubsorted(Production big, Production small) {
-        if (big == small)
-            return false;
-        if (big.getItems().size() != small.getItems().size())
-            return false;
-        if (!context.isSubsortedEq(big.getSort(), small.getSort()))
-            return false;
-        for (int i = 0; i < big.getItems().size(); i++) {
-            if (!(big.getItems().get(i) instanceof Terminal && small.getItems().get(i) instanceof Terminal) &&
-                !(big.getItems().get(i) instanceof Sort && small.getItems().get(i) instanceof Sort) &&
-                !(big.getItems().get(i) instanceof UserList && small.getItems().get(i) instanceof UserList) &&
-                !(big.getItems().get(i) instanceof Lexical && small.getItems().get(i) instanceof Lexical)) {
-                return false;
-            } else if (big.getItems().get(i) instanceof Sort) {
-                String bigSort = ((Sort) big.getItems().get(i)).getName();
-                String smallSort = ((Sort) small.getItems().get(i)).getName();
-                if (!context.isSubsortedEq(bigSort, smallSort))
-                    return false;
-            } else if (big.getItems().get(i) instanceof UserList) {
-                String bigSort = ((UserList) big.getItems().get(i)).getSort();
-                String smallSort = ((UserList) small.getItems().get(i)).getSort();
-                if (!context.isSubsortedEq(bigSort, smallSort))
-                    return false;
-            } else
-                continue;
-        }
-        return true;
-    }
-
-    private boolean termsAlike_simple(Term trm1, Term trm2) {
+    public static boolean termsAlike_simple(Term trm1, Term trm2) {
         if (!trm1.getClass().equals(trm2.getClass()))
             return false;
 

--- a/src/javasources/KTool/src/org/kframework/parser/concrete/disambiguate/VarHashMap.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete/disambiguate/VarHashMap.java
@@ -2,6 +2,7 @@
 package org.kframework.parser.concrete.disambiguate;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -41,5 +42,35 @@ public class VarHashMap extends HashMap<String, Set<String>> {
         } else
             return false;
         return true;
+    }
+
+    /**
+     * For the given key, adds the value into a set. If the key doesn't exist, it creates the set.
+     * @param key
+     * @param value
+     */
+    public void add(String key, String value) {
+        if (this.containsKey(key))
+            this.get(key).add(value);
+        else {
+            java.util.Set<String> varss = new HashSet<>();
+            varss.add(value);
+            this.put(key, varss);
+        }
+    }
+
+    /**
+     * For the given key, adds all the values to a set. If the key doesn't exist, it creates the set.
+     * @param key
+     * @param value
+     */
+    public void addAll(String key, Set<String> value) {
+        if (this.containsKey(key))
+            this.get(key).addAll(value);
+        else {
+            java.util.Set<String> varss = new HashSet<>();
+            varss.addAll(value);
+            this.put(key, varss);
+        }
     }
 }

--- a/src/javasources/KTool/src/org/kframework/parser/concrete/disambiguate/VariableTypeInferenceFilter.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete/disambiguate/VariableTypeInferenceFilter.java
@@ -64,7 +64,7 @@ public class VariableTypeInferenceFilter extends ParseForestTransformer {
         // after finding all of the variable declarations traverse the tree to disambiguate
         r = (Sentence) new VariableTypeFilter(varDeclMap, false, context).visitNode(r);
         r = (Sentence) new TypeSystemFilter(context).visitNode(r);
-        r = (Sentence) new TypeInferenceSupremumFilter(context).visitNode(r);
+        //r = (Sentence) new TypeInferenceSupremumFilter(context).visitNode(r);
 
         boolean varTypeInference = true;
         if (varTypeInference) {

--- a/src/javasources/KTool/src/org/kframework/parser/generator/DisambiguateRulesFilter.java
+++ b/src/javasources/KTool/src/org/kframework/parser/generator/DisambiguateRulesFilter.java
@@ -21,6 +21,7 @@ import org.kframework.parser.concrete.disambiguate.InclusionFilter;
 import org.kframework.parser.concrete.disambiguate.PreferAvoidFilter;
 import org.kframework.parser.concrete.disambiguate.PriorityFilter;
 import org.kframework.parser.concrete.disambiguate.SentenceVariablesFilter;
+import org.kframework.parser.concrete.disambiguate.TypeInferenceSupremumFilter;
 import org.kframework.parser.concrete.disambiguate.VariableTypeInferenceFilter;
 
 public class DisambiguateRulesFilter extends ParseForestTransformer {
@@ -55,7 +56,7 @@ public class DisambiguateRulesFilter extends ParseForestTransformer {
         // config = new AmbDuplicateFilter(context).visitNode(config);
         // config = new TypeSystemFilter(context).visitNode(config);
         // config = new BestFitFilter(new GetFitnessUnitTypeCheckVisitor(context), context).visitNode(config);
-        // config = new TypeInferenceSupremumFilter(context).visitNode(config);
+        config = new TypeInferenceSupremumFilter(context).visitNode(config);
         config = new BestFitFilter(new GetFitnessUnitKCheckVisitor(context), context).visitNode(config);
         config = new PreferAvoidFilter(context).visitNode(config);
         config = new FlattenListsFilter(context).visitNode(config);

--- a/src/javasources/KTool/src/org/kframework/parser/generator/ParseConfigsFilter.java
+++ b/src/javasources/KTool/src/org/kframework/parser/generator/ParseConfigsFilter.java
@@ -24,6 +24,7 @@ import org.kframework.parser.concrete.disambiguate.InclusionFilter;
 import org.kframework.parser.concrete.disambiguate.PreferAvoidFilter;
 import org.kframework.parser.concrete.disambiguate.PriorityFilter;
 import org.kframework.parser.concrete.disambiguate.SentenceVariablesFilter;
+import org.kframework.parser.concrete.disambiguate.TypeInferenceSupremumFilter;
 import org.kframework.parser.concrete.disambiguate.VariableTypeInferenceFilter;
 import org.kframework.utils.XmlLoader;
 import org.w3c.dom.Document;
@@ -98,7 +99,7 @@ public class ParseConfigsFilter extends ParseForestTransformer {
                 // config = new AmbDuplicateFilter(context).visitNode(config);
                 // config = new TypeSystemFilter(context).visitNode(config);
                 // config = new BestFitFilter(new GetFitnessUnitTypeCheckVisitor(context), context).visitNode(config);
-                // config = new TypeInferenceSupremumFilter(context).visitNode(config);
+                config = new TypeInferenceSupremumFilter(context).visitNode(config);
                 config = new BestFitFilter(new GetFitnessUnitKCheckVisitor(context), context).visitNode(config);
                 config = new PreferAvoidFilter(context).visitNode(config);
                 config = new FlattenListsFilter(context).visitNode(config);


### PR DESCRIPTION
- when finding overloaded operators, try to infer all of them in the same case
- infer the most general sort for variables, but afterwards the most concrete sorts for productions
- reorganized a bit the data structures to make the code cleaner

Basically, pushing the limits of the type inferencer hoping to make it even more correct.

Let's see if the tests pass first.
