### PR TITLE
Fix and test for ArrayIndexOutOfBounds in UnparserFilterNew pretty mode

### DIFF
--- a/src/javasources/KTool/src/org/kframework/backend/unparser/UnparserFilterNew.java
+++ b/src/javasources/KTool/src/org/kframework/backend/unparser/UnparserFilterNew.java
@@ -455,7 +455,7 @@ public class UnparserFilterNew extends NonCachingVisitor {
                     indenter.write(rawLabel);
                 } else{
                     int i = 0;
-                    String [] rawLabelList = rawLabel.split("_");
+                    String [] rawLabelList = rawLabel.split("_", -1);
                     int lastIdx = termList.size() - 1;
                     if (termList.get(lastIdx) instanceof ListTerminator) {
                         termList.remove(lastIdx);

--- a/src/javasources/KTool/test/org/kframework/backend/unparser/UnparserFilterNewTest.java
+++ b/src/javasources/KTool/test/org/kframework/backend/unparser/UnparserFilterNewTest.java
@@ -1,0 +1,39 @@
+// Copyright (c) 2014 K Team. All Rights Reserved.
+
+package org.kframework.backend.unparser;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kframework.kil.KApp;
+import org.kframework.kil.KLabelConstant;
+import org.kframework.kil.Variable;
+import org.kframework.kil.loader.Context;
+import org.kframework.krun.K;
+import org.mockito.Mockito;
+
+public class UnparserFilterNewTest {
+    Context context;
+    
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setup() {
+        K.output_mode = K.PRETTY;
+        
+        context = Mockito.mock(Context.class);
+        context.canonicalBracketForSort = Mockito.mock(Map.class);
+    }
+    
+    /**
+     * Regression test for an ArrayOutOfBoundsException on labels with multiple trailing underscores,
+     */
+    @Test
+    public void testTrailingUnderscores() {
+        UnparserFilterNew v = new UnparserFilterNew(context);
+        KApp t = KApp.of(KLabelConstant.of("'__", context), Variable.getFreshVar("K"), Variable.getFreshVar("K"));
+        v.visit(t, null);
+        v.getResult();
+    }
+    
+}


### PR DESCRIPTION
The single-argument String.split drops trailing empty pieces, leading to an ArrayIndexOutOfBoundsException for labels like '__.
