### PR TITLE
fix #800

### DIFF
--- a/src/javasources/KTool/src/org/kframework/ktest/Test/KRunProgram.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Test/KRunProgram.java
@@ -2,6 +2,7 @@
 package org.kframework.ktest.Test;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kframework.ktest.ExecNames;
 import org.kframework.ktest.PgmArg;
 import org.kframework.utils.OS;
@@ -45,14 +46,23 @@ public class KRunProgram {
         for (int i = 0; i < args.size(); i++) {
             stringArgs.addAll(args.get(i).toStringList());
         }
-        String[] argsArr = new String[stringArgs.size()];
-        return stringArgs.toArray(argsArr);
+        String[] argsArr = stringArgs.toArray(new String[stringArgs.size()]);
+        if (OS.current() == OS.WIN) {
+            for (int i = 0; i < argsArr.length; i++) {
+                argsArr[i] = StringUtil.escapeShell(argsArr[i], OS.current());
+            }
+        }
+        return argsArr;
     }
 
     /**
      * @return String to be used in logging.
      */
     public String toLogString() {
+        if (OS.current() == OS.WIN) {
+            // OS is WIN, getKrunCmd will return args escaped
+            return StringUtils.join(getKrunCmd(), ' ');
+        }
         return StringUtil.escapeShell(getKrunCmd(), OS.current());
     }
 }

--- a/src/javasources/KTool/src/org/kframework/ktest/Test/TestCase.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Test/TestCase.java
@@ -2,6 +2,7 @@
 package org.kframework.ktest.Test;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kframework.ktest.*;
 import org.kframework.ktest.CmdArgs.KTestOptions;
 import org.kframework.ktest.Config.InvalidConfigError;
@@ -158,14 +159,22 @@ public class TestCase {
         for (int i = 0; i < kompileOpts.size(); i++) {
             stringArgs.addAll(kompileOpts.get(i).toStringList());
         }
-        String[] argsArr = new String[stringArgs.size()];
-        return stringArgs.toArray(argsArr);
+        String[] argsArr = stringArgs.toArray(new String[stringArgs.size()]);
+        if (OS.current() == OS.WIN) {
+            for (int i = 0; i < argsArr.length; i++) {
+                argsArr[i] = StringUtil.escapeShell(argsArr[i], OS.current());
+            }
+        }
+        return argsArr;
     }
 
     /**
      * @return String representation of kompile command to be used in logging.
      */
     public String toKompileLogString() {
+        if (OS.current() == OS.WIN) {
+            return StringUtils.join(getKompileCmd(), ' ');
+        }
         return StringUtil.escapeShell(getKompileCmd(), OS.current());
     }
 
@@ -203,13 +212,23 @@ public class TestCase {
      */
     public String[] getPdfCmd() {
         assert new File(getDefinition()).isFile();
-        return new String[] { ExecNames.getKompile(), "--backend", "pdf", getDefinition() };
+        String[] argsArr =
+                new String[] { ExecNames.getKompile(), "--backend", "pdf", getDefinition() };
+        if (OS.current() == OS.WIN) {
+            for (int i = 0; i < argsArr.length; i++) {
+                argsArr[i] = StringUtil.escapeShell(argsArr[i], OS.current());
+            }
+        }
+        return argsArr;
     }
 
     /**
      * @return String representation of PDF command to be used in logging.
      */
     public String toPdfLogString() {
+        if (OS.current() == OS.WIN) {
+            return StringUtils.join(getPdfCmd(), ' ');
+        }
         return StringUtil.escapeShell(getPdfCmd(), OS.current());
     }
 

--- a/src/javasources/KTool/src/org/kframework/utils/StringUtil.java
+++ b/src/javasources/KTool/src/org/kframework/utils/StringUtil.java
@@ -1,14 +1,9 @@
 // Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.utils;
 
-import java.util.Arrays;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.apache.commons.lang3.StringUtils;
 
 import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterDescription;
 
 public class StringUtil {
     /**
@@ -586,26 +581,20 @@ public class StringUtil {
         return new String[] {mainOptions.toString(), experimentalOptions.toString()};
     }
 
-    public static String escapeShell(String[] args, OS os) {
+    public static String escapeShell(String arg, OS os) {
         if (os.isPosix) {
-            StringBuilder sb = new StringBuilder();
-            for (String arg : args) {
-                sb.append("'");
-                sb.append(StringUtils.replace(arg, "'", "'\\''"));
-                sb.append("' ");
-            }
-            sb.deleteCharAt(sb.length() - 1);
-            return sb.toString();
+            return "'" + StringUtils.replace(arg, "'", "'\\''") + "'";
         } else if (os == OS.WIN) {
-            StringBuilder sb = new StringBuilder();
-            for (String arg : args) {
-                sb.append('"');
-                sb.append(StringUtils.replace(arg, "\"", "\\\""));
-                sb.append("\" ");
-            }
-            sb.deleteCharAt(sb.length() - 1);
-            return sb.toString();
+            return '"' + StringUtils.replace(arg, "\"", "\\\"") + '"';
         }
         throw new IllegalArgumentException("unsupported OS");
+    }
+
+    public static String escapeShell(String[] args, OS os) {
+        String[] args1 = new String[args.length];
+        for (int i = 0; i < args.length; i++) {
+            args1[i] = StringUtil.escapeShell(args[i], os);
+        }
+        return StringUtils.join(args1, ' ');
     }
 }


### PR DESCRIPTION
I'll let Jenkins run test suite on Linux and I'm manually running test suite on my Windows laptop. It's very slow so it'll probably take several hours.

In the meantime I need reviews. It turns out that the problem is really about string escaping. Based on the observation that I'm using the same shell on both Linux and Windows(bash) but still having different results(on Linux it works OK, on Windows it fails as shown in #800), I assumed that it's only related with the platform and not the shell. So I treated Windows as a special case in `getXYZCmd()` methods.

I also assumed that the test suite is running fine on OSX so special case is really Windows and not Linux.
