### PR TITLE
Fixing the 80 character per line issue.

### DIFF
--- a/src/javasources/KTool/src/org/kframework/compile/checks/CheckSyntaxDecl.java
+++ b/src/javasources/KTool/src/org/kframework/compile/checks/CheckSyntaxDecl.java
@@ -136,8 +136,8 @@ public class CheckSyntaxDecl extends BasicVisitor {
                     (node.containsAttribute("notInRules") && node.containsAttribute("notInGround")))
                     && node.containsAttribute("klabel"))) {
                 String msg = "Cannot declare empty terminals in the definition.\n";
-                msg += "            Use attribute 'onlyLabel' or 'notInRules' and 'notInGround' paired with 'klabel(...)' to limit the use to programs.";
-
+                msg += "        Use attribute 'onlyLabel', or both 'notInRules' and 'notInGround'\n";
+                msg += "        paired with 'klabel(...)' to limit the use to programs.";
                 GlobalSettings.kem.registerCompilerError(msg, this, node);
             }
         }


### PR DESCRIPTION
The error message now looks like this:

```
d:\work\k\samples\test>kompile test.k
[Error] Compiler: Cannot declare empty terminals in the definition.
        Use attribute 'onlyLabel', or both 'notInRules' and 'notInGround'
        paired with 'klabel(...)' to limit the use to programs.
        Source: File: d:\work\k\samples\test\test.k
        Location: (3,19,3,20)
```

@grosu please review.
