### PR TITLE
some improvements in java backend strategy rule iterators

### DIFF
--- a/k-core/src/main/java/org/kframework/backend/java/strategies/NullStrategy.java
+++ b/k-core/src/main/java/org/kframework/backend/java/strategies/NullStrategy.java
@@ -26,7 +26,7 @@ public class NullStrategy implements Strategy {
     }
 
     public boolean hasNext() {
-        return rules != null;
+        return rules != null && !rules.isEmpty();
     }
 
     private Collection<Rule> rules;

--- a/k-core/src/main/java/org/kframework/backend/java/strategies/TransitionStrategy.java
+++ b/k-core/src/main/java/org/kframework/backend/java/strategies/TransitionStrategy.java
@@ -38,8 +38,8 @@ public class TransitionStrategy implements Strategy {
      * if it contains a transition tag, otherwise put it in the structural list.
      */
     public void reset(Collection<Rule> rules) {
-        transition = new LinkedList<Rule>();
-        structural = new LinkedList<Rule>();
+        transition = new LinkedList<>();
+        structural = new LinkedList<>();
         for (Rule r : rules) {
             boolean t = false;
             for (String s : tags) {
@@ -78,7 +78,8 @@ public class TransitionStrategy implements Strategy {
      * lists is still non-null.
      */
     public boolean hasNext() {
-        return structural != null || transition != null;
+        return (structural != null && !structural.isEmpty())
+                || (transition != null && !transition.isEmpty());
     }
 
     private Collection<Rule> transition;

--- a/k-core/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/k-core/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -234,7 +234,7 @@ public class SymbolicRewriter {
                 IndexingStatistics.rewritingStopWatch.start();
             }
             transition = strategy.nextIsTransition();
-            ArrayList<Rule> rules = new ArrayList<Rule>(strategy.next());
+            ArrayList<Rule> rules = new ArrayList<>(strategy.next());
 //            System.out.println("rules.size: "+rules.size());
             for (Rule rule : rules) {
                 rulesTried++;


### PR DESCRIPTION
While trying to debug something, I realized that rewrite engine is trying to iterate through rewrite rules, but strategy is just returning empty list of rules. I made some simplifications in the iterator methods to prevent this. This should come with a minor performance improvement. (no more iterating through empty lists)

Note that I'm just learning Java backend, so I may have done something wrong. @yilongli @dwightguth please review.
