### PR TITLE
Replace literal CR with escape sequence

### DIFF
--- a/src/main/scripts/fix_whitespace
+++ b/src/main/scripts/fix_whitespace
@@ -2,6 +2,6 @@
 # Copyright (c) 2014 K Team. All Rights Reserved.
 # Usage: ./fix_whitespace <files>
 
-sed -i 's/$//' "$@"
+sed -i $'s/\r$//' "$@"
 sed -i 's/ *$//' "$@"
 sed -i 's/	/    /g' "$@"


### PR DESCRIPTION
The fix_whitespace script used to include a literal carriage return
character in one of the replacements, which it quite confusing if
you just cat it. This instead uses bash's support for escape sequences
in $-prefixed string literals.
