### PR TITLE
Issue 607

### DIFF
--- a/include/builtins/set-impl.k
+++ b/include/builtins/set-impl.k
@@ -7,16 +7,15 @@ module SET-IMPL
 
   /* set difference */
 //  syntax Set ::= Set "-Set" Set   [function, hook(Set:difference), latex({#1}-_{\it Set}{#2})]
-  rule (SetItem(K:K) S1:Set) -Set S2:Set => S1 -Set S2
-  when K in S2
-  rule (SetItem(K:K) S1:Set) -Set S2:Set => SetItem(K) (S1 -Set S2)
-  when notBool(K in S2)
+  rule (SetItem(K:K) S1:Set) -Set S2:Set
+    => #if K in S2 ==K true #then S1 -Set S2 #else  SetItem(K) (S1 -Set S2) #fi
   rule .Set -Set _:Set => .Set
 
-  /* set difference axioms */
+  /* set difference axioms
   rule S1:Set -Set (SetItem(K:K) S2:Set) => S1 -Set S2
   when notBool(K in S1)
   rule S:Set -Set .Set => S
+ */
 
   /* set intersection */
 //  syntax Set ::= intersectSet(Set, Set)   [function]

--- a/include/modules/substitution.k
+++ b/include/modules/substitution.k
@@ -276,13 +276,12 @@ module SUBSTITUTION
 // Grigore: I added the operation below here, because I want it to be
 // generic.  I don't know how to generate globablly fresh variables
 // of desired type any other way ... sorry.  This is used in type inference
-/******** Soon to be *******************
   syntax K ::= freshVariables(Set,K)
   rule freshVariables(.Set, T) => T
   rule freshVariables(SetItem(Tv) S:Set, T)
     => freshVariables(S, T[#freshSym(Tv)/Tv])
-*/
 
+/*
   syntax K ::= freshVariables(Set,K)
   rule freshVariables(.Set, T:K) => T
   rule freshVariables(SetItem(Tv:K) S:Set, T:K)
@@ -290,5 +289,5 @@ module SUBSTITUTION
 
   syntax K ::= #changeLabel(K,K)  [function]
   rule #changeLabel(_:KLabel(Ks:KList),L':KLabel(_)) => L'(Ks)
-
+*/
 endmodule

--- a/include/modules/substitution.k
+++ b/include/modules/substitution.k
@@ -117,9 +117,8 @@ module FREE-VARS
   syntax Set ::= #freeVars(KList, Set, Set)  [function, klabel(#freevars2)]
   rule #freeVars(.KList, _, Free:Set) => Free
   rule #freeVars(X:Variable,,Ks:KList, Bound:Set, Free:Set)
-    => #freeVars(Ks, Bound, Free) when X in Bound
-  rule #freeVars(X:Variable,,Ks:KList, Bound:Set, Free:Set)
-    => #freeVars(Ks, Bound, Free SetItem(X)) when notBool(X in Bound)
+    => #if X in Bound ==K true #then #freeVars(Ks, Bound, Free) #else
+     #freeVars(Ks, Bound, Free SetItem(X)) #fi
   rule #freeVars((L:KLabel(Ks:KList) => Ks),, _, _, _)
     when (isVariable(L(Ks)) =/=K true) andBool
          (isBinder(L(Ks)) =/=K true) andBool
@@ -182,7 +181,7 @@ module SUBSTITUTION
 
   rule #substituteFV(Y:Variable, M:Map Y |-> V, _) => V
   rule #substituteFV(Y:Variable, M:Map, _) => Y
-    when notBool (Y in keys(M))
+    when Y in keys(M) =/=K true
   
   rule #substituteFV(K:K, M:Map, FV) => #substituteBinder(K, M, FV)
     when isBinder(K)

