### PR TITLE
Tool fixes to handle spaces in file paths

### DIFF
--- a/bin/kagreg
+++ b/bin/kagreg
@@ -5,7 +5,7 @@ if [ -z "$K_OPTS" ];
   then export K_OPTS="-Xms64m -Xmx1024m -Xss32m"
 fi
 if "$(dirname "$0")/../lib/scripts/checkJava"; then
-  java -Djava.awt.headless=true $K_OPTS -ea -jar "$(dirname "$0)/""../lib/java/k3.jar" -kagreg "$@"
+  java -Djava.awt.headless=true $K_OPTS -ea -jar "$(dirname "$0")/../lib/java/k3.jar" -kagreg "$@"
 else
   exit 1
 fi

--- a/bin/kagreg
+++ b/bin/kagreg
@@ -4,8 +4,8 @@ ulimit -s `ulimit -H -s`
 if [ -z "$K_OPTS" ];
   then export K_OPTS="-Xms64m -Xmx1024m -Xss32m"
 fi
-if "$(dirname $0)/../lib/scripts/checkJava"; then
-  java -Djava.awt.headless=true $K_OPTS -ea -jar "$(dirname $0)/../lib/java/k3.jar" -kagreg "$@"
+if "$(dirname "$0")/../lib/scripts/checkJava"; then
+  java -Djava.awt.headless=true $K_OPTS -ea -jar "$(dirname "$0)/""../lib/java/k3.jar" -kagreg "$@"
 else
   exit 1
 fi

--- a/bin/kast
+++ b/bin/kast
@@ -1,11 +1,11 @@
 #!/usr/bin/env sh
 
-#LD_LIBRARY_PATH="$(dirname $0)/../lib/native/linux/x64" java -Xcheck:jni -ea -ss8m -Xms64m -Xmx1G -jar "$(dirname $0)/../lib/java/k3.jar" -kast "$@"
+#LD_LIBRARY_PATH="$(dirname "$0")/../lib/native/linux/x64" java -Xcheck:jni -ea -ss8m -Xms64m -Xmx1G -jar "$(dirname "$0")/../lib/java/k3.jar" -kast "$@"
 if [ -z "$K_OPTS" ];
   then export K_OPTS="-Xms64m -Xmx1024m -Xss32m"
 fi
-if "$(dirname $0)/../lib/scripts/checkJava"; then
-  java -Djava.awt.headless=true $K_OPTS -ea -jar "$(dirname $0)/../lib/java/k3.jar" -kast "$@"
+if "$(dirname "$0")/../lib/scripts/checkJava"; then
+  java -Djava.awt.headless=true $K_OPTS -ea -jar "$(dirname "$0")/../lib/java/k3.jar" -kast "$@"
 else
   exit 1
 fi

--- a/bin/kompile
+++ b/bin/kompile
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
 
-export PATH=$PATH:$(dirname $0)/../lib/native/cygwin:$(dirname $0)/../lib/native/cygwin/x64
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(dirname $0)/../lib/native/linux:$(dirname $0)/../lib/native/linux/x64
+export PATH=$PATH:$(dirname "$0")/../lib/native/cygwin:$(dirname "$0")/../lib/native/cygwin/x64
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(dirname "$0")/../lib/native/linux:$(dirname "$0")/../lib/native/linux/x64
 ulimit -s `ulimit -H -s`
 if [ -z "$K_OPTS" ];
   then export K_OPTS="-Xms64m -Xmx1024m -Xss32m"
 fi
-if "$(dirname $0)/../lib/scripts/checkJava"; then
-  java -Djava.awt.headless=true $K_OPTS -ea -jar "$(dirname $0)/../lib/java/k3.jar" -kompile "$@"
+if "$(dirname "$0")/../lib/scripts/checkJava"; then
+  java -Djava.awt.headless=true $K_OPTS -ea -jar "$(dirname "$0")/../lib/java/k3.jar" -kompile "$@"
 else
   exit 1
 fi

--- a/bin/kpp
+++ b/bin/kpp
@@ -3,8 +3,8 @@
 if [ -z "$K_OPTS" ];
   then export K_OPTS="-Xms64m -Xmx1024m -Xss32m"
 fi
-if "$(dirname $0)/../lib/scripts/checkJava"; then
-  java -Djava.awt.headless=true $K_OPTS -jar "$(dirname $0)/../lib/java/k3.jar" -kpp "$@"
+if "$(dirname "$0")/../lib/scripts/checkJava"; then
+  java -Djava.awt.headless=true $K_OPTS -jar "$(dirname "$0")/../lib/java/k3.jar" -kpp "$@"
 else
   exit 1
 fi

--- a/bin/krun
+++ b/bin/krun
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
 
