### PR TITLE
kompile should only create a directory if definition exists

### DIFF
--- a/k-core/src/main/java/org/kframework/kompile/KompileFrontEnd.java
+++ b/k-core/src/main/java/org/kframework/kompile/KompileFrontEnd.java
@@ -110,7 +110,8 @@ public class KompileFrontEnd extends FrontEnd {
         if (backend.generatesDefinition()) {
                 context.kompiled = new File(options.directory, FilenameUtils.removeExtension(options.mainDefinitionFile().getName()) + "-kompiled");
                 checkAnotherKompiled(context.kompiled);
-                if (!context.kompiled.exists() && !context.kompiled.mkdirs()) {
+                if (options.mainDefinitionFile().exists()
+                        && !context.kompiled.exists() && !context.kompiled.mkdirs()) {
                     kem.registerCriticalError("Could not create directory " + context.kompiled);
                 }
         }


### PR DESCRIPTION
(Resolves #986 )

Note that this may not be flexible enough for new features. A more advanced implementation might provide an API to access to "-kompiled" directory and then generate the directory only when a request to put a file in that directory is happened. (e.g. we can create the directory lazily)

If you want I can also implement that.