--- a/include/modules/unification.k
+++ b/include/modules/unification.k
@@ -16,7 +16,7 @@ module UNIFICATION
   syntax K ::= applyMgu(Mgu,K)       [function, hook(Unification:applyMgu), latex({#1}({#2}))]  // applies Mgu to any term
   rule applyMgu(Theta:Mgu,K) => applySubst(Theta,K)
 
-  syntax Set ::= applyMgu(Mgu,Set)  [function, latex({#1}({#2}))]
+//  syntax Set ::= applyMgu(Mgu,Set)  [function, latex({#1}({#2}))]
   rule applyMgu(_, .Set) => .Set
   rule applyMgu(Theta:Mgu, SetItem(K:K) S:Set)
     => SetItem(applyMgu(Theta,K)) applyMgu(Theta,S)
@@ -154,19 +154,19 @@ constraint.
   rule accumulateVars(#vars(Xs:KList)) => #vars(Xs)   [structural, anywhere]
 
 
-  syntax Map ::= applyMgu(Mgu, Map) [function]
+//  syntax Map ::= applyMgu(Mgu, Map) [function]
   rule applyMgu(Mgu, ((X |-> V) M:Map))
     => (X |-> applyMgu(Mgu,V)) applyMgu(Mgu, M)
   rule applyMgu(_,.Map) => .Map
 
 
   syntax Map ::= #metaVariablesMap(K) [function]
-  rule #metaVariablesMap(K:K) => #metaVarsMap(getVars(K))
+  rule #metaVariablesMap(K:K) => #metaVarsMap(getVars(K), .Map)
 
-  syntax Map ::= #metaVarsMap(K) [function]
-  rule #metaVarsMap(#vars((X:K => .KList),,_))
-       (.Map => #tokenToString(X) |-> X)
-  rule #metaVarsMap(#vars(.KList)) => .Map
+  syntax Map ::= #metaVarsMap(K, Map) [function]
+  rule #metaVarsMap(#vars((X:K => .KList),,_),
+       M:Map (.Map => #tokenToString(X) |-> X))
+  rule #metaVarsMap(#vars(.KList), M:Map) => M:Map
 
 //  configuration <k> .K </k> <nextVar> 0 </nextVar>
 
@@ -195,11 +195,14 @@ constraint.
 
 // Turns an Mgu into a Map, ignoring the symbolic bindings
   syntax Map ::= Mgu2Map(K) [function]
+  rule Mgu2Map(K) => Mgu2MapHelper(K, .Map)
 
-  rule Mgu2Map(subst((eqn(K1:K,,_:K) => .KList),,_))
+  syntax Map ::= Mgu2MapHelper(K, Map) [function]
+
+  rule Mgu2MapHelper(subst((eqn(K1:K,,_:K) => .KList),,_), _)
     when isSymbolicK(K1)   // ignore symbolic bindings
-  rule Mgu2Map(subst((eqn(K1:K,,K2:K) => .KList),,_))
-       (. => K1 |-> K2)
+  rule Mgu2MapHelper(subst((eqn(K1:K,,K2:K) => .KList),,_), M:Map
+       (.Map => K1 |-> K2))
     when isSymbolicK(K1) =/=K true
 
 /*
@@ -223,7 +226,7 @@ constraint.
 */
 
 
-  rule Mgu2Map(subst(.KList)) => .Map
+  rule Mgu2MapHelper(subst(.KList), M:Map) => M
 
 
 

--- a/tutorial/1_k/5_types/lesson_4/lambda.k
+++ b/tutorial/1_k/5_types/lesson_4/lambda.k
@@ -36,14 +36,13 @@ module LAMBDA
   rule T1:Type  + T2:Type => T1 = int ~> T2 = int ~> int
   rule T1:Type <= T2:Type => T1 = int ~> T2 = int ~> bool
   syntax Exp ::= Exp "->" Exp  [strict]
-  // TODO (AndreiS): fix sort inference for E
-  // rule lambda X . E => T -> E[T/X]  when fresh(T:Type)
-  rule lambda X . E:Exp => T -> E[T/X]  when fresh(T:Type)
-  rule T1:Type T2:Type => T1 = (T2 -> T) ~> T  when fresh(T:Type)
+
+  rule lambda X . E:Exp => !T:Type -> E[!T/X]
+  rule T1:Type T2:Type => T1 = (T2 -> !T:Type) ~> !T
   rule if T:Type then T1:Type else T2:Type => T = bool ~> T1 = T2 ~> T1
   rule let X = E in E' => (lambda X . E') E                             [macro]
   rule letrec F X = E in E' => let F = mu F . lambda X . E in E'        [macro]
-  rule mu X . E => (T -> T) E[T/X]  when fresh(T:Type)
+  rule mu X . E => (!T:Type -> !T) E[!T/X] 
 
   syntax K ::= Type "=" Type
   rule <k> T = T' => . ...</k>  <mgu> Theta:Mgu => updateMgu(Theta,T,T') </mgu>

--- a/tutorial/1_k/5_types/lesson_4/lambda.k
+++ b/tutorial/1_k/5_types/lesson_4/lambda.k
@@ -37,12 +37,12 @@ module LAMBDA
   rule T1:Type <= T2:Type => T1 = int ~> T2 = int ~> bool
   syntax Exp ::= Exp "->" Exp  [strict]
 
-  rule lambda X . E:Exp => !T:Type -> E[!T/X]
-  rule T1:Type T2:Type => T1 = (T2 -> !T:Type) ~> !T
+  rule lambda X . E:Exp => ?T:Type -> E[?T/X]
+  rule T1:Type T2:Type => T1 = (T2 -> ?T:Type) ~> ?T
   rule if T:Type then T1:Type else T2:Type => T = bool ~> T1 = T2 ~> T1
   rule let X = E in E' => (lambda X . E') E                             [macro]
   rule letrec F X = E in E' => let F = mu F . lambda X . E in E'        [macro]
-  rule mu X . E => (!T:Type -> !T) E[!T/X] 
+  rule mu X . E => (?T:Type -> ?T) E[?T/X] 
 
   syntax K ::= Type "=" Type
   rule <k> T = T' => . ...</k>  <mgu> Theta:Mgu => updateMgu(Theta,T,T') </mgu>


### PR DESCRIPTION
Apparently there were some issues with the substitution when using bounded symbolic variables.  Not sure why these were not caught by the lambda tests.  To address them, I had to force syntactic equality in the process of computing the free variables.  The main thing I'm not proud of is basically changing the definition of -Set to a syntactic one (by abusing ==K true).  @andreistefanescu says that is probably ok.  If anybody objects to that, I can create a -SetSyn or something similar for syntactic difference.

@andreistefanescu @grosu @dwightguth please review.
