### PR TITLE
Deprecate Production.getLabel

### DIFF
--- a/src/javasources/KTool/src/org/kframework/kil/Production.java
+++ b/src/javasources/KTool/src/org/kframework/kil/Production.java
@@ -147,6 +147,10 @@ public class Production extends ASTNode implements Interfaces.MutableList<Produc
         return attributes.get("cons");
     }
 
+    /**
+     * Use .getKLabel() if you want the klabel
+     */
+    @Deprecated
     public String getLabel() {
         String label = attributes.get("prefixlabel");
         if (label == null) {


### PR DESCRIPTION
This method is easily confused with getKLabel. If it's needed at all, maybe it should be renamed to getPrefixLabel and the private getPrefixLabel helper method renamed.
