### PR TITLE
ktest should give a warning when running K file and programs is specified but extensions missing

### DIFF
--- a/k-core/src/main/java/org/kframework/ktest/CmdArgs/KTestOptions.java
+++ b/k-core/src/main/java/org/kframework/ktest/CmdArgs/KTestOptions.java
@@ -252,6 +252,10 @@ public class KTestOptions {
         return programs;
     }
 
+    public boolean programsSpecified() {
+        return _programs != null;
+    }
+
     public String getResults() {
         return results;
     }

--- a/k-core/src/main/java/org/kframework/ktest/Test/TestCase.java
+++ b/k-core/src/main/java/org/kframework/ktest/Test/TestCase.java
@@ -8,6 +8,7 @@ import org.kframework.ktest.Config.InvalidConfigError;
 import org.kframework.ktest.Config.LocationData;
 import org.kframework.utils.OS;
 import org.kframework.utils.StringUtil;
+import org.kframework.utils.general.GlobalSettings;
 
 import java.io.File;
 import java.util.*;
@@ -86,6 +87,13 @@ public class TestCase {
     }
 
     public static TestCase makeTestCaseFromK(KTestOptions cmdArgs) {
+        // give a warning if 'programs' is specified using the command line argument,
+        // but 'extension' is not.
+        if (cmdArgs.programsSpecified() && cmdArgs.getExtensions().isEmpty()) {
+            GlobalSettings.kem.registerCompilerWarning("'programs' attribute is given, " +
+                    "but 'extension' is not. ktest won't run any programs.");
+        }
+
         Annotated<String, LocationData> targetFile =
                 new Annotated<>(cmdArgs.getTargetFile(), new LocationData());
 


### PR DESCRIPTION
Resolves #138.
Resolves #209.

Running ktest using config.xml should work as before.

Difference is, when we run it using a .k file and specify "programs" attribute without specifying "extension", it prints a warning:

```
➜  lesson_1 git:(ktest-extension-eror) ✗ ktest lambda.k --skip "kompile pdf" --programs . --dry      
Running initial scripts...
SUCCESS
Running /home/omer/K/k_new_dist/k/k-distribution/tutorial/1_k/1_lambda/lesson_1/lambda.k programs... (0 in total, 0 with input, 0 with output, 0 with error)
SUCCESS
[Warning] Compiler: 'programs' attribute is given, but 'extension' is not.
ktest won't run any programs.
```

(note that this is not quite what I wanted -- I'd like to print the warning as first thing, instead of last thing. @dwightguth how can I do this?)

This works as before because default value of "programs" is used:

```
➜  lesson_1 git:(ktest-extension-eror) ✗ ktest lambda.k --skip "kompile pdf" --extension lambda --dry
Running initial scripts...
SUCCESS
Running /home/omer/K/k_new_dist/k/k-distribution/tutorial/1_k/1_lambda/lesson_1/lambda.k programs... (4 in total, 0 with input, 4 with output, 0 with error)
'/home/omer/K/k_new_dist/k/k-distribution/target/release/k/bin/krun' '/home/omer/K/k_new_dist/k/k-distribution/tutorial/1_k/1_lambda/lesson_1/tests/free-variable-capture.lambda' '--directory' '/home/omer/K/k_new_dist/k/k-distribution/tutorial/1_k/1_lambda/lesson_1'
'/home/omer/K/k_new_dist/k/k-distribution/target/release/k/bin/krun' '/home/omer/K/k_new_dist/k/k-distribution/tutorial/1_k/1_lambda/lesson_1/tests/closed-variable-capture.lambda' '--directory' '/home/omer/K/k_new_dist/k/k-distribution/tutorial/1_k/1_lambda/lesson_1'
'/home/omer/K/k_new_dist/k/k-distribution/target/release/k/bin/krun' '/home/omer/K/k_new_dist/k/k-distribution/tutorial/1_k/1_lambda/lesson_1/tests/omega.lambda' '--directory' '/home/omer/K/k_new_dist/k/k-distribution/tutorial/1_k/1_lambda/lesson_1'
'/home/omer/K/k_new_dist/k/k-distribution/target/release/k/bin/krun' '/home/omer/K/k_new_dist/k/k-distribution/tutorial/1_k/1_lambda/lesson_1/tests/identity.lambda' '--directory' '/home/omer/K/k_new_dist/k/k-distribution/tutorial/1_k/1_lambda/lesson_1'
SUCCESS
```
