### PR TITLE
improvements on ktest reporting

### DIFF
--- a/src/javasources/KTool/src/org/kframework/ktest/Test/TestSuite.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Test/TestSuite.java
@@ -430,38 +430,18 @@ public class TestSuite {
         if (errorContents != null)
             errorContentsAnn = new Annotated<>(errorContents, program.errorFile);
 
-        if (verbose)
-            printVerboseRunningMsg(program);
         StringMatcher matcher = strComparator;
         if (program.regex) {
             matcher = new RegexStringMatcher();
         }
-        Proc<KRunProgram> p = new Proc<>(program, args, inputContents, outputContentsAnn,
-                errorContentsAnn, program.toLogString(), matcher, timeout, verbose,
-                colorSetting, terminalColor, updateOut, generateOut, program.outputFile,
+        Proc<KRunProgram> p = new Proc<>(program, args, program.inputFile, inputContents,
+                outputContentsAnn, errorContentsAnn, program.toLogString(), matcher, timeout,
+                verbose, colorSetting, terminalColor, updateOut, generateOut, program.outputFile,
                 program.newOutputFile);
         p.setWorkingDir(new File(program.defPath));
         tpe.execute(p);
         krunSteps++;
         return p;
-    }
-
-    private void printVerboseRunningMsg(KRunProgram program) {
-        StringBuilder b = new StringBuilder();
-        b.append("Running [");
-        b.append(program.toLogString());
-        b.append("]");
-        if (program.inputFile != null) {
-            b.append(" [input: ");
-            b.append(program.inputFile);
-            b.append("]");
-        }
-        if (program.outputFile != null) {
-            b.append(" [output: ");
-            b.append(program.outputFile);
-            b.append("]");
-        }
-        System.out.println(b);
     }
 
     private void printResult(boolean condition) {


### PR DESCRIPTION
@grosu please review outputs.

I changed two things:
- `Running [<command>] [output: <output file>] [input: <input file>]` lines while running krun steps were printed all at once. So for example if I have 50 programs to test, I was seeing 50 lines of `Running ...` lines but for most programs the actual running was happening a lot later. Now it prints `Running ...` lines just before starting the process.
- `Running ...` lines were only printed for krun steps. Now they're printed for kompile and pdf steps too.

These changes are only effect verbose outputs and are completely optional, if you don't like it please close the pull request. The reason why I did this is printing 100 `Running ...` lines at once looked very useless to me because it doesn't help with tracking the progress or anything.

For comparison, here's an example output before this patch:

```
➜  1_untyped git:(verbose-out) ✗ ktest tests/config.xml -v --threads 2
Running initial scripts...
SUCCESS
Kompile the language definitions...(1 in total)
Done with ['/home/omer/K/k_new_dist/k/bin/kompile' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/simple-untyped.k' '--superheat' 'strict'] (time 5359 ms)
SUCCESS
Generate PDF files...(1 in total)
ERROR: ['/home/omer/K/k_new_dist/k/bin/kompile' '--backend' 'pdf' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/simple-untyped.k'] failed with error (time: 14376 ms)                                                    
error was: [Error] Compiler: pdflatex returned a non-zero exit code. The pdf might be
generated, but with bugs. Please inspect the latex logs.

FAIL
Running /home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/simple-untyped.k programs... (3 in total, 0 with input, 3 with output, 0 with error)
Running ['/home/omer/K/k_new_dist/k/bin/krun' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_01.simple' '--output' 'none' '--directory' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped'] [output: /home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_01.simple.out]
Running ['/home/omer/K/k_new_dist/k/bin/krun' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_02.simple' '--output' 'none' '--directory' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped'] [output: /home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_02.simple.out]
Running ['/home/omer/K/k_new_dist/k/bin/krun' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_03.simple' '--output' 'none' '--directory' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped'] [output: /home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_03.simple.out]
Done with ['/home/omer/K/k_new_dist/k/bin/krun' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_02.simple' '--output' 'none' '--directory' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped'] (time 3077 ms)
Done with ['/home/omer/K/k_new_dist/k/bin/krun' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_01.simple' '--output' 'none' '--directory' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped'] (time 3250 ms)
Done with ['/home/omer/K/k_new_dist/k/bin/krun' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_03.simple' '--output' 'none' '--directory' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped'] (time 2003 ms)
SUCCESS

FAIL (see details above)
----------------------------
Definitions kompiled: 1 (time: 0'5'' elapsed, 0'5'' CPU)
PDF posters kompiled: 1 (time: 0'14'' elapsed, 0'14'' CPU)
Programs krun: 3 (time: 0'5'' elapsed, 0'8'' CPU)
Total time: 0'24'' elapsed, 0'27'' CPU
----------------------------
```

This is after:

```
➜  1_untyped git:(verbose-out) ✗ ktest tests/config.xml -v --threads 2
Running initial scripts...
SUCCESS
Kompile the language definitions...(1 in total)
Running ['/home/omer/K/k_new_dist/k/bin/kompile' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/simple-untyped.k' '--superheat' 'strict']
Done with ['/home/omer/K/k_new_dist/k/bin/kompile' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/simple-untyped.k' '--superheat' 'strict'] (time 5295 ms)
SUCCESS
Generate PDF files...(1 in total)
Running ['/home/omer/K/k_new_dist/k/bin/kompile' '--backend' 'pdf' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/simple-untyped.k']
ERROR: ['/home/omer/K/k_new_dist/k/bin/kompile' '--backend' 'pdf' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/simple-untyped.k'] failed with error (time: 14325 ms)
error was: [Error] Compiler: pdflatex returned a non-zero exit code. The pdf might be
generated, but with bugs. Please inspect the latex logs.

FAIL
Running /home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/simple-untyped.k programs... (3 in total, 0 with input, 3 with output, 0 with error)
Running ['/home/omer/K/k_new_dist/k/bin/krun' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_01.simple' '--output' 'none' '--directory' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped'] [output: /home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_01.simple.out]
Running ['/home/omer/K/k_new_dist/k/bin/krun' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_02.simple' '--output' 'none' '--directory' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped'] [output: /home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_02.simple.out]
Done with ['/home/omer/K/k_new_dist/k/bin/krun' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_02.simple' '--output' 'none' '--directory' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped'] (time 3071 ms)
Running ['/home/omer/K/k_new_dist/k/bin/krun' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_03.simple' '--output' 'none' '--directory' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped'] [output: /home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_03.simple.out]
Done with ['/home/omer/K/k_new_dist/k/bin/krun' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_01.simple' '--output' 'none' '--directory' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped'] (time 3197 ms)
Done with ['/home/omer/K/k_new_dist/k/bin/krun' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped/tests/exceptions/exceptions_03.simple' '--output' 'none' '--directory' '/home/omer/K/k_new_dist/k/tutorial/2_languages/1_simple/1_untyped'] (time 1930 ms)
SUCCESS

FAIL (see details above)
----------------------------
Definitions kompiled: 1 (time: 0'5'' elapsed, 0'5'' CPU)
PDF posters kompiled: 1 (time: 0'14'' elapsed, 0'14'' CPU)
Programs krun: 3 (time: 0'5'' elapsed, 0'8'' CPU)
Total time: 0'24'' elapsed, 0'27'' CPU
----------------------------
```
