### PR TITLE
make the maude backend output more deterministic

### DIFF
--- a/include/builtins/set-impl.k
+++ b/include/builtins/set-impl.k
@@ -30,8 +30,8 @@ module SET-IMPL
 
   /* element membership */
 //  syntax Bool ::= K "in" Set    [function, hook(Set:in)]
-  rule K:K in SetItem(K) _:Set => true
-  rule K1:K in SetItem(K2:K) S:Set => K1 =K K2 orBool K1 in S
+  rule K1:K in SetItem(K2:K) _:Set => true when K1 =K K2
+  rule K1:K in SetItem(K2:K) S:Set => K1 in S when notBool(K1 =K K2)
   rule _ in .Set => false
 
   /* set cardinality */

--- a/include/builtins/set-impl.k
+++ b/include/builtins/set-impl.k
@@ -30,8 +30,8 @@ module SET-IMPL
 
   /* element membership */
 //  syntax Bool ::= K "in" Set    [function, hook(Set:in)]
-  rule K1:K in SetItem(K2:K) _:Set => true when K1 =K K2
-  rule K1:K in SetItem(K2:K) S:Set => K1 in S when notBool(K1 =K K2)
+  rule K1:K in SetItem(K2:K) _:Set => true requires K1 =K K2
+  rule K1:K in SetItem(K2:K) S:Set => K1 in S requires notBool(K1 =K K2)
   rule _ in .Set => false
 
   /* set cardinality */

