### PR TITLE
Ids should not be preceded by numbers either.

### DIFF
--- a/include/builtins/id.k
+++ b/include/builtins/id.k
@@ -2,7 +2,7 @@
 require "string.k"
 
 module ID-SYNTAX-HOOKS
-  syntax Id ::= Token{[A-Za-z\_][A-Za-z0-9\_]*}   [notInRules, regex("(?<![A-Za-z\\_])[A-Za-z\\_][A-Za-z0-9\\_]*")]
+  syntax Id ::= Token{[A-Za-z\_][A-Za-z0-9\_]*}   [notInRules, regex("(?<![A-Za-z0-9\\_])[A-Za-z\\_][A-Za-z0-9\\_]*")]
 endmodule
 
 module ID-HOOKS


### PR DESCRIPTION
I just noticed that I was missing numbers in the precede restriction for Ids in the new parser.
@dwightguth please review.
