### PR TITLE
KTest propagate debug flag to processes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,7 @@
                   <arg value="${config}" />
                   <arg value="-v" />
                   <arg value="--report" />
+                  <arg value="--debug" />
                 </exec>
               </target>
               <skip>${skipKTest}</skip>

--- a/src/main/java/org/kframework/backend/java/symbolic/SymbolicConstraint.java
+++ b/src/main/java/org/kframework/backend/java/symbolic/SymbolicConstraint.java
@@ -915,14 +915,14 @@ public class SymbolicConstraint extends JavaSymbolicObject {
             if (left.isFalse()) continue;
 
             if (context.definition().context().globalOptions.debug) {
-                System.out.println("Attempting to prove: \n\t" + left + "\n  implies \n\t" + right);
+                System.err.println("Attempting to prove: \n\t" + left + "\n  implies \n\t" + right);
             }
 
             right = left.simplifyConstraint(right);
             right.orientSubstitution(rightOnlyVariables);
             if (right.isTrue() || (right.equalities().isEmpty() && rightOnlyVariables.containsAll(right.substitution().keySet()))) {
                 if (context.definition().context().globalOptions.debug) {
-                    System.out.println("Implication proved by simplification");
+                    System.err.println("Implication proved by simplification");
                 }
                 continue;
             }
@@ -933,7 +933,7 @@ public class SymbolicConstraint extends JavaSymbolicObject {
                 // TODO (AndreiS): handle KList variables
                 Term condition = ((KList) ite.kList()).get(0);
                 if (context.definition().context().globalOptions.debug) {
-                    System.out.println("Split on " + condition);
+                    System.err.println("Split on " + condition);
                 }
                 SymbolicConstraint left1 = new SymbolicConstraint(left, context);
                 left1.add(condition, BoolToken.TRUE);
@@ -948,12 +948,12 @@ public class SymbolicConstraint extends JavaSymbolicObject {
 //            }
             if (!impliesSMT(left,right)) {
                 if (context.definition().context().globalOptions.debug) {
-                    System.out.println("Failure!");
+                    System.err.println("Failure!");
                 }
                 return false;
             } else {
                 if (context.definition().context().globalOptions.debug) {
-                    System.out.println("Proved!");
+                    System.err.println("Proved!");
                 }
             }
         }
@@ -985,7 +985,7 @@ public class SymbolicConstraint extends JavaSymbolicObject {
             if (!gterm1.equals("")) input += "(" + gterm1 + ") -> ";
             input += "(" + gterm2 + ")";
             if (left.termContext().definition().context().globalOptions.debug) {
-                System.out.println("Verifying " + input);
+                System.err.println("Verifying " + input);
             }
             if (GappaServer.proveTrue(input))
                 result = true;

--- a/src/main/java/org/kframework/ktest/CmdArgs/KTestOptions.java
+++ b/src/main/java/org/kframework/ktest/CmdArgs/KTestOptions.java
@@ -175,7 +175,7 @@ public class KTestOptions {
      */
     @Parameter(names="--dry", description="Dry run: print out the " +
                 "command to be executed without actual execution.")
-    private boolean dry = false;
+    public boolean dry = false;
 
     /**
      * Enable debugging. When enabled, KTest passes --debug to spawned processes.
@@ -302,10 +302,6 @@ public class KTestOptions {
 
     public boolean getGenerateReport() {
         return generateReport;
-    }
-
-    public boolean getDry() {
-        return dry;
     }
 
     public boolean getDebug() {

--- a/src/main/java/org/kframework/ktest/CmdArgs/KTestOptions.java
+++ b/src/main/java/org/kframework/ktest/CmdArgs/KTestOptions.java
@@ -178,6 +178,11 @@ public class KTestOptions {
     private boolean dry = false;
 
     /**
+     * Enable debugging. When enabled, KTest passes --debug to spawned processes.
+     */
+    private boolean debug = false;
+
+    /**
      * Copy constructor.
      * @param obj KTestOptions object to copy
      */
@@ -199,6 +204,7 @@ public class KTestOptions {
         this.ignoreWS = obj.ignoreWS;
         this.ignoreBalancedParens = obj.ignoreBalancedParens;
         this.dry = obj.dry;
+        this.debug = obj.debug;
     }
 
     /**
@@ -302,8 +308,16 @@ public class KTestOptions {
         return dry;
     }
 
+    public boolean getDebug() {
+        return debug;
+    }
+
     public int getThreads() {
         return threads;
+    }
+
+    public void setDebug(boolean debug) {
+        this.debug = debug;
     }
 
     public KTestOptions setDirectory(String directory) {

--- a/src/main/java/org/kframework/ktest/KTestFrontEnd.java
+++ b/src/main/java/org/kframework/ktest/KTestFrontEnd.java
@@ -59,6 +59,7 @@ public class KTestFrontEnd extends FrontEnd {
             JarInfo jarInfo) {
         super(kem, globalOptions, usage, experimentalUsage, jarInfo);
         this.options = options;
+        this.options.setDebug(globalOptions.debug);
         this.kem = kem;
     }
 

--- a/src/main/java/org/kframework/ktest/KTestFrontEnd.java
+++ b/src/main/java/org/kframework/ktest/KTestFrontEnd.java
@@ -66,13 +66,7 @@ public class KTestFrontEnd extends FrontEnd {
     public boolean run() {
         try {
             options.validateArgs();
-            TestSuite testSuite = makeTestSuite(options.getTargetFile(), options);
-            if (options.getDry()) {
-                testSuite.dryRun();
-                return true;
-            } else {
-                return testSuite.run();
-            }
+            return makeTestSuite(options.getTargetFile(), options).run();
         } catch (SAXException | ParserConfigurationException | IOException | InterruptedException |
                 TransformerException | ParameterException e) {
             kem.registerCriticalError(e.getMessage(), e);

--- a/src/main/java/org/kframework/ktest/Proc.java
+++ b/src/main/java/org/kframework/ktest/Proc.java
@@ -35,7 +35,7 @@ public class Proc<T> implements Runnable {
     /**
      * Directory to spawn process from.
      */
-    private File workingDir;
+    private final File workingDir;
 
     /**
      * Expected program output with location information for output file.
@@ -116,8 +116,8 @@ public class Proc<T> implements Runnable {
      */
     public Proc(T obj, String[] args, String inputFile, String procInput,
                 Annotated<String, String> expectedOut, Annotated<String, String> expectedErr,
-                StringMatcher strComparator, KTestOptions options, String outputFile,
-                String newOutputFile) {
+                StringMatcher strComparator, File workingDir, KTestOptions options,
+                String outputFile, String newOutputFile) {
         this.obj = obj;
         this.args = args;
         this.inputFile = inputFile;
@@ -125,14 +125,15 @@ public class Proc<T> implements Runnable {
         this.expectedOut = expectedOut;
         this.expectedErr = expectedErr;
         this.strComparator = strComparator;
+        this.workingDir = workingDir;
         this.options = options;
         this.outputFile = outputFile;
         this.newOutputFile = newOutputFile;
     }
 
-    public Proc(T obj, String[] args, KTestOptions options) {
-        this(obj, args, null, "", null, null, options.getDefaultStringMatcher(), options,
-                null, null);
+    public Proc(T obj, String[] args, File workingDir, KTestOptions options) {
+        this(obj, args, null, "", null, null, options.getDefaultStringMatcher(), workingDir,
+                options, null, null);
     }
 
     @Override
@@ -240,14 +241,6 @@ public class Proc<T> implements Runnable {
      */
     public String getPgmErr() {
         return procOutput.stderr;
-    }
-
-    public File getWorkingDir() {
-        return workingDir;
-    }
-
-    public void setWorkingDir(File workingDir) {
-        this.workingDir = workingDir;
     }
 
     public static String toLogString(String[] args) {

--- a/src/main/java/org/kframework/ktest/Proc.java
+++ b/src/main/java/org/kframework/ktest/Proc.java
@@ -154,7 +154,7 @@ public class Proc<T> implements Runnable {
                 }
             } else {
                 // Make one run with --debug
-                procOutput = runProc(args);
+                procOutput = runProc(debugArgs);
                 if (!options.dry) {
                     handlePgmResult(procOutput, null);
                 }

--- a/src/main/java/org/kframework/ktest/Proc.java
+++ b/src/main/java/org/kframework/ktest/Proc.java
@@ -143,6 +143,7 @@ public class Proc<T> implements Runnable {
     public void run() {
         if (options.getDebug()) {
             String[] debugArgs = Arrays.copyOf(args, args.length + 1);
+            debugArgs[args.length] = "--debug";
             if (expectedErr != null) {
                 // We want to use --debug and compare error outputs too. In this case we need to
                 // make two runs:

--- a/src/main/java/org/kframework/ktest/Proc.java
+++ b/src/main/java/org/kframework/ktest/Proc.java
@@ -153,7 +153,7 @@ public class Proc<T> implements Runnable {
                 handlePgmResult(procOutput, debugOutput);
             } else {
                 // Make one run with --debug
-                procOutput = runProc(args, false);
+                procOutput = runProc(args, true);
                 handlePgmResult(procOutput, null);
             }
         } else {

--- a/src/main/java/org/kframework/ktest/ReportGen.java
+++ b/src/main/java/org/kframework/ktest/ReportGen.java
@@ -11,7 +11,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;
@@ -74,9 +73,7 @@ public class ReportGen {
     }
 
     private void writeXmlFile(File targetFile, Element elem)
-            throws TransformerConfigurationException,
-            TransformerFactoryConfigurationError, TransformerException,
-            IOException, FileNotFoundException {
+            throws TransformerFactoryConfigurationError, TransformerException, IOException {
         Transformer transformer = TransformerFactory.newInstance().newTransformer();
         transformer.setOutputProperty("indent", "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");

--- a/src/main/java/org/kframework/ktest/Test/KRunProgram.java
+++ b/src/main/java/org/kframework/ktest/Test/KRunProgram.java
@@ -54,15 +54,4 @@ public class KRunProgram {
         }
         return argsArr;
     }
-
-    /**
-     * @return String to be used in logging.
-     */
-    public String toLogString() {
-        if (OS.current() == OS.WIN) {
-            // OS is WIN, getKrunCmd will return args escaped
-            return StringUtils.join(getKrunCmd(), ' ');
-        }
-        return StringUtil.escapeShell(getKrunCmd(), OS.current());
-    }
 }

--- a/src/main/java/org/kframework/ktest/Test/KRunProgram.java
+++ b/src/main/java/org/kframework/ktest/Test/KRunProgram.java
@@ -2,7 +2,6 @@
 package org.kframework.ktest.Test;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.kframework.ktest.ExecNames;
 import org.kframework.ktest.PgmArg;
 import org.kframework.utils.OS;
@@ -40,7 +39,7 @@ public class KRunProgram {
      * @return command array to pass process builder
      */
     public String[] getKrunCmd() {
-        List<String> stringArgs = new ArrayList<String>();
+        List<String> stringArgs = new ArrayList<>();
         stringArgs.add(ExecNames.getKrun());
         stringArgs.add(pgmPath);
         for (PgmArg arg : args) {

--- a/src/main/java/org/kframework/ktest/Test/TestCase.java
+++ b/src/main/java/org/kframework/ktest/Test/TestCase.java
@@ -2,7 +2,6 @@
 package org.kframework.ktest.Test;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.kframework.ktest.*;
 import org.kframework.ktest.CmdArgs.KTestOptions;
 import org.kframework.ktest.Config.InvalidConfigError;
@@ -188,13 +187,6 @@ public class TestCase {
     public String[] getPosixOnlyCmd() {
         assert new File(posixInitScript).isFile();
         return new String[] { posixInitScript };
-    }
-
-    /**
-     * @return String representation of posixInitScript command to be used in logging.
-     */
-    public String toPosixOnlyLogString() {
-        return StringUtil.escapeShell(getPosixOnlyCmd(), OS.current());
     }
 
     /**

--- a/src/main/java/org/kframework/ktest/Test/TestCase.java
+++ b/src/main/java/org/kframework/ktest/Test/TestCase.java
@@ -153,7 +153,7 @@ public class TestCase {
      */
     public String[] getKompileCmd() {
         assert new File(getDefinition()).isFile();
-        List<String> stringArgs = new ArrayList<String>();
+        List<String> stringArgs = new ArrayList<>();
         stringArgs.add(ExecNames.getKompile());
         stringArgs.add(getDefinition());
         for (PgmArg kompileOpt : kompileOpts) {
@@ -166,16 +166,6 @@ public class TestCase {
             }
         }
         return argsArr;
-    }
-
-    /**
-     * @return String representation of kompile command to be used in logging.
-     */
-    public String toKompileLogString() {
-        if (OS.current() == OS.WIN) {
-            return StringUtils.join(getKompileCmd(), ' ');
-        }
-        return StringUtil.escapeShell(getKompileCmd(), OS.current());
     }
 
     /**
@@ -220,16 +210,6 @@ public class TestCase {
             }
         }
         return argsArr;
-    }
-
-    /**
-     * @return String representation of PDF command to be used in logging.
-     */
-    public String toPdfLogString() {
-        if (OS.current() == OS.WIN) {
-            return StringUtils.join(getPdfCmd(), ' ');
-        }
-        return StringUtil.escapeShell(getPdfCmd(), OS.current());
     }
 
     public void setKompileOpts(List<PgmArg> kompileOpts) {

--- a/src/main/java/org/kframework/ktest/Test/TestSuite.java
+++ b/src/main/java/org/kframework/ktest/Test/TestSuite.java
@@ -97,12 +97,12 @@ public class TestSuite {
         if (!skips.contains(KTestStep.KOMPILE)) {
             List<TestCase> kompileSteps = filterSkips(tests, KTestStep.KOMPILE);
             for (TestCase tc : kompileSteps)
-                System.out.println(tc.toKompileLogString());
+                System.out.println(Proc.toLogString(tc.getKompileCmd()));
         }
         if (!skips.contains(KTestStep.PDF)) {
             List<TestCase> pdfSteps = collectPDFDefs(filterSkips(tests, KTestStep.PDF));
             for (TestCase tc : pdfSteps)
-                System.out.println(tc.toPdfLogString());
+                System.out.println(Proc.toLogString(tc.getPdfCmd()));
         }
         if (!skips.contains(KTestStep.KRUN)) {
             List<TestCase> krunSteps = filterSkips(tests, KTestStep.KRUN);
@@ -110,7 +110,7 @@ public class TestSuite {
                 List<KRunProgram> programs = tc.getPrograms();
                 for (KRunProgram program : programs) {
                     StringBuilder krunLogCmd = new StringBuilder();
-                    krunLogCmd.append(program.toLogString());
+                    krunLogCmd.append(Proc.toLogString(program.getKrunCmd()));
                     if (options.getUpdateOut() && program.outputFile != null)
                         krunLogCmd.append(" >").append(program.outputFile);
                     else if (options.getGenerateOut() && program.newOutputFile != null)
@@ -147,8 +147,7 @@ public class TestSuite {
         startTpe();
         for (TestCase tc : tests) {
             if (tc.hasPosixOnly()) {
-                Proc<TestCase> p =
-                        new Proc<>(tc, tc.getPosixOnlyCmd(), tc.toPosixOnlyLogString(), options);
+                Proc<TestCase> p = new Proc<>(tc, tc.getPosixOnlyCmd(), options);
                 ps.add(p);
                 p.setWorkingDir(tc.getWorkingDir());
                 tpe.execute(p);
@@ -190,7 +189,7 @@ public class TestSuite {
         long startTime = System.currentTimeMillis();
         startTpe();
         for (TestCase tc : tests) {
-            Proc<TestCase> p = new Proc<>(tc, tc.getKompileCmd(), tc.toKompileLogString(), options);
+            Proc<TestCase> p = new Proc<>(tc, tc.getKompileCmd(), options);
             p.setWorkingDir(tc.getWorkingDir());
             ps.add(p);
             tpe.execute(p);
@@ -246,7 +245,7 @@ public class TestSuite {
         startTpe();
         long startTime = System.currentTimeMillis();
         for (TestCase tc : pdfTests) {
-            Proc<TestCase> p = new Proc<>(tc, tc.getPdfCmd(), tc.toPdfLogString(), options);
+            Proc<TestCase> p = new Proc<>(tc, tc.getPdfCmd(), options);
             p.setWorkingDir(tc.getWorkingDir());
             ps.add(p);
             tpe.execute(p);
@@ -407,7 +406,7 @@ public class TestSuite {
             matcher = new RegexStringMatcher();
         }
         Proc<KRunProgram> p = new Proc<>(program, args, program.inputFile, inputContents,
-                outputContentsAnn, errorContentsAnn, program.toLogString(), matcher, options,
+                outputContentsAnn, errorContentsAnn, matcher, options,
                 program.outputFile, program.newOutputFile);
         p.setWorkingDir(new File(program.defPath));
         tpe.execute(p);

--- a/src/main/java/org/kframework/ktest/Test/TestSuite.java
+++ b/src/main/java/org/kframework/ktest/Test/TestSuite.java
@@ -147,9 +147,9 @@ public class TestSuite {
         startTpe();
         for (TestCase tc : tests) {
             if (tc.hasPosixOnly()) {
-                Proc<TestCase> p = new Proc<>(tc, tc.getPosixOnlyCmd(), options);
+                Proc<TestCase> p =
+                        new Proc<>(tc, tc.getPosixOnlyCmd(), tc.getWorkingDir(), options);
                 ps.add(p);
-                p.setWorkingDir(tc.getWorkingDir());
                 tpe.execute(p);
             } else {
                 successfulTests.add(tc);
@@ -189,8 +189,7 @@ public class TestSuite {
         long startTime = System.currentTimeMillis();
         startTpe();
         for (TestCase tc : tests) {
-            Proc<TestCase> p = new Proc<>(tc, tc.getKompileCmd(), options);
-            p.setWorkingDir(tc.getWorkingDir());
+            Proc<TestCase> p = new Proc<>(tc, tc.getKompileCmd(), tc.getWorkingDir(), options);
             ps.add(p);
             tpe.execute(p);
             kompileSteps++;
@@ -245,8 +244,7 @@ public class TestSuite {
         startTpe();
         long startTime = System.currentTimeMillis();
         for (TestCase tc : pdfTests) {
-            Proc<TestCase> p = new Proc<>(tc, tc.getPdfCmd(), options);
-            p.setWorkingDir(tc.getWorkingDir());
+            Proc<TestCase> p = new Proc<>(tc, tc.getPdfCmd(), tc.getWorkingDir(), options);
             ps.add(p);
             tpe.execute(p);
             pdfSteps++;
@@ -406,9 +404,8 @@ public class TestSuite {
             matcher = new RegexStringMatcher();
         }
         Proc<KRunProgram> p = new Proc<>(program, args, program.inputFile, inputContents,
-                outputContentsAnn, errorContentsAnn, matcher, options,
+                outputContentsAnn, errorContentsAnn, matcher, new File(program.defPath), options,
                 program.outputFile, program.newOutputFile);
-        p.setWorkingDir(new File(program.defPath));
         tpe.execute(p);
         krunSteps++;
         return p;


### PR DESCRIPTION
Do not merge yet. There's a missing feature(I did not update --dry yet).

Some notes:
- Programs are only run twice when --debug is enabled and program is expected to produce error output. (so that we can use --debug output in verbose output and non--debug output to compare program error output with expected error output)
- If --debug is enabled, it's always passed to programs. No matter what the verbosity setting is. (except in second run of programs with expected output)
- If stack trace is printed, it's only used in verbose output and not in generated JUnit reports.
- KTest only cares about error outputs when programs terminate with non-zero exit code. So if a program exists with zero but still prints a stack trace to _stderr_ because of --debug, the test still passes.
- If program prints something different to _stdout_ due to --debug use and exit with non-zero, then the test fails.
