### PR TITLE
Make Term#hashcode in Java backend transient

### DIFF
--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/Bottom.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/Bottom.java
@@ -1,8 +1,7 @@
 // Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.kil;
 
-import java.util.HashMap;
-
+import java.util.EnumMap;
 import org.kframework.backend.java.symbolic.Matcher;
 import org.kframework.backend.java.symbolic.Transformer;
 import org.kframework.backend.java.symbolic.Unifier;
@@ -22,7 +21,7 @@ import com.google.common.collect.Maps;
  */
 public class Bottom extends Term implements MaximalSharing {
 
-    private static final HashMap<Kind, Bottom> cache = Maps.newHashMap();
+    private static final EnumMap<Kind, Bottom> cache = Maps.newEnumMap(Kind.class);
 
     public static Bottom of(Kind kind) {
         Bottom bottom = cache.get(kind);

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/JavaSymbolicObject.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/JavaSymbolicObject.java
@@ -26,9 +26,9 @@ public abstract class JavaSymbolicObject extends ASTNode
         implements Transformable, Visitable, Serializable {
 
     /**
-     * Field used for cashing the hash code
+     * Field used for caching the hash code
      */
-    protected int hashCode = Utils.NO_HASHCODE;
+    protected transient int hashCode = Utils.NO_HASHCODE;
 
     /**
      * AndreiS: serializing this field causes a NullPointerException when hashing a de-serialized

--- a/src/javasources/KTool/src/org/kframework/backend/java/kil/Rule.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/kil/Rule.java
@@ -439,7 +439,7 @@ public class Rule extends JavaSymbolicObject {
 
     @Override
     public int hashCode() {
-        if (hashCode == 0) {
+        if (hashCode == Utils.NO_HASHCODE) {
             hashCode = 1;
             hashCode = hashCode * Utils.HASH_PRIME + label.hashCode();
             hashCode = hashCode * Utils.HASH_PRIME + leftHandSide.hashCode();

--- a/src/javasources/KTool/src/org/kframework/backend/java/symbolic/CopyOnWriteTransformer.java
+++ b/src/javasources/KTool/src/org/kframework/backend/java/symbolic/CopyOnWriteTransformer.java
@@ -12,7 +12,6 @@ import org.kframework.backend.java.kil.*;
 import org.kframework.kil.ASTNode;
 
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 
@@ -164,15 +163,15 @@ public class CopyOnWriteTransformer implements Transformer {
     @Override
     public ASTNode transform(UninterpretedConstraint uninterpretedConstraint) {
         boolean changed = false;
-        UninterpretedConstraint transformedUninterpretedConstraint = new UninterpretedConstraint();
+        UninterpretedConstraint.Builder builder = UninterpretedConstraint.builder();
         for (UninterpretedConstraint.Equality equality : uninterpretedConstraint.equalities()) {
             Term transformedLHS = (Term) equality.leftHandSide().accept(this);
             Term transformedRHS = (Term) equality.rightHandSide().accept(this);
             changed = changed || transformedLHS != equality.leftHandSide()
                     || transformedRHS != equality.rightHandSide();
-            transformedUninterpretedConstraint.add(transformedLHS, transformedRHS);
+            builder.add(transformedLHS, transformedRHS);
         }
-        return changed ? transformedUninterpretedConstraint : uninterpretedConstraint;
+        return changed ? builder.build() : uninterpretedConstraint;
     }
 
     @Override


### PR DESCRIPTION
The field Term#hashCode should be invalidated after deserialization. @dwightguth please review