-export PATH=$PATH:$(dirname $0)/../lib/native/cygwin:$(dirname $0)/../lib/native/cygwin/x64
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(dirname $0)/../lib/native/linux:$(dirname $0)/../lib/native/linux/x64
+export PATH=$PATH:$(dirname "$0")/../lib/native/cygwin:$(dirname "$0")/../lib/native/cygwin/x64
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(dirname "$0")/../lib/native/linux:$(dirname "$0")/../lib/native/linux/x64
 if [ -z "$K_OPTS" ];
   then export K_OPTS="-Xms64m -Xmx1024m -Xss32m"
 fi
-if "$(dirname $0)/../lib/scripts/checkJava";
+if "$(dirname "$0")/../lib/scripts/checkJava";
 then
-  java -Djava.awt.headless=true $K_OPTS -ea -jar "$(dirname $0)/../lib/java/k3.jar" -krun "$@"
+  java -Djava.awt.headless=true $K_OPTS -ea -jar "$(dirname "$0")/../lib/java/k3.jar" -krun "$@"
 else
   exit 1
 fi

--- a/bin/ktest
+++ b/bin/ktest
@@ -4,8 +4,8 @@ ulimit -s `ulimit -H -s`
 if [ -z "$K_OPTS" ];
   then export K_OPTS="-Xms64m -Xmx1024m -Xss32m"
 fi
-if "$(dirname $0)/../lib/scripts/checkJava"; then
-  java -Djava.awt.headless=true $K_OPTS -ea -jar "$(dirname $0)/../lib/java/k3.jar" -ktest "$@"
+if "$(dirname "$0")/../lib/scripts/checkJava"; then
+  java -Djava.awt.headless=true $K_OPTS -ea -jar "$(dirname "$0")/../lib/java/k3.jar" -ktest "$@"
 else
   exit 1
 fi

--- a/src/javasources/KTool/src/org/kframework/krun/runner/KRunner.java
+++ b/src/javasources/KTool/src/org/kframework/krun/runner/KRunner.java
@@ -107,6 +107,11 @@ public class KRunner {
         // Client.main(null);
     }
 
+    private static String maudeEscapePath(String original) {
+	// backslash-escape white spaces, backslashes, and double quotes
+	return original.replaceAll("[\\s\"\\\\]", "\\\\$0");
+    }
+
     public int run() {
         Thread ioServer = null;
         try {
@@ -116,8 +121,8 @@ public class KRunner {
             _maudeFileName = KPaths.windowfyPath(_maudeFileName);
             _maudeCommandFileName = KPaths.windowfyPath(_maudeCommandFileName);
             String commandTemplate = "load {0}" + K.lineSeparator + "mod KRUNNER is including {1} ." + K.lineSeparator + "eq #TCPPORT = {2,number,#} ." + K.lineSeparator + "endm" + K.lineSeparator + "load {3}" + K.lineSeparator;
-            /*_maudeFileName = _maudeFileName.replaceAll("(\\s)", "\\\1");
-            _maudeCommandFileName = _maudeCommandFileName.replaceAll("(\\s)", "\\ ");*/
+            _maudeFileName = maudeEscapePath(_maudeFileName);
+            _maudeCommandFileName = maudeEscapePath(_maudeCommandFileName);
             
             String command = MessageFormat.format(commandTemplate, _maudeFileName, _maudeModule, _port, _maudeCommandFileName);
             MaudeTask maude = new MaudeTask(command, _outputFileName, _errorFileName);

--- a/src/javasources/KTool/src/org/kframework/krun/runner/KRunner.java
+++ b/src/javasources/KTool/src/org/kframework/krun/runner/KRunner.java
@@ -108,8 +108,8 @@ public class KRunner {
     }
 
     private static String maudeEscapePath(String original) {
-	// backslash-escape white spaces, backslashes, and double quotes
-	return original.replaceAll("[\\s\"\\\\]", "\\\\$0");
+        // backslash-escape white spaces, backslashes, and double quotes
+        return original.replaceAll("[\\s\"\\\\]", "\\\\$0");
     }
 
     public int run() {


### PR DESCRIPTION
These changes collectively fix issue #655. Most of the changes add proper double-quoting to shell scripts so that they properly handle spaces in the path leading to the K installation directory. The `KRunner` tweaks handle the case of spaces in the path leading to the user's `*-kompiled` directory. For that we use backslash-escaping, a feature supported by Maude's `load` command.

Unfortunately, running `ant test` currently fails even for a pristine snapshot of the K master branch in directories with no spaces. Therefore, I can't definitively say that this fixes all spaces-in-paths bugs while introducing no new regressions. I can say that my changes are both necessary and sufficient to make the first several tutorial steps work when there are spaces in paths. Those steps involve using `kompile`, `krun`, and `kast`. I have not tried other K tools suck as `kagreg`, `kpp`, or `ktest`, even though I have made the obvious fixes to those shell scripts too.
