### PR TITLE
--dry should not print commands with output redirections by default (see details inside)

### DIFF
--- a/src/javasources/KTool/src/org/kframework/ktest/Test/TestCase.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Test/TestCase.java
@@ -156,8 +156,8 @@ public class TestCase {
         List<String> stringArgs = new ArrayList<String>();
         stringArgs.add(ExecNames.getKompile());
         stringArgs.add(getDefinition());
-        for (int i = 0; i < kompileOpts.size(); i++) {
-            stringArgs.addAll(kompileOpts.get(i).toStringList());
+        for (PgmArg kompileOpt : kompileOpts) {
+            stringArgs.addAll(kompileOpt.toStringList());
         }
         String[] argsArr = stringArgs.toArray(new String[stringArgs.size()]);
         if (OS.current() == OS.WIN) {

--- a/src/javasources/KTool/src/org/kframework/ktest/Test/TestSuite.java
+++ b/src/javasources/KTool/src/org/kframework/ktest/Test/TestSuite.java
@@ -155,8 +155,10 @@ public class TestSuite {
                 for (KRunProgram program : programs) {
                     StringBuilder krunLogCmd = new StringBuilder();
                     krunLogCmd.append(program.toLogString());
-                    if (program.outputFile != null)
+                    if (updateOut && program.outputFile != null)
                         krunLogCmd.append(" >").append(program.outputFile);
+                    else if (generateOut && program.newOutputFile != null)
+                        krunLogCmd.append(" >").append(program.newOutputFile);
                     if (program.inputFile != null)
                         krunLogCmd.append(" <").append(program.inputFile);
                     System.out.println(krunLogCmd.toString());


### PR DESCRIPTION
ktest's `--dry` was generating commands with `... > output_file` parts. That was wrong because ktest generates output files only when `--generate-out` or `--update-out` arguments are provided.

(Also discussed at #892)

With this patch, `--dry` only generates `... > output_file` parts when `--generate-out` and `--update-out` are provided, and printed paths are same as what ktest would use when that arguments are used.

@daejunpark Small patch but I still don't understand `--generate-out` in all details so it'd be nice if you could review.
