### PR TITLE
Adding Constant class and ProductionReference as a superclass of TermCons

### DIFF
--- a/src/javasources/KTool/src/org/kframework/backend/unparser/UnparserFilter.java
+++ b/src/javasources/KTool/src/org/kframework/backend/unparser/UnparserFilter.java
@@ -7,6 +7,7 @@ import org.kframework.krun.ColorSetting;
 import org.kframework.krun.KRunOptions;
 import org.kframework.krun.KRunOptions.OutputMode;
 import org.kframework.utils.ColorUtil;
+import org.kframework.utils.StringUtil;
 
 import java.awt.Color;
 import java.util.Iterator;
@@ -419,6 +420,13 @@ public class UnparserFilter extends NonCachingVisitor {
         } else {
             indenter.write(".K");
         }
+        return postpare();
+    }
+
+    @Override
+    public Void visit(Constant t, Void _) {
+        prepare(t);
+        indenter.write(t.getValue());
         return postpare();
     }
 

--- a/src/javasources/KTool/src/org/kframework/compile/transformers/FlattenTerms.java
+++ b/src/javasources/KTool/src/org/kframework/compile/transformers/FlattenTerms.java
@@ -59,18 +59,7 @@ public class FlattenTerms extends CopyOnWriteTransformer {
 
     @Override
     public ASTNode visit(Constant constant, Void _) {
-        Term rez;
-        if (constant.getSort().equals(Sort.KLIST)) {
-            rez = new KLabelConstant(constant.getValue());
-        } else {
-            // builtin token or lexical token
-            rez =  Token.kAppOf(constant.getSort(), constant.getValue());
-        }
-        rez.setLocation(constant.getLocation());
-        rez.setSource(constant.getSource());
-        rez.copyAttributesFrom(constant);
-
-        return this.visitNode(rez);
+        return kTrans.visitNode(constant);
     }
 
     class FlattenKSyntax extends CopyOnWriteTransformer {
@@ -96,6 +85,22 @@ public class FlattenTerms extends CopyOnWriteTransformer {
         @Override
         public ASTNode visit(Freezer node, Void _)  {
             return KApp.of(new FreezerLabel((Term) this.visitNode(node.getTerm())));
+        }
+
+        @Override
+        public ASTNode visit(Constant constant, Void _) {
+            Term rez;
+            if (constant.getSort().equals(Sort.KLIST)) {
+                rez = new KLabelConstant(constant.getValue());
+            } else {
+                // builtin token or lexical token
+                rez =  Token.kAppOf(constant.getSort(), constant.getValue());
+            }
+            rez.setLocation(constant.getLocation());
+            rez.setSource(constant.getSource());
+            rez.copyAttributesFrom(constant);
+
+            return this.visitNode(rez);
         }
 
         @Override

--- a/src/javasources/KTool/src/org/kframework/compile/transformers/FlattenTerms.java
+++ b/src/javasources/KTool/src/org/kframework/compile/transformers/FlattenTerms.java
@@ -90,7 +90,7 @@ public class FlattenTerms extends CopyOnWriteTransformer {
         @Override
         public ASTNode visit(Constant constant, Void _) {
             Term rez;
-            if (constant.getSort().equals(Sort.KLIST)) {
+            if (constant.getSort().equals(Sort.KLABEL)) {
                 rez = new KLabelConstant(constant.getValue());
             } else {
                 // builtin token or lexical token

--- a/src/javasources/KTool/src/org/kframework/kil/AbstractVisitor.java
+++ b/src/javasources/KTool/src/org/kframework/kil/AbstractVisitor.java
@@ -778,7 +778,7 @@ public abstract class AbstractVisitor<P, R, E extends Throwable> implements Visi
     @Override
     public R visit(TermCons node, P p) throws E {
         node = genericVisitList(node, p, mutableList(TermCons.class), null);
-        return visit((Term) node, p);
+        return visit((ProductionReference) node, p);
     }
 
     @Override

--- a/src/javasources/KTool/src/org/kframework/kil/AbstractVisitor.java
+++ b/src/javasources/KTool/src/org/kframework/kil/AbstractVisitor.java
@@ -766,6 +766,16 @@ public abstract class AbstractVisitor<P, R, E extends Throwable> implements Visi
     }
 
     @Override
+    public R visit(Constant node, P p) throws E {
+        return visit((Term) node, p);
+    }
+
+    @Override
+    public R visit(ProductionReference node, P p) throws E {
+        return visit((Term) node, p);
+    }
+
+    @Override
     public R visit(TermCons node, P p) throws E {
         node = genericVisitList(node, p, mutableList(TermCons.class), null);
         return visit((Term) node, p);

--- a/src/javasources/KTool/src/org/kframework/kil/AbstractVisitor.java
+++ b/src/javasources/KTool/src/org/kframework/kil/AbstractVisitor.java
@@ -767,7 +767,7 @@ public abstract class AbstractVisitor<P, R, E extends Throwable> implements Visi
 
     @Override
     public R visit(Constant node, P p) throws E {
-        return visit((Term) node, p);
+        return visit((ProductionReference) node, p);
     }
 
     @Override

--- a/src/javasources/KTool/src/org/kframework/kil/Constant.java
+++ b/src/javasources/KTool/src/org/kframework/kil/Constant.java
@@ -17,15 +17,32 @@ import java.util.Map;
  * and should be flattened into KIL classes after FlattenSyntax.
  */
 public class Constant extends ProductionReference {
+
     protected String value;
 
+    /**
+     * Represents a lexical production from the parser.
+     * Should be used only in the 'parser' package.
+     * @param sort Sort of the production.
+     * @param value String representation of the constant.
+     */
     public Constant(Sort sort, String value) {
         super(sort, null);
+        assert value != null;
         this.value = value;
     }
 
+    /**
+     * Represents a lexical production from the parser.
+     * Should be used only in the 'parser' package.
+     * @param sort Sort of the production.
+     * @param value String representation of the constant.
+     * @param p Reference to the production from which this node comes from. This is viewed as
+     *          metadata.
+     */
     public Constant(Sort sort, String value, Production p) {
         super(sort, p);
+        assert value != null;
         this.value = value;
     }
 

--- a/src/javasources/KTool/src/org/kframework/kil/Constant.java
+++ b/src/javasources/KTool/src/org/kframework/kil/Constant.java
@@ -1,0 +1,79 @@
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
+package org.kframework.kil;
+
+import org.kframework.kil.loader.Constants;
+import org.kframework.kil.loader.JavaClassesFactory;
+import org.kframework.kil.visitors.Visitor;
+import org.kframework.utils.StringUtil;
+import org.kframework.utils.xml.XML;
+import org.w3c.dom.Element;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The AST representation of tokens. This should be used only in the front end,
+ * and should be flattened into KIL classes after FlattenSyntax.
+ */
+public class Constant extends ProductionReference {
+    protected String value;
+
+    public Constant(Sort sort, String value) {
+        super(sort, null);
+        this.value = value;
+    }
+
+    public Constant(Sort sort, String value, Production p) {
+        super(sort, p);
+        this.value = value;
+    }
+
+    public Constant(Constant node) {
+        super(node);
+        this.value = node.value;
+        assert this.production != null;
+    }
+
+    @Override
+    public String toString() {
+        return "#token(" + StringUtil.enquoteKString(sort.getName()) + "," +
+                StringUtil.enquoteKString(value) + ")(.KList)";
+    }
+
+    @Override
+    protected <P, R, E extends Throwable> R accept(Visitor<P, R, E> visitor, P p) throws E {
+        return visitor.complete(this, visitor.visit(this, p));
+    }
+
+    @Override
+    public Constant shallowCopy() {
+        return new Constant(this);
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Constant)) return false;
+
+        Constant constant = (Constant) o;
+
+        if (!value.equals(constant.value)) return false;
+        if (!sort.equals(constant.sort)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode() + 31 * sort.hashCode();
+    }
+}

--- a/src/javasources/KTool/src/org/kframework/kil/ProductionReference.java
+++ b/src/javasources/KTool/src/org/kframework/kil/ProductionReference.java
@@ -1,3 +1,4 @@
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.kil;
 
 import org.kframework.kil.loader.Constants;

--- a/src/javasources/KTool/src/org/kframework/kil/ProductionReference.java
+++ b/src/javasources/KTool/src/org/kframework/kil/ProductionReference.java
@@ -1,0 +1,32 @@
+package org.kframework.kil;
+
+import org.kframework.kil.loader.Constants;
+import org.w3c.dom.Element;
+
+import java.util.Map;
+
+/**
+ * Created by Radu on 26.08.2014.
+ */
+public abstract class ProductionReference extends Term {
+    protected final Production production;
+
+    public ProductionReference(Element element, Map<String, Production> conses) {
+        super(element);
+        this.production = conses.get(element.getAttribute(Constants.CONS_cons_ATTR));
+    }
+
+    public ProductionReference(Sort sort, Production production) {
+        super(sort);
+        this.production = production;
+    }
+
+    public ProductionReference(ProductionReference pr) {
+        super(pr);
+        this.production = pr.production;
+    }
+
+    public Production getProduction() {
+        return production;
+    }
+}

--- a/src/javasources/KTool/src/org/kframework/kil/Term.java
+++ b/src/javasources/KTool/src/org/kframework/kil/Term.java
@@ -35,7 +35,6 @@ public abstract class Term extends ASTNode implements Comparable<Term> {
 
     public Term(Sort sort) {
         super();
-        assert sort != null;
         this.sort = sort;
     }
 

--- a/src/javasources/KTool/src/org/kframework/kil/Term.java
+++ b/src/javasources/KTool/src/org/kframework/kil/Term.java
@@ -35,6 +35,7 @@ public abstract class Term extends ASTNode implements Comparable<Term> {
 
     public Term(Sort sort) {
         super();
+        assert sort != null;
         this.sort = sort;
     }
 

--- a/src/javasources/KTool/src/org/kframework/kil/TermCons.java
+++ b/src/javasources/KTool/src/org/kframework/kil/TermCons.java
@@ -142,6 +142,15 @@ public class TermCons extends ProductionReference implements Interfaces.MutableL
         return cachedHashCode;
     }
 
+    /**
+     * TODO: (Radu) Make TermCons immutable
+     * At the moment TermCons is mutable, so I am hacking it this way to invalidate the cache
+     * but I will have to implement it correctly and make TermCons immutable.
+     */
+    public void invalidateHashCode() {
+        upToDateHash = false;
+    }
+
     @Override
     public boolean contains(Object obj) {
         if (obj == null)

--- a/src/javasources/KTool/src/org/kframework/kil/TermCons.java
+++ b/src/javasources/KTool/src/org/kframework/kil/TermCons.java
@@ -14,7 +14,7 @@ import org.w3c.dom.Element;
 /**
  * Applications that are not in sort K, or have not yet been flattened.
  */
-public class TermCons extends Term implements Interfaces.MutableList<Term, Enum<?>> {
+public class TermCons extends ProductionReference implements Interfaces.MutableList<Term, Enum<?>> {
     protected java.util.List<Term> contents;
 
     /**
@@ -25,15 +25,13 @@ public class TermCons extends Term implements Interfaces.MutableList<Term, Enum<
      * TODO(dwightguth): make TermCons used only in the parser where productions should not
      * change.
      */
-    protected final Production production;
 
     private int cachedHashCode = 0;
     private boolean upToDateHash = false;
 
     public TermCons(Element element, Map<String, Production> conses){
-        super(element);
+        super(element, conses);
         this.sort = Sort.of(element.getAttribute(Constants.SORT_sort_ATTR));
-        this.production = conses.get(element.getAttribute(Constants.CONS_cons_ATTR));
         assert this.production != null;
 
         contents = new ArrayList<Term>();
@@ -49,18 +47,12 @@ public class TermCons extends Term implements Interfaces.MutableList<Term, Enum<
     public TermCons(TermCons node) {
         super(node);
         this.contents = new ArrayList<Term>(node.contents);
-        this.production = node.production;
         assert this.production != null;
     }
 
     public TermCons(Sort psort, List<Term> contents, Production production) {
-        super(psort);
+        super(psort, production);
         this.contents = contents;
-        this.production = production;
-    }
-
-    public Production getProduction() {
-        return production;
     }
 
     @Override

--- a/src/javasources/KTool/src/org/kframework/kil/visitors/Visitor.java
+++ b/src/javasources/KTool/src/org/kframework/kil/visitors/Visitor.java
@@ -84,7 +84,9 @@ public interface Visitor<P, R, E extends Throwable> {
     public R visit(KLabelConstant node, P p) throws E;
     public R visit(KLabelInjection node, P p) throws E;
     public R visit(Rewrite node, P p) throws E;
+    public R visit(ProductionReference node, P p) throws E;
     public R visit(TermCons node, P p) throws E;
+    public R visit(Constant node, P p) throws E;
     public R visit(Bracket node, P p) throws E;
     public R visit(Cast node, P p) throws E;
     public R visit(Variable node, P p) throws E;

--- a/src/javasources/KTool/src/org/kframework/parser/ProgramLoader.java
+++ b/src/javasources/KTool/src/org/kframework/parser/ProgramLoader.java
@@ -131,16 +131,16 @@ public class ProgramLoader {
             Parser parser = new Parser(contentString);
             out = parser.parse(grammar.get(startSymbol), 0);
             if (context.globalOptions.debug)
-                System.out.println("Raw: " + out + "\n");
+                System.err.println("Raw: " + out + "\n");
             try {
                 out = new TreeCleanerVisitor(context).visitNode(out);
                 out = new MakeConsList(context).visitNode(out);
                 if (context.globalOptions.debug)
-                    System.out.println("Clean: " + out + "\n");
+                    System.err.println("Clean: " + out + "\n");
                 out = new PriorityFilter(context).visitNode(out);
                 out = new PreferAvoidFilter(context).visitNode(out);
                 if (context.globalOptions.debug)
-                    System.out.println("Filtered: " + out + "\n");
+                    System.err.println("Filtered: " + out + "\n");
                 out = new AmbFilter(context).visitNode(out);
                 out = new RemoveBrackets(context).visitNode(out);
                 out = new FlattenTerms(context).visitNode(out);

--- a/src/javasources/KTool/src/org/kframework/parser/concrete/disambiguate/AmbFilter.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete/disambiguate/AmbFilter.java
@@ -5,12 +5,14 @@ import org.kframework.backend.unparser.UnparserFilter;
 import org.kframework.kil.ASTNode;
 import org.kframework.kil.Ambiguity;
 import org.kframework.kil.BoolBuiltin;
+import org.kframework.kil.Constant;
 import org.kframework.kil.FloatBuiltin;
 import org.kframework.kil.GenericToken;
 import org.kframework.kil.IntBuiltin;
 import org.kframework.kil.KApp;
 import org.kframework.kil.Sort;
 import org.kframework.kil.StringBuiltin;
+import org.kframework.kil.Term;
 import org.kframework.kil.TermCons;
 import org.kframework.kil.loader.Context;
 import org.kframework.kil.visitors.ParseForestTransformer;
@@ -31,11 +33,12 @@ public class AmbFilter extends ParseForestTransformer {
 
         for (int i = 0; i < amb.getContents().size(); i++) {
             msg += "\n" + (i + 1) + ": ";
-            if (amb.getContents().get(i) instanceof TermCons) {
+            Term elem = amb.getContents().get(i);
+            if (elem instanceof TermCons) {
                 TermCons tc = (TermCons) amb.getContents().get(i);
                 msg += tc.getProduction().getSort() + " ::= ";
                 msg += tc.getProduction().toString();
-            } else if (amb.getContents().get(i) instanceof KApp) {
+            } else if (elem instanceof KApp) {
                 // TODO: RaduM. For the new parser this will be a class called Constant which
                 // points exactly to the production that generates the constant
                 KApp kApp = (KApp) amb.getContents().get(i);
@@ -51,9 +54,13 @@ public class AmbFilter extends ParseForestTransformer {
                 } else if (kApp.getLabel() instanceof IntBuiltin) {
                     msg += "Constant of type " + Sort.BUILTIN_INT;
                 }
+            } else if (elem instanceof Constant) {
+                Constant constant = (Constant) elem;
+                msg += constant.getProduction().getSort() + " ::= ";
+                msg += constant.getProduction().toString();
             }
             UnparserFilter unparserFilter = new UnparserFilter(context);
-            unparserFilter.visitNode(amb.getContents().get(i));
+            unparserFilter.visitNode(elem);
             msg += "\n   " + unparserFilter.getResult().replace("\n", "\n   ");
         }
         GlobalSettings.kem.register(new KException(ExceptionType.WARNING, KExceptionGroup.INNER_PARSER, msg, getName(), amb.getSource(), amb.getLocation()));

--- a/src/javasources/KTool/src/org/kframework/parser/concrete2/Grammar.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete2/Grammar.java
@@ -13,6 +13,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.kframework.kil.KSorts;
+import org.kframework.kil.Production;
 import org.kframework.parser.concrete2.Rule.DeleteRule;
 import org.kframework.utils.algorithms.SCCTarjan;
 
@@ -149,7 +150,7 @@ public class Grammar implements Serializable {
      */
     private NextableState addWhitespace(NextableState start) {
         PrimitiveState whitespace = new RegExState(
-            "whitespace", start.nt, pattern, KSorts.KITEM);
+            "whitespace", start.nt, pattern, null);
         RuleState deleteToken = new RuleState(
             "whitespace-D", start.nt, new DeleteRule(1, true));
         whitespace.next.add(deleteToken);
@@ -464,8 +465,8 @@ public class Grammar implements Serializable {
      * TODO: revisit this description once we get the new KORE
      */
     public abstract static class PrimitiveState extends NextableState {
-        /** The sort of the KApp */
-        public final String sort;
+        /** The production of the Constant. Used as a reference for trace back */
+        public final Production prd;
         public static class MatchResult {
             final public int matchEnd;
             public MatchResult(int matchEnd) {
@@ -479,10 +480,9 @@ public class Grammar implements Serializable {
          */
         abstract Set<MatchResult> matches(CharSequence text, int startPosition);
 
-        public PrimitiveState(String name, NonTerminal nt, String sort) {
+        public PrimitiveState(String name, NonTerminal nt, Production prd) {
             super(name, nt, true);
-            assert sort != null;
-            this.sort = sort;
+            this.prd = prd;
         }
 
         /**
@@ -505,15 +505,15 @@ public class Grammar implements Serializable {
         /** The set of terminals (keywords) that shouldn't be parsed as this regular expression. */
         public final Set<String> rejects;
 
-        public RegExState(String name, NonTerminal nt, Pattern pattern, String sort) {
-            super(name, nt, sort);
+        public RegExState(String name, NonTerminal nt, Pattern pattern, Production prd) {
+            super(name, nt, prd);
             assert pattern != null;
             this.pattern = pattern;
             this.rejects = new HashSet<>();
         }
 
-        public RegExState(String name, NonTerminal nt, Pattern pattern, String sort, Set<String> rejects) {
-            super(name, nt, sort);
+        public RegExState(String name, NonTerminal nt, Pattern pattern, Production prd, Set<String> rejects) {
+            super(name, nt, prd);
             assert pattern != null;
             this.pattern = pattern;
             this.rejects = rejects;

--- a/src/javasources/KTool/src/org/kframework/parser/concrete2/KSyntax2GrammarStatesFilter.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete2/KSyntax2GrammarStatesFilter.java
@@ -73,9 +73,9 @@ public class KSyntax2GrammarStatesFilter extends BasicVisitor {
                  *      +---[E]---(",")--<Del>--+
                  *           ^------------------+
                  */
-                RuleState labelState = new RuleState(ntName + "-L", nt, new WrapLabelRule(prd, prd.getSort()));
+                RuleState labelState = new RuleState(ntName + "-L", nt, new WrapLabelRule(prd));
                 NonTerminalState IdState = new NonTerminalState(ntName + "-S", nt, grammar.get(ul.getSort().getName()), false);
-                PrimitiveState separatorState = new RegExState(ntName + "-T", nt, Pattern.compile(ul.getSeparator(), Pattern.LITERAL), KSorts.KITEM);
+                PrimitiveState separatorState = new RegExState(ntName + "-T", nt, Pattern.compile(ul.getSeparator(), Pattern.LITERAL), null);
                 RuleState deleteToken = new RuleState(ntName + "-D", nt, new DeleteRule(1, true));
 
                 if (ul.getListType().equals(UserList.ZERO_OR_MORE)) {
@@ -126,7 +126,7 @@ public class KSyntax2GrammarStatesFilter extends BasicVisitor {
                 NonTerminal IdsTerminatorNt = new NonTerminal(prd.getSort() + "-Terminator");
                 {
                     RuleState terminatorLabelRule = new RuleState("AddLabelRS", IdsTerminatorNt,
-                            new WrapLabelRule(prd, prd.getSort()));
+                            new WrapLabelRule(prd));
                     RuleState locRule = new RuleState(prd.getSort() + "-R", IdsTerminatorNt,
                             new AddLocationRule());
 
@@ -141,13 +141,13 @@ public class KSyntax2GrammarStatesFilter extends BasicVisitor {
                     NonTerminalState IdState = new NonTerminalState(ntName + "-S", NeIdsNt,
                             grammar.get(ul.getSort().getName()), false);
                     PrimitiveState separatorState = new RegExState(ntName + "-T", NeIdsNt,
-                            Pattern.compile(ul.getSeparator(), Pattern.LITERAL), KSorts.KITEM);
+                            Pattern.compile(ul.getSeparator(), Pattern.LITERAL), null);
                     RuleState deleteToken = new RuleState(ntName + "-D", NeIdsNt,
                             new DeleteRule(1, true));
                     NonTerminalState NeIdsState = new NonTerminalState(ntName + "-S", NeIdsNt,
                             NeIdsNt, false);
                     RuleState labelState = new RuleState(ntName + "-L", NeIdsNt,
-                            new WrapLabelRule(prd, prd.getSort()));
+                            new WrapLabelRule(prd));
                     RuleState locRule = new RuleState(prd.getSort() + "-R", NeIdsNt,
                             new AddLocationRule());
 
@@ -218,7 +218,7 @@ public class KSyntax2GrammarStatesFilter extends BasicVisitor {
                 }
             }
             PrimitiveState pstate = new RegExState(prd.getSort().getName() + "-T",
-                nt, p, prd.getSort().getName(), rejects);
+                nt, p, prd, rejects);
             previous.next.add(pstate);
             previous = pstate;
         } else if (prd.isConstant(context)) { // TODO(Radu): properly determine if a production is a constant or not
@@ -227,7 +227,7 @@ public class KSyntax2GrammarStatesFilter extends BasicVisitor {
             Terminal terminal = prd.getConstant();
             PrimitiveState pstate = new RegExState(
                 prd.getSort().getName() + "-T", nt,
-                Pattern.compile(terminal.getTerminal(), Pattern.LITERAL), prd.getSort().getName());
+                Pattern.compile(terminal.getTerminal(), Pattern.LITERAL), prd);
             previous.next.add(pstate);
             previous = pstate;
         } else {
@@ -238,7 +238,7 @@ public class KSyntax2GrammarStatesFilter extends BasicVisitor {
                     Terminal terminal = (Terminal) prdItem;
                     PrimitiveState pstate = new RegExState(
                             prd.getSort() + "-T", nt,
-                            Pattern.compile(terminal.getTerminal(), Pattern.LITERAL), KSorts.KITEM);
+                            Pattern.compile(terminal.getTerminal(), Pattern.LITERAL), null);
                     previous.next.add(pstate);
                     RuleState del = new RuleState("DelTerminalRS", nt, new DeleteRule(1, true));
                     pstate.next.add(del);
@@ -254,7 +254,7 @@ public class KSyntax2GrammarStatesFilter extends BasicVisitor {
                 }
             }
             RuleState labelRule = new RuleState("AddLabelRS",
-                    nt, new WrapLabelRule(prd, prd.getSort()));
+                    nt, new WrapLabelRule(prd));
             previous.next.add(labelRule);
             previous = labelRule;
         }

--- a/src/javasources/KTool/src/org/kframework/parser/concrete2/Rule.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete2/Rule.java
@@ -72,15 +72,14 @@ public abstract class Rule implements Serializable {
      */
     public static class WrapLabelRule extends KListRule {
         private final Production label;
-        private final Sort sort;
-        public WrapLabelRule(Production label, Sort sort) {
-            assert label != null; assert sort != null;
-            this.label = label; this.sort = sort;
+        public WrapLabelRule(Production label) {
+            assert label != null;
+            this.label = label;
         }
         protected KList apply(KList klist, MetaData metaData) {
             //Term term = new KApp(label, klist);
-            Term term = new TermCons(this.sort, klist.getContents(), label);
-            term.setSort(this.sort);
+            Term term = new TermCons(label.getSort(), klist.getContents(), label);
+            term.setSort(label.getSort());
             return new KList(Arrays.asList(term));
         }
     }

--- a/src/javasources/KTool/src/org/kframework/parser/concrete2/TreeCleanerVisitor.java
+++ b/src/javasources/KTool/src/org/kframework/parser/concrete2/TreeCleanerVisitor.java
@@ -36,8 +36,11 @@ public class TreeCleanerVisitor extends ParseForestTransformer {
         ASTNode vis;
         if (tc.getProduction().getKLabel() == null)
             vis = this.visitNode(tc.getContents().get(0), _);
-        else
+        else {
+            // invalidate the hashCode cache
+            tc.invalidateHashCode();
             vis = super.visit(tc, _);
+        }
         return vis;
     }
 

--- a/src/javasources/KTool/test/org/kframework/parser/concrete2/ParserTest.java
+++ b/src/javasources/KTool/test/org/kframework/parser/concrete2/ParserTest.java
@@ -771,7 +771,7 @@ public class ParserTest {
         Term mexp = new TermCons(EXP_SORT, Arrays.asList(one), p1);
         Term expected = new TermCons(Sort.of("Exps"), Arrays.<Term>asList(amb(mexp, mone)), p2);
 
-        Assert.assertEquals("The error: ", expected.toString(), result2.toString());
+        Assert.assertEquals("The error: ", expected, result2);
     }
     public static Ambiguity amb(Term ... terms) {
         return new Ambiguity(Sort.K, Arrays.asList(terms));

--- a/src/javasources/KTool/test/org/kframework/parser/concrete2/ParserTest.java
+++ b/src/javasources/KTool/test/org/kframework/parser/concrete2/ParserTest.java
@@ -10,6 +10,7 @@ import junit.framework.Assert;
 
 import org.junit.Test;
 import org.kframework.kil.Ambiguity;
+import org.kframework.kil.Constant;
 import org.kframework.kil.KApp;
 import org.kframework.kil.KList;
 import org.kframework.kil.KSorts;
@@ -69,7 +70,7 @@ public class ParserTest {
     @Test
     public void testSingleToken() throws Exception {
         NonTerminal nt1 = new NonTerminal("StartNT");
-        RegExState res = new RegExState("RegExStid", nt1, Pattern.compile("[a-zA-Z0-9]+"), KSorts.K);
+        RegExState res = new RegExState("RegExStid", nt1, Pattern.compile("[a-zA-Z0-9]+"), null);
         Grammar grammar = new Grammar();
         grammar.add(nt1);
         nt1.entryState.next.add(res);
@@ -79,7 +80,7 @@ public class ParserTest {
         Parser parser = new Parser("asdfAAA1");
 
         Term result = parser.parse(nt1, 0);
-        Term expected = amb(klist(amb(klist(Token.kAppOf(Sort.K, "asdfAAA1")))));
+        Term expected = amb(klist(amb(klist(new Constant(Sort.K, "asdfAAA1")))));
         Assert.assertEquals("Single Token check: ", expected, result);
         Nullability nc = new Nullability(grammar) ;
         Assert.assertEquals("Expected Nullable NTs", true, nc.isNullable(nt1.entryState) && nc.isNullable(nt1.exitState));
@@ -91,9 +92,9 @@ public class ParserTest {
         // A ::= #token{"[a-zA-Z0-9]+ +"} #token{"[a-zA-Z0-9]+"} [klabel(seq)]
         NonTerminal nt1 = new NonTerminal("StartNT");
 
-        RegExState res1 = new RegExState("RegExStid", nt1, Pattern.compile("[a-zA-Z0-9]+ +"), KSorts.K);
-        RegExState res2 = new RegExState("RegExStid2", nt1, Pattern.compile("[a-zA-Z0-9]+"), KSorts.K);
-        RuleState rs = new RuleState("RuleStateId", nt1, new WrapLabelRule(label("seq"), Sort.K));
+        RegExState res1 = new RegExState("RegExStid", nt1, Pattern.compile("[a-zA-Z0-9]+ +"), null);
+        RegExState res2 = new RegExState("RegExStid2", nt1, Pattern.compile("[a-zA-Z0-9]+"), null);
+        RuleState rs = new RuleState("RuleStateId", nt1, new WrapLabelRule(label("seq")));
 
         nt1.entryState.next.add(res1);
         res1.next.add(res2);
@@ -105,7 +106,7 @@ public class ParserTest {
         Parser parser = new Parser("asdfAAA1 adfsf");
 
         Term result = parser.parse(nt1, 0);
-        Term expected = amb(klist(amb(klist(kapp("seq", Token.kAppOf(Sort.K, "asdfAAA1 "), Token.kAppOf(Sort.K, "adfsf"))))));
+        Term expected = amb(klist(amb(klist(kapp("seq", new Constant(Sort.K, "asdfAAA1 "), new Constant(Sort.K, "adfsf"))))));
         Assert.assertEquals("Single Token check: ", expected, result);
         Nullability nc = new Nullability(grammar) ;
         Assert.assertEquals("Expected Nullable NTs", true, nc.isNullable(nt1.entryState) && nc.isNullable(nt1.exitState));
@@ -118,12 +119,12 @@ public class ParserTest {
         //     | #token{"[A-Z0-2]+"} #token{"[3-9]*"} [klabel(s3)]
         NonTerminal nt1 = new NonTerminal("StartNT");
 
-        RegExState res1 = new RegExState("RegExStid", nt1, Pattern.compile("[a-z0-9]+"), KSorts.K);
-        RegExState res2 = new RegExState("RegExStid2", nt1, Pattern.compile("[A-Z0-2]+"), KSorts.K);
-        RegExState res3 = new RegExState("RegExStid3", nt1, Pattern.compile("[3-9]*"), KSorts.K);
+        RegExState res1 = new RegExState("RegExStid", nt1, Pattern.compile("[a-z0-9]+"), null);
+        RegExState res2 = new RegExState("RegExStid2", nt1, Pattern.compile("[A-Z0-2]+"), null);
+        RegExState res3 = new RegExState("RegExStid3", nt1, Pattern.compile("[3-9]*"), null);
 
-        RuleState rs1 = new RuleState("RuleStateId1", nt1, new WrapLabelRule(label("s1"), Sort.K));
-        RuleState rs3 = new RuleState("RuleStateId2", nt1, new WrapLabelRule(label("s3"), Sort.K));
+        RuleState rs1 = new RuleState("RuleStateId1", nt1, new WrapLabelRule(label("s1")));
+        RuleState rs3 = new RuleState("RuleStateId2", nt1, new WrapLabelRule(label("s3")));
 
         nt1.entryState.next.add(res1);
         nt1.entryState.next.add(res2);
@@ -139,19 +140,19 @@ public class ParserTest {
 
         {
             Term result = new Parser("abc").parse(nt1, 0);
-            Term expected = amb(klist(amb(klist(kapp("s1", Token.kAppOf(Sort.K, "abc"))))));
+            Term expected = amb(klist(amb(klist(kapp("s1", new Constant(Sort.K, "abc"))))));
             Assert.assertEquals("Single Token check: ", expected, result);
         }
 
         {
             Term result = new Parser("ABC").parse(nt1, 0);
-            Term expected = amb(klist(amb(klist(kapp("s3", Token.kAppOf(Sort.K, "ABC"), Token.kAppOf(Sort.K, ""))))));
+            Term expected = amb(klist(amb(klist(kapp("s3", new Constant(Sort.K, "ABC"), new Constant(Sort.K, ""))))));
             Assert.assertEquals("Single Token check: ", expected, result);
         }
 
         {
             Term result = new Parser("123").parse(nt1, 0);
-            Term expected = amb(klist(amb(klist(kapp("s1", Token.kAppOf(Sort.K, "123"))), klist(kapp("s3", Token.kAppOf(Sort.K, "12"), Token.kAppOf(Sort.K, "3"))))));
+            Term expected = amb(klist(amb(klist(kapp("s1", new Constant(Sort.K, "123"))), klist(kapp("s3", new Constant(Sort.K, "12"), new Constant(Sort.K, "3"))))));
             Assert.assertEquals("Single Token check: ", expected, result);
         }
         Nullability nc = new Nullability(grammar) ;
@@ -165,8 +166,8 @@ public class ParserTest {
 
         NonTerminal nt1 = new NonTerminal("StartNT");
 
-        RegExState res1 = new RegExState("RegExStid", nt1, Pattern.compile("[a-zA-Z0-9]"), KSorts.K);
-        RuleState rs3 = new RuleState("RuleStateId2", nt1, new WrapLabelRule(label("seq"), Sort.K));
+        RegExState res1 = new RegExState("RegExStid", nt1, Pattern.compile("[a-zA-Z0-9]"), null);
+        RuleState rs3 = new RuleState("RuleStateId2", nt1, new WrapLabelRule(label("seq")));
 
         nt1.entryState.next.add(res1);
         nt1.entryState.next.add(rs3);
@@ -179,7 +180,7 @@ public class ParserTest {
 
         {
             Term result = new Parser("abc").parse(nt1, 0);
-            Term expected = amb(klist(amb(klist(kapp("seq", Token.kAppOf(Sort.K, "a"), Token.kAppOf(Sort.K, "b"), Token.kAppOf(Sort.K, "c"))))));
+            Term expected = amb(klist(amb(klist(kapp("seq", new Constant(Sort.K, "a"), new Constant(Sort.K, "b"), new Constant(Sort.K, "c"))))));
             Assert.assertEquals("Single Token check: ", expected, result);
         }
 
@@ -221,10 +222,10 @@ public class ParserTest {
         //     | x A y [klabel(xAy)]
         NonTerminal nt1 = new NonTerminal("StartNT");
 
-        RegExState resx = new RegExState("RegExStidx", nt1, Pattern.compile("x"), KSorts.K);
-        RegExState resy = new RegExState("RegExStidy", nt1, Pattern.compile("y"), KSorts.K);
-        RuleState rs1 = new RuleState("RuleStateId1", nt1, new WrapLabelRule(label("xAy"), Sort.K));
-        RuleState rs3 = new RuleState("RuleStateId2", nt1, new WrapLabelRule(label("epsilon"), Sort.K));
+        RegExState resx = new RegExState("RegExStidx", nt1, Pattern.compile("x"), null);
+        RegExState resy = new RegExState("RegExStidy", nt1, Pattern.compile("y"), null);
+        RuleState rs1 = new RuleState("RuleStateId1", nt1, new WrapLabelRule(label("xAy")));
+        RuleState rs3 = new RuleState("RuleStateId2", nt1, new WrapLabelRule(label("epsilon")));
 
         NonTerminalState nts = new NonTerminalState("NT", nt1, nt1, false);
 
@@ -250,12 +251,12 @@ public class ParserTest {
             Term result = new Parser("xxyy").parse(nt1, 0);
             Term expected =
                 amb(klist(amb(klist(kapp("xAy",
-                    Token.kAppOf(Sort.K, "x"),
+                        new Constant(Sort.K, "x"),
                     amb(klist(kapp("xAy",
-                        Token.kAppOf(Sort.K, "x"),
+                            new Constant(Sort.K, "x"),
                         amb(klist(kapp("epsilon"))),
-                        Token.kAppOf(Sort.K, "y")))),
-                    Token.kAppOf(Sort.K, "y"))))));
+                            new Constant(Sort.K, "y")))),
+                        new Constant(Sort.K, "y"))))));
             Assert.assertEquals("x^ny^n check: ", expected, result);
         }
         Nullability nc = new Nullability(grammar) ;
@@ -269,11 +270,11 @@ public class ParserTest {
         //     | A y [klabel(Ay)]
         NonTerminal nt1 = new NonTerminal("StartNT");
 
-        RegExState resy = new RegExState("RegExStidy", nt1, Pattern.compile("y"), KSorts.K);
+        RegExState resy = new RegExState("RegExStidy", nt1, Pattern.compile("y"), null);
 
         NonTerminalState nts = new NonTerminalState("NT", nt1, nt1, false);
-        RuleState rs1 = new RuleState("RuleStateId1", nt1, new WrapLabelRule(label("Ay"), Sort.K));
-        RuleState rs3 = new RuleState("RuleStateId2", nt1, new WrapLabelRule(label("epsilon"), Sort.K));
+        RuleState rs1 = new RuleState("RuleStateId1", nt1, new WrapLabelRule(label("Ay")));
+        RuleState rs3 = new RuleState("RuleStateId2", nt1, new WrapLabelRule(label("epsilon")));
 
         nt1.entryState.next.add(nts);
         nt1.entryState.next.add(rs3);
@@ -297,8 +298,8 @@ public class ParserTest {
                 amb(klist(amb(klist(kapp("Ay",
                     amb(klist(kapp("Ay",
                         amb(klist(kapp("epsilon"))),
-                        Token.kAppOf(Sort.K, "y")))),
-                    Token.kAppOf(Sort.K, "y"))))));
+                            new Constant(Sort.K, "y")))),
+                        new Constant(Sort.K, "y"))))));
             Assert.assertEquals("y^n check: ", expected, result);
         }
         Nullability nc = new Nullability(grammar) ;
@@ -312,11 +313,11 @@ public class ParserTest {
         //     | x A [klabel(xA)]
         NonTerminal nt1 = new NonTerminal("StartNT");
 
-        RegExState resx = new RegExState("RegExStidx", nt1, Pattern.compile("x"), KSorts.K);
+        RegExState resx = new RegExState("RegExStidx", nt1, Pattern.compile("x"), null);
 
         NonTerminalState nts = new NonTerminalState("NT", nt1, nt1, false);
-        RuleState rs1 = new RuleState("RuleStateId1", nt1, new WrapLabelRule(label("xA"), Sort.K));
-        RuleState rs3 = new RuleState("RuleStateId2", nt1, new WrapLabelRule(label("epsilon"), Sort.K));
+        RuleState rs1 = new RuleState("RuleStateId1", nt1, new WrapLabelRule(label("xA")));
+        RuleState rs3 = new RuleState("RuleStateId2", nt1, new WrapLabelRule(label("epsilon")));
 
         nt1.entryState.next.add(resx);
         nt1.entryState.next.add(rs3);
@@ -339,9 +340,9 @@ public class ParserTest {
             Term result = new Parser("xx").parse(nt1, 0);
             Term expected =
                 amb(klist(amb(klist(kapp("xA",
-                        Token.kAppOf(Sort.K, "x"),
+                        new Constant(Sort.K, "x"),
                         amb(klist(kapp("xA",
-                                Token.kAppOf(Sort.K, "x"),
+                                new Constant(Sort.K, "x"),
                                 amb(klist(kapp("epsilon")))))))))));
             Assert.assertEquals("x^n check: ", expected, result);
         }
@@ -356,13 +357,13 @@ public class ParserTest {
         //     | A A [klabel(AA)]
         NonTerminal nt1 = new NonTerminal("StartNT");
 
-        RegExState resx = new RegExState("RegExStidx", nt1,Pattern.compile("x"), KSorts.K);//, label("x"), KSorts.K);
+        RegExState resx = new RegExState("RegExStidx", nt1,Pattern.compile("x"), null);
 
         NonTerminalState nts1 = new NonTerminalState("NT1", nt1, nt1, false);
         NonTerminalState nts2 = new NonTerminalState("NT2", nt1, nt1, false);//, label("AA"), KSorts.K);
 
-        RuleState rs1 = new RuleState("RuleStateId1", nt1, new WrapLabelRule(label("x"), Sort.K));
-        RuleState rs3 = new RuleState("RuleStateId2", nt1, new WrapLabelRule(label("AA"), Sort.K));
+        RuleState rs1 = new RuleState("RuleStateId1", nt1, new WrapLabelRule(label("x")));
+        RuleState rs3 = new RuleState("RuleStateId2", nt1, new WrapLabelRule(label("AA")));
 
 
         nt1.entryState.next.add(resx);
@@ -381,16 +382,16 @@ public class ParserTest {
 
         {
             Term result = new Parser("x").parse(nt1, 0);
-            Term expected = amb(klist(amb(klist(kapp("x", Token.kAppOf(Sort.K, "x"))))));
+            Term expected = amb(klist(amb(klist(kapp("x", new Constant(Sort.K, "x"))))));
             Assert.assertEquals("Single char check: ", expected, result);
         }
 
         {
             Term result = new Parser("xx").parse(nt1, 0);
-            Term expected = amb(klist(amb(klist(kapp("AA", amb(klist(kapp("x", Token.kAppOf(Sort.K, "x")))), amb(klist(kapp("x", Token.kAppOf(Sort.K, "x")))))))));
+            Term expected = amb(klist(amb(klist(kapp("AA", amb(klist(kapp("x", new Constant(Sort.K, "x")))), amb(klist(kapp("x", new Constant(Sort.K, "x")))))))));
             Assert.assertEquals("AA check: ", expected, result);
         }
-        Term X = kapp("x", Token.kAppOf(Sort.K, "x"));
+        Term X = kapp("x", new Constant(Sort.K, "x"));
         {
             Term result = new Parser("xxx").parse(nt1, 0);
             Term expected = amb(klist(amb(klist(kapp("AA", amb(klist(kapp("AA", amb(klist(X)), amb(klist(X))))), amb(klist(X)))),
@@ -419,19 +420,19 @@ public class ParserTest {
         // An ::= An-1 [klabel(n[n-1])]
         // start symb is An
         NonTerminal baseCase = new NonTerminal("BaseCase");
-        RegExState resx = new RegExState("X", baseCase, Pattern.compile("x"), KSorts.K);
-        RuleState rs1 = new RuleState("RuleStateId1", baseCase, new WrapLabelRule(label("x"), Sort.K));
+        RegExState resx = new RegExState("X", baseCase, Pattern.compile("x"), null);
+        RuleState rs1 = new RuleState("RuleStateId1", baseCase, new WrapLabelRule(label("x")));
 
         baseCase.entryState.next.add(resx);
         resx.next.add(rs1);
         rs1.next.add(baseCase.exitState);
 
-        Term expected = amb(klist(kapp("x", Token.kAppOf(Sort.K, "x"))));
+        Term expected = amb(klist(kapp("x", new Constant(Sort.K, "x"))));
 
         for (int i = 2; i < 10; i++) {
             NonTerminal nt = new NonTerminal("NT"+i);
             NonTerminalState state = new NonTerminalState("S"+i, nt, baseCase, false);
-            RuleState rs2 = new RuleState("RuleStateId" + i, nt, new WrapLabelRule(label("n" + i), Sort.K));
+            RuleState rs2 = new RuleState("RuleStateId" + i, nt, new WrapLabelRule(label("n" + i)));
             nt.entryState.next.add(state);
             state.next.add(rs2);
             rs2.next.add(nt.exitState);
@@ -461,19 +462,19 @@ public class ParserTest {
         // start symb is An
 
         NonTerminal baseCase = new NonTerminal("BaseCase");
-        RegExState resx = new RegExState("X", baseCase, Pattern.compile(""), KSorts.K);
-        RuleState rs1 = new RuleState("RuleStateId1", baseCase, new WrapLabelRule(label("x"), Sort.K));
+        RegExState resx = new RegExState("X", baseCase, Pattern.compile(""), null);
+        RuleState rs1 = new RuleState("RuleStateId1", baseCase, new WrapLabelRule(label("x")));
 
         baseCase.entryState.next.add(resx);
         resx.next.add(rs1);
         rs1.next.add(baseCase.exitState);
 
-        Term expected = amb(klist(kapp("x", Token.kAppOf(Sort.K, ""))));
+        Term expected = amb(klist(kapp("x", new Constant(Sort.K, ""))));
 
         for (int i = 2; i < 10; i++) {
             NonTerminal nt = new NonTerminal("NT"+i);
             NonTerminalState state = new NonTerminalState("S"+i, nt, baseCase, false);
-            RuleState rs2 = new RuleState("RuleStateId" + i, nt, new WrapLabelRule(label("n" + i), Sort.K));
+            RuleState rs2 = new RuleState("RuleStateId" + i, nt, new WrapLabelRule(label("n" + i)));
             nt.entryState.next.add(state);
             state.next.add(rs2);
             rs2.next.add(nt.exitState);
@@ -507,23 +508,23 @@ public class ParserTest {
         NonTerminal exp = new NonTerminal("Exp");
 
         { // lit
-            RegExState litState = new RegExState("LitState", lit, Pattern.compile("[0-9]+"), KSorts.K);
-            RuleState rs1 = new RuleState("RuleStateId1", lit, new WrapLabelRule(label("lit"), Sort.K));
+            RegExState litState = new RegExState("LitState", lit, Pattern.compile("[0-9]+"), null);
+            RuleState rs1 = new RuleState("RuleStateId1", lit, new WrapLabelRule(label("lit")));
             lit.entryState.next.add(litState);
             litState.next.add(rs1);
             rs1.next.add(lit.exitState);
         }
 
         { // trm
-            RegExState lparen = new RegExState("LParen", trm, Pattern.compile("\\("), KSorts.K);
-            RegExState rparen = new RegExState("RParen", trm, Pattern.compile("\\)"), KSorts.K);
-            RuleState rs1 = new RuleState("RuleStateId1", trm, new WrapLabelRule(label("bracket"), Sort.K));
+            RegExState lparen = new RegExState("LParen", trm, Pattern.compile("\\("), null);
+            RegExState rparen = new RegExState("RParen", trm, Pattern.compile("\\)"), null);
+            RuleState rs1 = new RuleState("RuleStateId1", trm, new WrapLabelRule(label("bracket")));
 
-            RegExState star = new RegExState("Star", trm, Pattern.compile("\\*"), KSorts.K);
+            RegExState star = new RegExState("Star", trm, Pattern.compile("\\*"), null);
             NonTerminalState expState = new NonTerminalState("Trm->Exp", trm, exp, false);
             NonTerminalState trmState = new NonTerminalState("Trm->Trm", trm, trm, false);
             NonTerminalState lit1State = new NonTerminalState("Trm->Lit1", trm, lit, false);
-            RuleState rs2 = new RuleState("RuleStateId2", trm, new WrapLabelRule(label("mul"), Sort.K));
+            RuleState rs2 = new RuleState("RuleStateId2", trm, new WrapLabelRule(label("mul")));
 
             NonTerminalState lit2State = new NonTerminalState("Trm->Lit2", trm, lit, false);
 
@@ -544,10 +545,10 @@ public class ParserTest {
         }
 
         { // exp
-            RegExState plus = new RegExState("Plus", exp, Pattern.compile("\\+"), KSorts.K);
+            RegExState plus = new RegExState("Plus", exp, Pattern.compile("\\+"), null);
             NonTerminalState expState = new NonTerminalState("Exp->Exp", exp, exp, false);
             NonTerminalState trm1State = new NonTerminalState("Exp->Trm1", exp, trm, false);
-            RuleState rs1 = new RuleState("RuleStateId3", exp, new WrapLabelRule(label("plus"), Sort.K));
+            RuleState rs1 = new RuleState("RuleStateId3", exp, new WrapLabelRule(label("plus")));
             NonTerminalState trm2State = new NonTerminalState("Exp->Trm2", exp, trm, false);
 
             exp.entryState.next.add(expState);
@@ -705,7 +706,7 @@ public class ParserTest {
         // Int
         // (|-----([\+-]?\d+)------|)
         NonTerminal intNt = new NonTerminal("Int");
-        PrimitiveState ints = new RegExState("Int-State", intNt, Pattern.compile("[\\+-]?\\d+"), "Int");
+        PrimitiveState ints = new RegExState("Int-State", intNt, Pattern.compile("[\\+-]?\\d+"), null);
         intNt.entryState.next.add(ints);
         ints.next.add(intNt.exitState);
 
@@ -719,17 +720,17 @@ public class ParserTest {
 
         NonTerminalState expInt = new NonTerminalState("Int-nts(Exp)", expNt, intNt, false);
         Production p22 = prod(EXP_SORT, new org.kframework.kil.NonTerminal(Sort.INT));
-        RuleState rs2 = new RuleState("Exp-wrapInt", expNt, new WrapLabelRule(p22, Sort.INT));
+        RuleState rs2 = new RuleState("Exp-wrapInt", expNt, new WrapLabelRule(p22));
         expNt.entryState.next.add(expInt);
         expInt.next.add(rs2);
         rs2.next.add(expNt.exitState);
 
-        PrimitiveState minus = new RegExState("Minus-State", expNt, Pattern.compile("-", Pattern.LITERAL), KSorts.K);
+        PrimitiveState minus = new RegExState("Minus-State", expNt, Pattern.compile("-", Pattern.LITERAL), null);
         RuleState deleteToken = new RuleState("Minus-Delete", expNt, new DeleteRule(1, true));
         NonTerminalState expExp = new NonTerminalState("Exp-nts(Exp)", expNt, expNt, false);
         Production p1 = prod(EXP_SORT, new Terminal("-"), new org.kframework.kil.NonTerminal(EXP_SORT));
         p1.putAttribute("klabel", "'-_");
-        RuleState rs1 = new RuleState("Exps-wrapMinus", expNt, new WrapLabelRule(p1, Sort.INT));
+        RuleState rs1 = new RuleState("Exps-wrapMinus", expNt, new WrapLabelRule(p1));
         expNt.entryState.next.add(minus);
         minus.next.add(deleteToken);
         deleteToken.next.add(expExp);
@@ -745,10 +746,10 @@ public class ParserTest {
         NonTerminal expsNt = new NonTerminal("Exps");
         NonTerminalState expExps = new NonTerminalState("Exp-nts(Exps)", expsNt, expNt, false);
         Production p2 = prod(Sort.of("Exps"), new UserList(EXP_SORT, ","));
-        PrimitiveState separator = new RegExState("Sep-State", expsNt, Pattern.compile(",", Pattern.LITERAL), KSorts.K);
+        PrimitiveState separator = new RegExState("Sep-State", expsNt, Pattern.compile(",", Pattern.LITERAL), null);
         RuleState deleteToken2 = new RuleState("Separator-Delete", expsNt, new DeleteRule(1, true));
         p2.putAttribute("klabel", "'_,_");
-        RuleState labelList = new RuleState("RuleStateExps", expsNt, new WrapLabelRule(p2, Sort.of("Exps")));
+        RuleState labelList = new RuleState("RuleStateExps", expsNt, new WrapLabelRule(p2));
         expsNt.entryState.next.add(expExps);
         expExps.next.add(expExps); // circularity
         separator.next.add(deleteToken2);
@@ -765,10 +766,10 @@ public class ParserTest {
         Term result2 = (Term) new TreeCleanerVisitor(null).visitNode(result);
         //System.out.println(result2);
 
-        Term one = Token.kAppOf(Sort.INT, "1");
-        Term mone = Token.kAppOf(Sort.INT, "-1");
+        Term one = new Constant(Sort.K, "1");
+        Term mone = new Constant(Sort.K, "-1");
         Term mexp = new TermCons(EXP_SORT, Arrays.asList(one), p1);
-        Term expected = new TermCons(Sort.of("Exps"), Arrays.<Term>asList(amb(mone, mexp)), p2);
+        Term expected = new TermCons(Sort.of("Exps"), Arrays.<Term>asList(amb(mexp, mone)), p2);
 
         Assert.assertEquals("The error: ", expected.toString(), result2.toString());
     }
@@ -776,8 +777,8 @@ public class ParserTest {
         return new Ambiguity(Sort.K, Arrays.asList(terms));
     }
 
-    public static KApp token(String x) {
-        return Token.kAppOf(Sort.K, x);
+    public static Constant token(String x) {
+        return new Constant(Sort.K, x);
     }
 
     public static Production prod(Sort sort, ProductionItem... pi) {
@@ -793,6 +794,7 @@ public class ParserTest {
     }
 
     public static Production label(String x) {
+        // using UserList to avoid arity checks
         return prod(Sort.K, new UserList(Sort.K, x));
     }
 }


### PR DESCRIPTION
This allows for better error reporting in the new parser when having ambiguities.
It will also allow for more simple disambiguation filters.

@dwightguth please review. We talked about this change a while back, and now I got to it.
Basically now the new parser outputs only two types of objects: TermCons and Constant, bot having a reference to the production from which they come from.
