### PR TITLE
ktest: print tested output file in case of a match failure (fixes #689)

### DIFF
--- a/src/javasources/KTool/src/org/kframework/ktest/Proc.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Proc.java
@@ -272,8 +272,9 @@ public class Proc<T> implements Runnable {
                 } catch (MatchFailure e) {
                     // outputs don't match
                     System.out.format(
-                            "%sERROR: [%s] output doesn't match with expected output (time: %d ms)%s%n",
-                            red, logStr, timeDelta, ColorUtil.ANSI_NORMAL);
+                        "%sERROR: [%s] output doesn't match with expected output " +
+                        "%s (time: %d ms)%s%n",
+                        red, logStr, expectedOut.getAnn(), timeDelta, ColorUtil.ANSI_NORMAL);
                     reportOutMatch(e.getMessage());
                     if (verbose)
                         System.out.println(getReason());
@@ -318,8 +319,9 @@ public class Proc<T> implements Runnable {
                 } catch (MatchFailure e) {
                     // error outputs don't match
                     System.out.format(
-                            "%sERROR: [%s] throwed error, but expected error message doesn't match "+
-                                    "(time: %d ms)%s%n", red, logStr, timeDelta, ColorUtil.ANSI_NORMAL);
+                        "%sERROR: [%s] throwed error, but expected error message doesn't match " +
+                        "%s (time: %d ms)%s%n",
+                        red, logStr, expectedErr.getAnn(), timeDelta, ColorUtil.ANSI_NORMAL);
                     reportErrMatch(e.getMessage());
                 }
             }


### PR DESCRIPTION
Changed error reporting when an output mismatch happened from this:

```
ERROR: ['/home/omer/K/k_new_dist/k/bin/krun' '/home/omer/K/k_new_dist/k/tutorial/1_k/5_types/lesson_4/tests/composition.lambda' '--search' '--pattern' '<k> V:K </k>' '--directory' '/home/omer/K/k_new_dist/k/tutorial/1_k/5_types/lesson_9'] output doesn't match with expected output (time: 11072 ms)
```

to this:

```
ERROR: ['/home/omer/K/k_new_dist/k/bin/krun' '/home/omer/K/k_new_dist/k/tutorial/1_k/5_types/lesson_4/tests/composition.lambda' '--search' '--pattern' '<k> V:K </k>' '--directory' '/home/omer/K/k_new_dist/k/tutorial/1_k/5_types/lesson_9'] output doesn't match with expected output /home/omer/K/k_new_dist/k/tutorial/1_k/5_types/lesson_4/tests/composition.lambda.out (time: 11578 ms)
```

(not the extra file path that points to compared output file)
#689
