### PR TITLE
[WIP] plugin loading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,18 @@
               <goal>run</goal>
             </goals>
           </execution>
+          <execution>
+            <id>generate-plugin-dir</id>
+            <phase>generate-sources</phase>
+            <configuration>
+              <tasks>
+                <mkdir dir="target/lib/plugins"/>
+              </tasks>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/src/main/java/org/kframework/kagreg/KagregFrontEnd.java
+++ b/src/main/java/org/kframework/kagreg/KagregFrontEnd.java
@@ -58,7 +58,7 @@ public class KagregFrontEnd extends FrontEnd {
         this.kem = kem;
     }
 
-    public static Module[] getModules(final String[] args) {
+    public static List<Module> getModules(final String[] args) {
         if (args.length != 2) {
             printBootError("There must be exactly two K definitions as arguments to kagreg.");
             return null;
@@ -67,7 +67,9 @@ public class KagregFrontEnd extends FrontEnd {
         final GlobalOptions globalOptions = new GlobalOptions();
         globalOptions.verbose = true;
 
-        return new Module[] { new CommonModule(), new AbstractModule() {
+        List<Module> modules = new ArrayList<>();
+        modules.add(new CommonModule());
+        modules.add(new AbstractModule() {
             @Override
             protected void configure() {
                 bind(FrontEnd.class).to(KagregFrontEnd.class);
@@ -76,7 +78,8 @@ public class KagregFrontEnd extends FrontEnd {
                 bind(String.class).annotatedWith(SecondArg.class).toInstance(args[1]);
                 bind(GlobalOptions.class).toInstance(globalOptions);
             }
-        }};
+        });
+        return modules;
     }
 
     @Override

--- a/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -2,6 +2,8 @@
 package org.kframework.kast;
 
 import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.kframework.backend.maude.MaudeFilter;
 import org.kframework.backend.unparser.IndentationOptions;
@@ -29,14 +31,15 @@ import com.google.inject.Provider;
 
 public class KastFrontEnd extends FrontEnd {
 
-    public static Module[] getModules(String[] args) {
+    public static List<Module> getModules(String[] args) {
         try {
             KastOptions options = new KastOptions();
 
-            return new Module[] {
-                    new KastModule(options),
-                    new JCommanderModule(args),
-                    new CommonModule() };
+            List<Module> modules = new ArrayList<>();
+            modules.add(new KastModule(options));
+            modules.add(new JCommanderModule(args));
+            modules.add(new CommonModule());
+            return modules;
         } catch (ParameterException ex) {
             printBootError(ex.getMessage());
             return null;

--- a/src/main/java/org/kframework/kompile/KompileFrontEnd.java
+++ b/src/main/java/org/kframework/kompile/KompileFrontEnd.java
@@ -4,6 +4,8 @@ package org.kframework.kompile;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -33,19 +35,20 @@ import com.google.inject.Module;
 
 public class KompileFrontEnd extends FrontEnd {
 
-    public static Module[] getModules(String[] args) {
+    public static List<Module> getModules(String[] args) {
         try {
             KompileOptions options = new KompileOptions();
 
             final Context context = new Context();
             context.kompileOptions = options;
 
-            return new Module[] {
-                    new KompileModule(context, options),
-                    new JCommanderModule(args),
-                    new CommonModule(),
-                    new JavaSymbolicCommonModule(),
-                    new JavaSymbolicKompileModule() };
+            List<Module> modules = new ArrayList<>();
+            modules.add(new KompileModule(context, options));
+            modules.add(new JCommanderModule(args));
+            modules.add(new CommonModule());
+            modules.add(new JavaSymbolicCommonModule());
+            modules.add(new JavaSymbolicKompileModule());
+            return modules;
         } catch (ParameterException ex) {
             printBootError(ex.getMessage());
             return null;

--- a/src/main/java/org/kframework/krun/KRunFrontEnd.java
+++ b/src/main/java/org/kframework/krun/KRunFrontEnd.java
@@ -7,6 +7,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -392,7 +393,7 @@ public class KRunFrontEnd extends FrontEnd {
         }
     }
 
-    public static com.google.inject.Module[] getModules(String[] args) {
+    public static List<com.google.inject.Module> getModules(String[] args) {
         try {
             KRunOptions options = new KRunOptions();
             JavaExecutionOptions javaOptions = new JavaExecutionOptions();
@@ -401,22 +402,18 @@ public class KRunFrontEnd extends FrontEnd {
                 System.setProperty("java.awt.headless", "false");
             }
 
+            List<com.google.inject.Module> modules = new ArrayList<>();
+            modules.add(new KRunModule(options));
+            modules.add(new CommonModule());
+            modules.add(new JCommanderModule(args));
             if (options.experimental.simulation != null) {
-                return new com.google.inject.Module[] {
-                        new KRunModule(options),
-                        new CommonModule(),
-                        new JCommanderModule(args),
-                        new JavaSymbolicKRunModule.SimulationModule(),
-                        new JavaSymbolicKRunModule.MainExecutionContextModule(options),
-                        new JavaSymbolicKRunModule(javaOptions) };
+                modules.add(new JavaSymbolicKRunModule.SimulationModule());
+                modules.add(new JavaSymbolicKRunModule.MainExecutionContextModule(options));
             } else {
-                return new com.google.inject.Module[] {
-                        new KRunModule(options),
-                        new CommonModule(),
-                        new JCommanderModule(args),
-                        new KRunModule.NoSimulationModule(options),
-                        new JavaSymbolicKRunModule(javaOptions) };
+                modules.add(new KRunModule.NoSimulationModule(options));
             }
+            modules.add(new JavaSymbolicKRunModule(javaOptions));
+            return modules;
         } catch (ParameterException ex) {
             printBootError(ex.getMessage());
             return null;

--- a/src/main/java/org/kframework/ktest/KTestFrontEnd.java
+++ b/src/main/java/org/kframework/ktest/KTestFrontEnd.java
@@ -31,14 +31,15 @@ import java.util.*;
 
 public class KTestFrontEnd extends FrontEnd {
 
-    public static Module[] getModules(String[] args) {
+    public static List<Module> getModules(String[] args) {
         try {
             KTestOptions options = new KTestOptions();
 
-            return new Module[] {
-                    new KTestModule(options),
-                    new JCommanderModule(args),
-                    new CommonModule() };
+            List<Module> modules = new ArrayList<>();
+            modules.add(new KTestModule(options));
+            modules.add(new JCommanderModule(args));
+            modules.add(new CommonModule());
+            return modules;
         } catch (ParameterException ex) {
             printBootError(ex.getMessage());
             return null;

--- a/src/main/java/org/kframework/main/KPluginClassLoader.java
+++ b/src/main/java/org/kframework/main/KPluginClassLoader.java
@@ -1,0 +1,43 @@
+// Copyright (c) 2012-2014 K Team. All Rights Reserved.
+package org.kframework.main;
+
+import org.apache.commons.io.FilenameUtils;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * A ClassLoader that allows adding JARs in directories.
+ */
+public class KPluginClassLoader extends URLClassLoader {
+
+    public KPluginClassLoader() {
+        super(new URL[0]);
+    }
+
+    /**
+     * Add JAR files in the path to ClassLoader. Does not traverse sub-directories.
+     * @param path Path to directory.
+     */
+    public void addPath(String path) {
+        File root = new File(path);
+        File[] fs = root.listFiles();
+        if (fs == null) {
+            Thread.dumpStack();
+            FrontEnd.printBootError(path + " is not a directory or an IO error occured.");
+        } else {
+            for (File f : fs) {
+                if (FilenameUtils.getExtension(f.getPath()).toLowerCase().equals("jar")) {
+                    try {
+                        addURL(f.toURI().toURL());
+                    } catch (MalformedURLException e) {
+                        e.printStackTrace();
+                        FrontEnd.printBootError(e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/kframework/main/KppFrontEnd.java
+++ b/src/main/java/org/kframework/main/KppFrontEnd.java
@@ -2,6 +2,8 @@
 package org.kframework.main;
 
 import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.JarInfo;
@@ -30,12 +32,13 @@ public class KppFrontEnd extends FrontEnd {
         this.fileName = fileName;
     }
 
-    public static Module[] getModules(final String[] args) {
+    public static List<Module> getModules(final String[] args) {
         if (args.length != 1) {
             printBootError("Kpp takes exactly one file");
             return null;
         }
-        return new Module[] { new AbstractModule() {
+        List<Module> modules = new ArrayList<>();
+        modules.add(new AbstractModule() {
             @Override
             protected void configure() {
                 bind(FrontEnd.class).to(KppFrontEnd.class);
@@ -43,7 +46,8 @@ public class KppFrontEnd extends FrontEnd {
                 bind(String.class).annotatedWith(FirstArg.class).toInstance(args[0]);
                 bind(GlobalOptions.class).toInstance(new GlobalOptions());
             }
-        }};
+        });
+        return modules;
     }
 
     public boolean run() {

--- a/src/main/java/org/kframework/main/Main.java
+++ b/src/main/java/org/kframework/main/Main.java
@@ -2,8 +2,12 @@
 package org.kframework.main;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.ServiceLoader;
 
+import org.apache.commons.io.FilenameUtils;
 import org.fusesource.jansi.AnsiConsole;
 import org.kframework.kagreg.KagregFrontEnd;
 import org.kframework.kast.KastFrontEnd;
@@ -18,6 +22,7 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.ProvisionException;
 import com.google.inject.spi.Message;
+import org.kframework.utils.file.JarInfo;
 
 public class Main {
 
@@ -29,36 +34,71 @@ public class Main {
     public static void main(String[] args) {
         AnsiConsole.systemInstall();
 
-        Module[] modules;
+        KPluginClassLoader loader = new KPluginClassLoader();
+        loader.addPath(
+                FilenameUtils.concat(JarInfo.getKBase(false),
+                        FilenameUtils.concat("lib", "plugins")));
+
+        ServiceLoader<KModule> kLoader = ServiceLoader.load(KModule.class, loader);
+        List<KModule> kModules = new ArrayList<>();
+        for (KModule m : kLoader) {
+            kModules.add(m);
+        }
+
+        List<Module> modules = new ArrayList<>(0);
         if (args.length >= 1) {
             String[] args2 = Arrays.copyOfRange(args, 1, args.length);
                 switch (args[0]) {
                     case "-kompile":
-                        modules = KompileFrontEnd.getModules(args2);
+                        modules.addAll(Arrays.asList(KompileFrontEnd.getModules(args2)));
+                        for (KModule kModule : kModules) {
+                            List<Module> ms = kModule.getKompileModules();
+                            if (ms != null) {
+                                modules.addAll(ms);
+                            }
+                        }
                         break;
                     case "-kagreg":
-                        modules = KagregFrontEnd.getModules(args2);
+                        modules = Arrays.asList(KagregFrontEnd.getModules(args2));
                         break;
                     case "-kcheck":
                         assert false : "kcheck no longer supported";
                         return;
                     case "-ktest":
-                        modules = KTestFrontEnd.getModules(args2);
+                        modules.addAll(Arrays.asList(KTestFrontEnd.getModules(args2)));
+                        for (KModule kModule : kModules) {
+                            List<Module> ms = kModule.getKTestModules();
+                            if (ms != null) {
+                                modules.addAll(ms);
+                            }
+                        }
                         break;
                     case "-kast":
-                        modules = KastFrontEnd.getModules(args2);
+                        modules.addAll(Arrays.asList(KastFrontEnd.getModules(args2)));
+                        for (KModule kModule : kModules) {
+                            List<Module> ms = kModule.getKastModules();
+                            if (ms != null) {
+                                modules.addAll(ms);
+                            }
+                        }
                         break;
                     case "-krun":
-                        modules = KRunFrontEnd.getModules(args2);
+                        modules.addAll(Arrays.asList(KRunFrontEnd.getModules(args2)));
+                        for (KModule kModule : kModules) {
+                            List<Module> ms = kModule.getKRunModules();
+                            if (ms != null) {
+                                modules.addAll(ms);
+                            }
+                        }
                         break;
                     case "-kpp":
-                        modules = KppFrontEnd.getModules(args2);
+                        modules = Arrays.asList(KppFrontEnd.getModules(args2));
                         break;
                     default:
                         invalidJarArguments();
                         return;
             }
-            if (modules == null) {
+            if (modules.size() == 0) {
                 //boot error, we should have printed it already
                 System.exit(1);
             }

--- a/src/main/java/org/kframework/main/Main.java
+++ b/src/main/java/org/kframework/main/Main.java
@@ -50,7 +50,7 @@ public class Main {
             String[] args2 = Arrays.copyOfRange(args, 1, args.length);
                 switch (args[0]) {
                     case "-kompile":
-                        modules.addAll(Arrays.asList(KompileFrontEnd.getModules(args2)));
+                        modules.addAll(KompileFrontEnd.getModules(args2));
                         for (KModule kModule : kModules) {
                             List<Module> ms = kModule.getKompileModules();
                             if (ms != null) {
@@ -59,13 +59,13 @@ public class Main {
                         }
                         break;
                     case "-kagreg":
-                        modules = Arrays.asList(KagregFrontEnd.getModules(args2));
+                        modules = KagregFrontEnd.getModules(args2);
                         break;
                     case "-kcheck":
                         assert false : "kcheck no longer supported";
                         return;
                     case "-ktest":
-                        modules.addAll(Arrays.asList(KTestFrontEnd.getModules(args2)));
+                        modules.addAll(KTestFrontEnd.getModules(args2));
                         for (KModule kModule : kModules) {
                             List<Module> ms = kModule.getKTestModules();
                             if (ms != null) {
@@ -74,7 +74,7 @@ public class Main {
                         }
                         break;
                     case "-kast":
-                        modules.addAll(Arrays.asList(KastFrontEnd.getModules(args2)));
+                        modules.addAll(KastFrontEnd.getModules(args2));
                         for (KModule kModule : kModules) {
                             List<Module> ms = kModule.getKastModules();
                             if (ms != null) {
@@ -83,7 +83,7 @@ public class Main {
                         }
                         break;
                     case "-krun":
-                        modules.addAll(Arrays.asList(KRunFrontEnd.getModules(args2)));
+                        modules.addAll(KRunFrontEnd.getModules(args2));
                         for (KModule kModule : kModules) {
                             List<Module> ms = kModule.getKRunModules();
                             if (ms != null) {
@@ -92,7 +92,7 @@ public class Main {
                         }
                         break;
                     case "-kpp":
-                        modules = Arrays.asList(KppFrontEnd.getModules(args2));
+                        modules = KppFrontEnd.getModules(args2);
                         break;
                     default:
                         invalidJarArguments();

--- a/src/test/java/org/kframework/backend/java/symbolic/JavaSymbolicKRunModuleTest.java
+++ b/src/test/java/org/kframework/backend/java/symbolic/JavaSymbolicKRunModuleTest.java
@@ -14,17 +14,19 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 
+import java.util.List;
+
 public class JavaSymbolicKRunModuleTest extends BaseTestCase {
 
     @Test
     public void testCreateInjectionSimulation() {
         String[] argv = new String[] { "foo.c", "--simulation", "bar.c" };
-        Module[] modules = KRunFrontEnd.getModules(argv);
-        for (int i = 0; i < modules.length; i++) {
+        List<Module> modules = KRunFrontEnd.getModules(argv);
+        for (int i = 0; i < modules.size(); i++) {
             //we have to override private modules one at a time to override private bindings
-            if (modules[i] instanceof MainExecutionContextModule
-                    || modules[i] instanceof SimulationModule) {
-                modules[i] = Modules.override(modules[i]).with(new TestModule());
+            if (modules.get(i) instanceof MainExecutionContextModule
+                    || modules.get(i) instanceof SimulationModule) {
+                modules.set(i, Modules.override(modules.get(i)).with(new TestModule()));
             }
         }
         Injector injector = Guice.createInjector(modules);

--- a/src/test/java/org/kframework/kast/KastModuleTest.java
+++ b/src/test/java/org/kframework/kast/KastModuleTest.java
@@ -10,12 +10,14 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.util.Modules;
 
+import java.util.List;
+
 public class KastModuleTest extends BaseTestCase {
 
     @Test
     public void testCreateInjection() {
         String[] argv = new String[] { "foo.c" };
-        Module[] modules = KastFrontEnd.getModules(argv);
+        List<Module> modules = KastFrontEnd.getModules(argv);
         Injector injector = Guice.createInjector(Modules.override(modules).with(new TestModule()));
         assertTrue(injector.getInstance(FrontEnd.class) instanceof KastFrontEnd);
     }

--- a/src/test/java/org/kframework/krun/KRunModuleTest.java
+++ b/src/test/java/org/kframework/krun/KRunModuleTest.java
@@ -4,6 +4,7 @@ package org.kframework.krun;
 import static org.junit.Assert.*;
 
 import java.util.HashMap;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -25,14 +26,14 @@ public class KRunModuleTest extends BaseTestCase {
     @Test
     public void testCreateInjection() {
         String[] argv = new String[] { "foo.c" };
-        Module[] modules = KRunFrontEnd.getModules(argv);
+        List<Module> modules = KRunFrontEnd.getModules(argv);
         Injector injector = Guice.createInjector(Modules.override(modules).with(new TestModule()));
         assertTrue(injector.getInstance(FrontEnd.class) instanceof KRunFrontEnd);
     }
 
     public void testInvalidArguments() {
         String[] argv = new String[] { "--backend", "foobarbaz" };
-        Module[] modules = KRunFrontEnd.getModules(argv);
+        List<Module> modules = KRunFrontEnd.getModules(argv);
         assertNull(modules);
     }
 }

--- a/src/test/java/org/kframework/ktest/KTestModuleTest.java
+++ b/src/test/java/org/kframework/ktest/KTestModuleTest.java
@@ -11,13 +11,15 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 
+import java.util.List;
+
 
 public class KTestModuleTest extends BaseTestCase {
 
     @Test
     public void testCreateInjection() {
         String[] argv = new String[] { "foo.c" };
-        Module[] modules = KTestFrontEnd.getModules(argv);
+        List<Module> modules = KTestFrontEnd.getModules(argv);
         Injector injector = Guice.createInjector(modules);
         assertTrue(injector.getInstance(FrontEnd.class) instanceof KTestFrontEnd);
     }


### PR DESCRIPTION
I'm creating this to get some comments and discuss what to do next. This is a very basic and crude implementation of plugin loader. I'll clean the implementation and squash commits before merging.

As an example, I created this kompile plugin: https://github.com/osa1/kompile-plugin. This is the output I get when I run the patched version of K:

```
➜  k git:(plugin-wip) ✗ ./target/release/k/bin/kompile  
found a kmodule
running my kompile frontend
➜  k git:(plugin-wip) ✗ 
```

Second line is printed by the plugin which works as kompile.

Now I have some questions to improve:

1) I'd like to know if I understand the use case correctly. @dwightguth can you please review https://github.com/osa1/kompile-plugin too just to make sure I'm not doing something wrong?
2) How should I get path of the JAR or the directory to search JARs in from user?
3) What should the framework do if there are multiple plugins for same K part? For example, multiple kompile implementations.
4) What should the framework do if there are multiple plugins for different K parts? For example, there may be plugins for kompile and krun. Should we load both? Should we allow user to choose what to load so that he/she can tell the framework to use only kompile plugin?
