### PR TITLE
fix some of wrong comparisons in MaudeKRun to fix a test

### DIFF
--- a/src/main/java/org/kframework/backend/maude/krun/MaudeKRun.java
+++ b/src/main/java/org/kframework/backend/maude/krun/MaudeKRun.java
@@ -680,15 +680,15 @@ public class MaudeKRun implements KRun {
         assertXML(child.size() == 1);
         String sort = child.get(0).getAttribute("sort");
         String op = child.get(0).getAttribute("op");
-        assertXML(op.equals("_`(_`)") && sort.equals(Sort.KITEM));
+        assertXML(op.equals("_`(_`)") && sort.equals(Sort.KITEM.toString()));
         child = XmlUtil.getChildElements(child.get(0));
         assertXML(child.size() == 2);
         sort = child.get(0).getAttribute("sort");
         op = child.get(0).getAttribute("op");
-        assertXML(op.equals("#_") && sort.equals(Sort.KLABEL));
+        assertXML(op.equals("#_") && sort.equals(Sort.KLABEL.toString()));
         sort = child.get(1).getAttribute("sort");
         op = child.get(1).getAttribute("op");
-        assertXML(op.equals(".KList") && sort.equals(Sort.KLIST));
+        assertXML(op.equals(".KList") && sort.equals(Sort.KLIST.toString()));
         child = XmlUtil.getChildElements(child.get(0));
         assertXML(child.size() == 1);
         elem = child.get(0);


### PR DESCRIPTION
I realized this while trying to make tests working under Java 8.

Note that static analyzers are reporting a lot of warnings about compare methods. They'll become a problem sooner or later. I'll open a separate issue for that.