--- a/include/io/io.k
+++ b/include/io/io.k
@@ -15,10 +15,6 @@ module K-IO
        (ListItem(I:Int) => .List)
        _:List [stdout, stderr]
   rule ListItem(#ostream(_))
-       ListItem(#buffer(Buffer:String => Buffer +String Char2String(C)))
-       (ListItem(C:Char) => .List)
-       _:List [stdout, stderr]
-  rule ListItem(#ostream(_))
        ListItem(#buffer(Buffer:String => Buffer +String S))
        (ListItem(S:String) => .List)
        _:List [stdout, stderr]
@@ -28,9 +24,6 @@ module K-IO
        _:List [stdout, stderr]
   rule ListItem(#buffer(Buffer:String => Buffer +String Int2String(I)))
        (ListItem(I:Int) => .List)
-       _:List [stdout, stderr]
-  rule ListItem(#buffer(Buffer:String => Buffer +String Char2String(C)))
-       (ListItem(C:Char) => .List)
        _:List [stdout, stderr]
   rule ListItem(#buffer(Buffer:String => Buffer +String S))
        (ListItem(S:String) => .List)

--- a/src/javasources/KTool/src/org/kframework/backend/maude/MaudeBackend.java
+++ b/src/javasources/KTool/src/org/kframework/backend/maude/MaudeBackend.java
@@ -4,6 +4,7 @@ package org.kframework.backend.maude;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.kframework.backend.BasicBackend;
 import org.kframework.compile.sharing.FreshVariableNormalizer;
+import org.kframework.compile.sharing.SortRulesNormalizer;
 import org.kframework.kil.Definition;
 import org.kframework.kil.Production;
 import org.kframework.kil.UserList;
@@ -24,6 +25,7 @@ public class MaudeBackend extends BasicBackend {
     @Override
     public void run(Definition definition) throws IOException {
         definition = (Definition) new FreshVariableNormalizer(context).visitNode(definition);
+        definition = (Definition) new SortRulesNormalizer(context).visitNode(definition);
         MaudeFilter maudeFilter = new MaudeFilter(context);
         maudeFilter.visitNode(definition);
 

--- a/src/javasources/KTool/src/org/kframework/compile/sharing/FreshVariableNormalizer.java
+++ b/src/javasources/KTool/src/org/kframework/compile/sharing/FreshVariableNormalizer.java
@@ -4,8 +4,8 @@ package org.kframework.compile.sharing;
 import org.kframework.kil.Rule;
 import org.kframework.kil.Variable;
 import org.kframework.kil.loader.Context;
-import org.kframework.kil.visitors.BasicVisitor;
 import org.kframework.kil.visitors.CopyOnWriteTransformer;
+import org.kframework.kil.visitors.NonCachingVisitor;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -52,7 +52,7 @@ public class FreshVariableNormalizer extends CopyOnWriteTransformer {
      * Class implementing a visitor which constructs a substitution mapping the fresh variables
      * into variables with indices the number in the range [0, this.counter].
      */
-    class FreshVariableCounter extends BasicVisitor {
+    class FreshVariableCounter extends NonCachingVisitor {
 
         public FreshVariableCounter(Context context) {
             super(context);

--- a/src/javasources/KTool/src/org/kframework/compile/sharing/SortRulesNormalizer.java
+++ b/src/javasources/KTool/src/org/kframework/compile/sharing/SortRulesNormalizer.java
@@ -20,6 +20,13 @@ public class SortRulesNormalizer extends CopyOnWriteTransformer {
         Collections.sort(module.getItems(), new Comparator<ModuleItem>() {
             @Override
             public int compare(ModuleItem arg0, ModuleItem arg1) {
+                int x;
+                if ((x = arg0.getFilename().compareTo(arg1.getFilename())) != 0) {
+                    return x;
+                }
+                if ((x = arg0.getLocation().compareTo(arg1.getLocation())) != 0) {
+                    return x;
+                }
                 return arg0.toString().compareTo(arg1.toString());
             }
         });

--- a/src/javasources/KTool/src/org/kframework/compile/sharing/SortRulesNormalizer.java
+++ b/src/javasources/KTool/src/org/kframework/compile/sharing/SortRulesNormalizer.java
@@ -1,3 +1,4 @@
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.compile.sharing;
 
 import java.util.Collections;

--- a/src/javasources/KTool/src/org/kframework/compile/sharing/SortRulesNormalizer.java
+++ b/src/javasources/KTool/src/org/kframework/compile/sharing/SortRulesNormalizer.java
@@ -1,0 +1,27 @@
+package org.kframework.compile.sharing;
+
+import java.util.Collections;
+import java.util.Comparator;
+
+import org.kframework.kil.Module;
+import org.kframework.kil.ModuleItem;
+import org.kframework.kil.loader.Context;
+import org.kframework.kil.visitors.CopyOnWriteTransformer;
+
+public class SortRulesNormalizer extends CopyOnWriteTransformer {
+
+    public SortRulesNormalizer(Context context) {
+        super("Sort rules deterministically", context);
+    }
+    
+    @Override
+    public Module visit(Module module, Void _) {
+        Collections.sort(module.getItems(), new Comparator<ModuleItem>() {
+            @Override
+            public int compare(ModuleItem arg0, ModuleItem arg1) {
+                return arg0.toString().compareTo(arg1.toString());
+            }
+        });
+        return module;
+    }
+}

--- a/src/javasources/KTool/src/org/kframework/compile/transformers/ResolveSyntaxPredicates.java
+++ b/src/javasources/KTool/src/org/kframework/compile/transformers/ResolveSyntaxPredicates.java
@@ -5,7 +5,9 @@ import org.kframework.compile.utils.MetaK;
 import org.kframework.kil.*;
 import org.kframework.kil.visitors.CopyOnWriteTransformer;
 
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class ResolveSyntaxPredicates extends CopyOnWriteTransformer {
     
@@ -29,7 +31,10 @@ public class ResolveSyntaxPredicates extends CopyOnWriteTransformer {
     @Override
     public ASTNode visit(Sentence node, Void _)  {
         boolean change = false;
-        Set<Variable> vars = node.getBody().variables();
+        List<Variable> vars = new ArrayList<>(node.getBody().variables());
+        // if we kept it as a set then the order of side conditions in maude would be dependent on 
+        // the iteration order of a set, which is JVM dependent. So we sort the list first.
+        Collections.sort(vars);
         KList ands = new KList();
         Term condition = node.getRequires();
         if (null != condition) {

--- a/tutorial/2_languages/2_kool/2_typed/2_static/kool-typed-static.k
+++ b/tutorial/2_languages/2_kool/2_typed/2_static/kool-typed-static.k
@@ -589,7 +589,7 @@ checks for cycles. */
             ...</classes> _ => .)
            <out>... .List => ListItem("Class \"" +String Id2String(C)
                                   +String "\" is in a cycle!\n") </out>
-       </T>  [transition]
+       </T>  [inheritance-cycle]
 
 
 /*@ \subsubsection{New}

--- a/tutorial/2_languages/2_kool/2_typed/2_static/kool-typed-static.k
+++ b/tutorial/2_languages/2_kool/2_typed/2_static/kool-typed-static.k
@@ -589,7 +589,7 @@ checks for cycles. */
             ...</classes> _ => .)
            <out>... .List => ListItem("Class \"" +String Id2String(C)
                                   +String "\" is in a cycle!\n") </out>
-       </T>  [structural]
+       </T>  [transition]
 
 
 /*@ \subsubsection{New}

--- a/tutorial/2_languages/2_kool/2_typed/2_static/tests/config.xml
+++ b/tutorial/2_languages/2_kool/2_typed/2_static/tests/config.xml
@@ -11,7 +11,7 @@
       <all-programs>
         <krun-option name="--output" value="none"/>
       </all-programs>
-      <program name="cycle.kool" regex="true">
+      <program name="cycle.kool">
         <krun-option name="--search" />
       </program>
   </test>

--- a/tutorial/2_languages/2_kool/2_typed/2_static/tests/config.xml
+++ b/tutorial/2_languages/2_kool/2_typed/2_static/tests/config.xml
@@ -7,6 +7,7 @@
       programs="../../programs"
       extension="kool"
       results="." >
+      <kompile-option name="--transition" value="inheritance-cycle" />
       <all-programs>
         <krun-option name="--output" value="none"/>
       </all-programs>

--- a/tutorial/2_languages/2_kool/2_typed/2_static/tests/config.xml
+++ b/tutorial/2_languages/2_kool/2_typed/2_static/tests/config.xml
@@ -13,6 +13,7 @@
       </all-programs>
       <program name="cycle.kool">
         <krun-option name="--search" />
+        <krun-option name="--pattern" value="&lt;out&gt; L:List &lt;/out&gt;" />
       </program>
   </test>
 

--- a/tutorial/2_languages/2_kool/2_typed/2_static/tests/config.xml
+++ b/tutorial/2_languages/2_kool/2_typed/2_static/tests/config.xml
@@ -10,6 +10,9 @@
       <all-programs>
         <krun-option name="--output" value="none"/>
       </all-programs>
+      <program name="cycle.kool" regex="true">
+        <krun-option name="--search" />
+      </program>
   </test>
 
 </tests>

--- a/tutorial/2_languages/2_kool/2_typed/2_static/tests/cycle.kool.out
+++ b/tutorial/2_languages/2_kool/2_typed/2_static/tests/cycle.kool.out
@@ -1,2 +1,15 @@
-Class \\"C2\\" is in a cycle!
-Class \\"C1\\" is in a cycle!
+Search results:
+
+Solution 1:
+<T>
+    <out>
+        ListItem ( #buffer ( "Class \"C1\" is in a cycle!\n" ) )
+    </out>
+</T>
+
+Solution 2:
+<T>
+    <out>
+        ListItem ( #buffer ( "Class \"C2\" is in a cycle!\n" ) )
+    </out>
+</T>

--- a/tutorial/2_languages/2_kool/2_typed/2_static/tests/cycle.kool.out
+++ b/tutorial/2_languages/2_kool/2_typed/2_static/tests/cycle.kool.out
@@ -1,15 +1,9 @@
 Search results:
 
 Solution 1:
-<T>
-    <out>
-        ListItem ( #buffer ( "Class \"C1\" is in a cycle!\n" ) )
-    </out>
-</T>
+L:List -->
+ListItem ( #buffer ( "Class \"C1\" is in a cycle!\n" ) )
 
 Solution 2:
-<T>
-    <out>
-        ListItem ( #buffer ( "Class \"C2\" is in a cycle!\n" ) )
-    </out>
-</T>
+L:List -->
+ListItem ( #buffer ( "Class \"C2\" is in a cycle!\n" ) )

--- a/tutorial/2_languages/2_kool/2_typed/2_static/tests/cycle.kool.out
+++ b/tutorial/2_languages/2_kool/2_typed/2_static/tests/cycle.kool.out
@@ -1,1 +1,2 @@
-Class "C2" is in a cycle!
+Class \\"C2\\" is in a cycle!
+Class \\"C1\\" is in a cycle!


### PR DESCRIPTION
@traiansf please review

The Maude backend had some issues that were making the output to maude JVM dependent. I added some code whose purpose is to ensure that the ordering and numbering of rules is the same accross different Java versions.
