### PR TITLE
Safely borrowing SDF lexical syntax into the new parser.

### DIFF
--- a/src/javasources/KTool/src/org/kframework/compile/checks/CheckSyntaxDecl.java
+++ b/src/javasources/KTool/src/org/kframework/compile/checks/CheckSyntaxDecl.java
@@ -122,11 +122,14 @@ public class CheckSyntaxDecl extends BasicVisitor {
             }
         }
 
-        if (!isBinaryInfixProd(node)) {
-            if (node.containsAttribute(Constants.LEFT) || node.containsAttribute(Constants.RIGHT) || node.containsAttribute(Constants.NON_ASSOC)) {
-                String msg = "Associativity attribute should only be assigned to binary infix production.\n";
-                GlobalSettings.kem.registerCompilerWarning(msg, this, node);
-            }
+        if (!(node.getItems().get(0) instanceof NonTerminal) && node.containsAttribute(Constants.RIGHT)) {
+            String msg = "'" + Constants.RIGHT + "' should be used only on productions which start with a NonTerminal.\n";
+            GlobalSettings.kem.registerCompilerWarning(msg, this, node);
+        }
+
+        if (!(node.getItems().get(node.getItems().size() - 1) instanceof NonTerminal) && node.containsAttribute(Constants.LEFT)) {
+            String msg = "'" + Constants.LEFT + "' should be used only on productions which end with a NonTerminal.\n";
+            GlobalSettings.kem.registerCompilerWarning(msg, this, node);
         }
 
         if (eTerminals > 0 && (neTerminals == 0 || sorts < 2)) {
@@ -148,24 +151,5 @@ public class CheckSyntaxDecl extends BasicVisitor {
     public Void visit(Sentence node, Void _) {
         // optimization to not visit the entire tree
         return null;
-    }
-
-    private boolean isBinaryInfixProd(Production node) {
-        if (node.getArity() != 2) {
-            return false;
-        }
-        List<ProductionItem> prodItems = node.getItems();
-        if (prodItems.size() == 2) {
-            ProductionItem oprnd1 = node.getItems().get(0);
-            ProductionItem oprnd2 = node.getItems().get(1);
-            return (oprnd1 instanceof NonTerminal) && (oprnd2 instanceof NonTerminal);
-        } else if (prodItems.size() == 3) {
-            ProductionItem oprnd1 = node.getItems().get(0);
-            ProductionItem op = node.getItems().get(1);
-            ProductionItem oprnd2 = node.getItems().get(2);
-            return (oprnd1 instanceof NonTerminal) && (oprnd2 instanceof NonTerminal) && (op instanceof Terminal);
-        } else {
-            return false;
-        }
     }
 }

--- a/src/javasources/KTool/src/org/kframework/parser/concrete2/KSyntax2GrammarStatesFilter.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete2/KSyntax2GrammarStatesFilter.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import org.kframework.kil.Configuration;
 import org.kframework.kil.KSorts;
@@ -28,6 +29,7 @@ import org.kframework.parser.concrete2.Rule.AddLocationRule;
 import org.kframework.parser.concrete2.Rule.DeleteRule;
 import org.kframework.parser.concrete2.Rule.WrapLabelRule;
 import org.kframework.parser.generator.CollectTerminalsVisitor;
+import org.kframework.utils.general.GlobalSettings;
 
 /**
  * A simple visitor that goes through every accessible production and creates the NFA states for the
@@ -185,13 +187,24 @@ public class KSyntax2GrammarStatesFilter extends BasicVisitor {
             // T ::= Token{regex}
             // these kind of productions create KApps which contain token elements
             Lexical lx = prd.getLexical();
-            String pattern = prd.containsAttribute(Constants.REGEX) ?
-                                prd.getAttribute(Constants.REGEX) :
-                                lx.getLexicalRule();
+            Pattern p;
+            if (!prd.containsAttribute(Constants.REGEX)) {
+                // try to use the regular expression from SDF.
+                // If it's not compatible give a warning
+                try {
+                    p = Pattern.compile(lx.getLexicalRule());
+                } catch (PatternSyntaxException ex) {
+                    p = Pattern.compile("NoMatch");
+                    String msg = "Lexical pattern not compatible with the new parser.";
+                    GlobalSettings.kem.registerCompilerWarning(msg, lx);
+                }
+            } else {
+                p = Pattern.compile(prd.getAttribute(Constants.REGEX));
+            }
+
             // check to see which terminals match the current regular expression and send it to
             // the PrimitiveState for rejection
             Set<String> rejects = new HashSet<>();
-            Pattern p = Pattern.compile(pattern);
             if (!prd.containsAttribute("noAutoReject")) {
                 for (Terminal keyword : ctv.terminals) {
                     Matcher m = p.matcher(keyword.getTerminal());
@@ -205,7 +218,7 @@ public class KSyntax2GrammarStatesFilter extends BasicVisitor {
                 }
             }
             PrimitiveState pstate = new RegExState(prd.getSort().getName() + "-T",
-                nt, Pattern.compile(pattern), prd.getSort().getName(), rejects);
+                nt, p, prd.getSort().getName(), rejects);
             previous.next.add(pstate);
             previous = pstate;
         } else if (prd.isConstant(context)) { // TODO(Radu): properly determine if a production is a constant or not

--- a/src/javasources/KTool/src/org/kframework/parser/concrete2/KSyntax2GrammarStatesFilter.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete2/KSyntax2GrammarStatesFilter.java
@@ -196,7 +196,7 @@ public class KSyntax2GrammarStatesFilter extends BasicVisitor {
                 } catch (PatternSyntaxException ex) {
                     p = Pattern.compile("NoMatch");
                     String msg = "Lexical pattern not compatible with the new parser.";
-                    GlobalSettings.kem.registerCompilerWarning(msg, lx);
+                    GlobalSettings.kem.registerCompilerWarning(msg, ex, lx);
                 }
             } else {
                 p = Pattern.compile(prd.getAttribute(Constants.REGEX));


### PR DESCRIPTION
@dwightguth please review.
Should be a small fix. Some regular expressions from SDF are not supported by Java, throwing an exception even though the user doesn't care about that. In that case, just give a silent warning, and the definition would still kompile safely.
