### PR TITLE
ktest: don't generate duplicate PDF files. kompile: remove .k

### DIFF
--- a/src/main/java/org/kframework/kompile/KompileFrontEnd.java
+++ b/src/main/java/org/kframework/kompile/KompileFrontEnd.java
@@ -103,7 +103,7 @@ public class KompileFrontEnd extends FrontEnd {
             Runtime.getRuntime().addShutdownHook(new Thread() {
                 public void run() {
                     try {
-                        FileUtils.deleteDirectory(context.dotk);
+                        FileUtils.deleteDirectory(new File(options.directory, ".k"));
                     } catch (IOException e) {
                         e.printStackTrace();
                     }

--- a/src/main/java/org/kframework/ktest/Test/TestSuite.java
+++ b/src/main/java/org/kframework/ktest/Test/TestSuite.java
@@ -100,7 +100,7 @@ public class TestSuite {
                 System.out.println(tc.toKompileLogString());
         }
         if (!skips.contains(KTestStep.PDF)) {
-            List<TestCase> pdfSteps = filterSkips(tests, KTestStep.PDF);
+            List<TestCase> pdfSteps = collectPDFDefs(filterSkips(tests, KTestStep.PDF));
             for (TestCase tc : pdfSteps)
                 System.out.println(tc.toPdfLogString());
         }
@@ -215,6 +215,24 @@ public class TestSuite {
     }
 
     /**
+     * Filter test cases with same definitions for PDF step.
+     * @param tests list of test cases to filter.
+     * @return test cases with unique definition files.
+     */
+    private List<TestCase> collectPDFDefs(List<TestCase> tests) {
+        Set<String> pdfDefs = new HashSet<>();
+        List<TestCase> ret = new ArrayList<>();
+        for (TestCase tc : tests) {
+            String def = tc.getDefinition();
+            if (!pdfDefs.contains(def)) {
+                pdfDefs.add(def);
+                ret.add(tc);
+            }
+        }
+        return ret;
+    }
+
+    /**
      * Run pdf tests.
      * @param tests list of tests to run pdf step
      * @return whether all run successfully or not
@@ -222,11 +240,12 @@ public class TestSuite {
      */
     private boolean runPDFSteps(List<TestCase> tests) throws InterruptedException {
         List<Proc<TestCase>> ps = new ArrayList<>();
-        int len = tests.size();
+        List<TestCase> pdfTests = collectPDFDefs(tests);
+        int len = pdfTests.size();
         System.out.format("Generate PDF files...(%d in total)%n", len);
         startTpe();
         long startTime = System.currentTimeMillis();
-        for (TestCase tc : tests) {
+        for (TestCase tc : pdfTests) {
             Proc<TestCase> p = new Proc<>(tc, tc.getPdfCmd(), tc.toPdfLogString(), options);
             p.setWorkingDir(tc.getWorkingDir());
             ps.add(p);


### PR DESCRIPTION
This fixes #789 and #943 .

Since no one commented about #943, I took the liberty to go with the conservative approach. KTest now should not generate same PDF files multiple times, so no race conditions about .k directory is happening. Second commit then removes .k directory after kompile is done.
