### PR TITLE
Non recursive pattern matcher

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/rewritemachine/KAbstractRewriteMachine.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/rewritemachine/KAbstractRewriteMachine.java
@@ -77,7 +77,8 @@ public class KAbstractRewriteMachine {
             /* take the first match that also satisfies the side-condition as solution */
             ExtendedSubstitution solution = null;
             for (ExtendedSubstitution extSubst : normalizedExtSubsts) {
-                Map<Variable, Term> updatedSubst = evaluateConditions(extSubst.substitution());
+                Map<Variable, Term> updatedSubst = NonACPatternMatcher
+                        .evaluateConditions(rule, extSubst.substitution(), context);
                 if (updatedSubst != null) {
                     /* update the substitution according to the result of evaluation */
                     extSubst.setSubst(updatedSubst);
@@ -202,20 +203,6 @@ public class KAbstractRewriteMachine {
                 }
             }
         }
-    }
-
-    /**
-     * Evaluates the side-conditions of a rule according to a given
-     * substitution.
-     *
-     * @param substitution
-     * @return the updated substitution on success; otherwise, {@code null}
-     */
-    private Map<Variable, Term> evaluateConditions(Map<Variable, Term> substitution) {
-        List<Map<Variable, Term>> results = PatternMatcher.evaluateConditions(
-                rule, Collections.singletonList(substitution), context);
-        assert results.size() <= 1;
-        return results.isEmpty() ? null : results.get(0);
     }
 
     private Instruction nextInstruction() {

--- a/java-backend/src/main/java/org/kframework/backend/java/rewritemachine/KAbstractRewriteMachine.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/rewritemachine/KAbstractRewriteMachine.java
@@ -17,6 +17,7 @@ import org.kframework.backend.java.kil.TermContext;
 import org.kframework.backend.java.kil.Variable;
 import org.kframework.backend.java.symbolic.CopyOnShareSubstAndEvalTransformer;
 import org.kframework.backend.java.symbolic.DeepCloner;
+import org.kframework.backend.java.symbolic.NonACPatternMatcher;
 import org.kframework.backend.java.symbolic.PatternMatcher;
 import org.kframework.backend.java.symbolic.Transformer;
 import org.kframework.backend.java.util.Profiler;
@@ -49,6 +50,8 @@ public class KAbstractRewriteMachine {
     private boolean success = true;
     private boolean isStarNested = false;
 
+    private final NonACPatternMatcher patternMatcher;
+
     private final TermContext context;
 
     private KAbstractRewriteMachine(Rule rule, Cell<?> subject, TermContext context) {
@@ -56,6 +59,7 @@ public class KAbstractRewriteMachine {
         this.subject = subject;
         this.instructions = rule.instructions();
         this.context = context;
+        this.patternMatcher = new NonACPatternMatcher(context);
     }
 
     public static boolean rewrite(Rule rule, Term subject, TermContext context) {
@@ -120,8 +124,8 @@ public class KAbstractRewriteMachine {
             Profiler.startTimer(Profiler.PATTERN_MATCH_TIMER);
             /* there should be no AC-matching under the crntCell (violated rule
              * has been filtered out by the compiler) */
-            Map<Variable, Term> subst = PatternMatcher.nonAssocCommPatternMatch(
-                    crntCell.getContent(), getReadCellLHS(cellLabel), context);
+            Map<Variable, Term> subst = patternMatcher.patternMatch(
+                    crntCell.getContent(), getReadCellLHS(cellLabel));
 
             if (subst == null) {
                 success = false;

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/Matcher.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/Matcher.java
@@ -14,7 +14,6 @@ import org.kframework.backend.java.kil.KLabelFreezer;
 import org.kframework.backend.java.kil.KLabelInjection;
 import org.kframework.backend.java.kil.KList;
 import org.kframework.backend.java.kil.KSequence;
-import org.kframework.backend.java.kil.MetaVariable;
 import org.kframework.backend.java.kil.Term;
 import org.kframework.backend.java.kil.Token;
 import org.kframework.backend.java.kil.Variable;
@@ -44,7 +43,6 @@ public interface Matcher {
     public void match(KLabelInjection kLabelInjection, Term pattern);
     public void match(KList kList, Term pattern);
     public void match(KSequence kSequence, Term pattern);
-    public void match(MetaVariable metaVariable, Term pattern);
     public void match(Term subject, Term pattern);
     public void match(Token token, Term pattern);
     public void match(Variable variable, Term pattern);

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/NonACPatternMatcher.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/NonACPatternMatcher.java
@@ -1,0 +1,365 @@
+// Copyright (c) 2014 K Team. All Rights Reserved.
+package org.kframework.backend.java.symbolic;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.kframework.backend.java.kil.Cell;
+import org.kframework.backend.java.kil.CellCollection;
+import org.kframework.backend.java.kil.CellLabel;
+import org.kframework.backend.java.kil.ConcreteCollectionVariable;
+import org.kframework.backend.java.kil.Hole;
+import org.kframework.backend.java.kil.KCollection;
+import org.kframework.backend.java.kil.KItem;
+import org.kframework.backend.java.kil.KLabelConstant;
+import org.kframework.backend.java.kil.KLabelInjection;
+import org.kframework.backend.java.kil.KList;
+import org.kframework.backend.java.kil.KSequence;
+import org.kframework.backend.java.kil.Kind;
+import org.kframework.backend.java.kil.Term;
+import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.Token;
+import org.kframework.backend.java.kil.Variable;
+import org.kframework.kil.loader.Context;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.beust.jcommander.internal.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+
+
+/**
+ * @author YilongL
+ */
+public class NonACPatternMatcher {
+
+    /**
+     * Represents the substitution after the pattern matching.
+     */
+    private Map<Variable, Term> substitution;
+
+    private final Deque<Pair<Term, Term>> tasks = new ArrayDeque<>();
+
+    private final List<Pair<Term, Term>> taskBuffer = Lists.newArrayList();
+
+    private Pair<Term, Term> crntTask;
+
+    private boolean failed = false;
+
+    private final TermContext termContext;
+
+    public NonACPatternMatcher(TermContext context) {
+        this.termContext = context;
+    }
+
+    /**
+     * Matches the subject term against the pattern.
+     *
+     * @param subject
+     *            the subject term
+     * @param pattern
+     *            the pattern term
+     * @return the substitution if the matching succeeds; otherwise, {@code null}
+     */
+    public Map<Variable, Term> patternMatch(Term subject, Term pattern) {
+        substitution = Maps.newHashMapWithExpectedSize(32);
+        tasks.clear();
+        taskBuffer.clear();
+        tasks.addFirst(Pair.of(subject, pattern));
+        failed = false;
+        return match() ? java.util.Collections.unmodifiableMap(substitution) : null;
+    }
+
+    private void check(boolean condition) {
+        failed = failed || !condition;
+    }
+
+    private boolean match() {
+        while (!failed) {
+            for (int i = taskBuffer.size() - 1; i >= 0; i--) {
+                tasks.addFirst(taskBuffer.get(i));
+            }
+            taskBuffer.clear();
+            if (tasks.isEmpty()) {
+                return true;
+            }
+
+            crntTask = tasks.pop();
+            Term subject = crntTask.getLeft();
+            Term pattern = crntTask.getRight();
+
+            if (pattern instanceof Variable) {
+                Variable variable = (Variable) pattern;
+
+                /* special case for concrete collections  */
+                check(!(variable instanceof ConcreteCollectionVariable)
+                        || ((ConcreteCollectionVariable) variable).match(subject));
+                if (failed) {
+                    return false;
+                }
+
+                /* add substitution */
+                addSubstitution(variable, subject);
+            } else {
+                check(!subject.isSymbolic());
+                if (failed) {
+                    return false;
+                }
+
+                if (subject instanceof Cell) {
+                    if (pattern instanceof Cell) {
+                        match((Cell) subject, (Cell) pattern);
+                    } else if (pattern instanceof CellCollection) {
+                        match((Cell) subject, (CellCollection) pattern);
+                    } else {
+                        return false;
+                    }
+                } else if (subject instanceof CellCollection) {
+                    if (pattern instanceof CellCollection) {
+                        match((CellCollection) subject, (CellCollection) pattern);
+                    } else {
+                        return false;
+                    }
+                } else if (subject instanceof KLabelConstant) {
+                    check(subject.equals(pattern));
+                } else if (subject instanceof KItem) {
+                    if (pattern instanceof KItem) {
+                        match((KItem) subject, (KItem) pattern);
+                    } else if (pattern instanceof KSequence) {
+                        match((KItem) subject, (KSequence) pattern);
+                    } else if (pattern instanceof KList) {
+                        match((KItem) subject, (KList) pattern);
+                    } else {
+                        return false;
+                    }
+                } else if (subject instanceof KSequence) {
+                    if (pattern instanceof KSequence) {
+                        match((KSequence) subject, (KSequence) pattern);
+                    } else if (pattern instanceof KList) {
+                        match((KSequence) subject, (KList) pattern);
+                    } else {
+                        return false;
+                    }
+                } else if (subject instanceof KList) {
+                    if (pattern instanceof KList) {
+                        match((KList) subject, (KList) pattern);
+                    } else {
+                        return false;
+                    }
+                } else if (subject instanceof Token) {
+                    check(subject.equals(pattern));
+                } else if (subject instanceof KLabelInjection) {
+                    if (pattern instanceof KLabelInjection) {
+                        match((KLabelInjection) subject, (KLabelInjection) pattern);
+                    } else {
+                        return false;
+                    }
+                } else if (subject instanceof Hole) {
+                    check(subject.equals(pattern));
+                } else {
+                    assert false : "unreachable";
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private void addMatchingTask(Term subject, Term pattern) {
+        taskBuffer.add(Pair.of(subject, pattern));
+    }
+
+    /**
+     * Binds a variable in the pattern to a subterm of the subject; calls
+     * {@link NonACPatternMatcher#fail()} when the binding fails.
+     *
+     * @param variable
+     *            the variable
+     * @param term
+     *            the term
+     */
+    private void addSubstitution(Variable variable, Term term) {
+        /* KList is the only possible singleton collection because we enforce
+         * the second argument of KItem#of to have kind KList */
+        if (term.kind() == Kind.KLIST) {
+            term = KCollection.downKind(term);
+        }
+
+        check(termContext.definition().subsorts().isSubsortedEq(variable.sort(), term.sort()));
+        if (failed) {
+            return;
+        }
+
+        Term subst = substitution.get(variable);
+        if (subst == null) {
+            substitution.put(variable, term);
+        } else {
+            check(subst.equals(term));
+        }
+    }
+
+    private void match(Cell cell, Cell otherCell) {
+        check(cell.getLabel().equals(otherCell.getLabel()));
+        if (!failed) {
+            addMatchingTask(cell.getContent(), otherCell.getContent());
+        }
+    }
+
+    private void match(Cell cell, CellCollection pattern) {
+        check(pattern.concreteSize() == 1);
+        if (!failed) {
+            addMatchingTask(cell, pattern.cells().iterator().next());
+            addSubstitution(pattern.frame(), CellCollection.EMPTY);
+        }
+    }
+
+    private void match(CellCollection cellCollection, CellCollection otherCellCollection) {
+        Context context = termContext.definition().context();
+
+        if (cellCollection.hasFrame()) {
+            check(otherCellCollection.hasFrame());
+            if (failed) {
+                return;
+            }
+        }
+
+        Set<CellLabel> unifiableCellLabels = Sets.intersection(cellCollection.labelSet(), otherCellCollection.labelSet());
+        int numOfDiffCellLabels = cellCollection.labelSet().size() - unifiableCellLabels.size();
+        int numOfOtherDiffCellLabels = otherCellCollection.labelSet().size() - unifiableCellLabels.size();
+
+        /* there will be no AC-matching involved if at least one of the cell
+         * collections doesn't contain any multiplicity cell */
+        assert (!cellCollection.hasMultiplicityCell() || !otherCellCollection.hasMultiplicityCell());
+
+        for (CellLabel label : unifiableCellLabels) {
+            /* these are non-multiplicity cells for sure */
+            match(cellCollection.get(label).iterator().next(),
+                    otherCellCollection.get(label).iterator().next());
+        }
+
+        Variable frame = cellCollection.hasFrame() ? cellCollection.frame() : null;
+        Variable otherFrame = otherCellCollection.hasFrame()? otherCellCollection.frame() : null;
+
+        if (frame != null) {
+            check(otherFrame != null && numOfOtherDiffCellLabels == 0);
+            if (failed) {
+                return;
+            }
+
+            addSubstitution(otherFrame, cellCollection.removeAll(unifiableCellLabels, context));
+        } else {
+            check(numOfOtherDiffCellLabels == 0);
+            if (failed) {
+                return;
+            }
+
+            if (otherFrame != null) {
+                addSubstitution(otherFrame, cellCollection.removeAll(unifiableCellLabels, context));
+            } else {
+                check(numOfDiffCellLabels == 0);
+                if (failed) {
+                    return;
+                }
+            }
+        }
+    }
+
+    private void match(KItem kItem, KItem pattern) {
+        Term kLabel = kItem.kLabel();
+        Term kList = kItem.kList();
+        addMatchingTask(kLabel, pattern.kLabel());
+        // TODO(AndreiS): deal with KLabel variables
+        if (kLabel instanceof KLabelConstant) {
+            KLabelConstant kLabelConstant = (KLabelConstant) kLabel;
+            if (kLabelConstant.isMetaBinder()) {
+                // TODO(AndreiS): deal with non-concrete KLists
+                assert kList instanceof KList;
+                Multimap<Integer, Integer> binderMap = kLabelConstant.getBinderMap();
+                List<Term> terms = new ArrayList<>(((KList) kList).getContents());
+                for (Integer boundVarPosition : binderMap.keySet()) {
+                    Term boundVars = terms.get(boundVarPosition);
+                    Set<Variable> variables = boundVars.variableSet();
+                    Map<Variable,Variable> freshSubstitution = Variable.getFreshSubstitution(variables);
+                    Term freshBoundVars = boundVars.substituteWithBinders(freshSubstitution, termContext);
+                    terms.set(boundVarPosition, freshBoundVars);
+                    for (Integer bindingExpPosition : binderMap.get(boundVarPosition)) {
+                        Term bindingExp = terms.get(bindingExpPosition-1);
+                        Term freshbindingExp = bindingExp.substituteWithBinders(freshSubstitution, termContext);
+                        terms.set(bindingExpPosition-1, freshbindingExp);
+                    }
+                }
+                kList = KList.concatenate(terms);
+            }
+        }
+        addMatchingTask(kList, pattern.kList());
+    }
+
+    private void match(KItem kItem, KSequence pattern) {
+        check(pattern.concreteSize() == 1);
+        if (!failed) {
+            addMatchingTask(kItem, pattern.get(0));
+            addSubstitution(pattern.frame(), KSequence.EMPTY);
+        }
+    }
+
+    private void match(KItem kItem, KList pattern) {
+        check(pattern.concreteSize() == 1);
+        if (!failed) {
+            addMatchingTask(kItem, pattern.get(0));
+            addSubstitution(pattern.frame(), KList.EMPTY);
+        }
+    }
+
+    private void match(KSequence kSequence, KList pattern) {
+        check(pattern.concreteSize() == 1);
+        if (!failed) {
+            addMatchingTask(kSequence, pattern.get(0));
+            addSubstitution(pattern.frame(), KList.EMPTY);
+        }
+    }
+
+    private void match(KSequence kSequence, KSequence pattern) {
+        matchKCollection(kSequence, pattern);
+    }
+
+    private void match(KList kList, KList pattern) {
+        matchKCollection(kList, pattern);
+    }
+
+    private void matchKCollection(KCollection kCollection, KCollection pattern) {
+        assert kCollection.getClass().equals(pattern.getClass());
+
+        int len = kCollection.concreteSize();
+        int otherLen = pattern.concreteSize();
+        check(len >= otherLen);
+        if (failed) {
+            return;
+        }
+
+        if (len >= otherLen) {
+            if (pattern.hasFrame()) {
+                addSubstitution(pattern.frame(), kCollection.fragment(otherLen));
+            } else {
+                check(!kCollection.hasFrame() && len == otherLen);
+                if (failed) {
+                    return;
+                }
+            }
+
+            // kCollection.size() == length
+            for (int index = 0; index < otherLen; ++index) {
+                addMatchingTask(kCollection.get(index), pattern.get(index));
+            }
+        }
+    }
+
+    private void match(KLabelInjection kLabelInjection, KLabelInjection pattern) {
+        addMatchingTask(kLabelInjection.term(), pattern.term());
+    }
+
+}

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/NonACPatternMatcher.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/NonACPatternMatcher.java
@@ -2,10 +2,15 @@
 package org.kframework.backend.java.symbolic;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.kframework.backend.java.builtins.BoolToken;
+import org.kframework.backend.java.builtins.FreshOperations;
+import org.kframework.backend.java.builtins.TermEquality;
+import org.kframework.backend.java.kil.Bottom;
 import org.kframework.backend.java.kil.Cell;
 import org.kframework.backend.java.kil.CellCollection;
 import org.kframework.backend.java.kil.CellLabel;
 import org.kframework.backend.java.kil.ConcreteCollectionVariable;
+import org.kframework.backend.java.kil.DataStructureLookupOrChoice;
 import org.kframework.backend.java.kil.Hole;
 import org.kframework.backend.java.kil.KCollection;
 import org.kframework.backend.java.kil.KItem;
@@ -14,10 +19,12 @@ import org.kframework.backend.java.kil.KLabelInjection;
 import org.kframework.backend.java.kil.KList;
 import org.kframework.backend.java.kil.KSequence;
 import org.kframework.backend.java.kil.Kind;
+import org.kframework.backend.java.kil.Rule;
 import org.kframework.backend.java.kil.Term;
 import org.kframework.backend.java.kil.TermContext;
 import org.kframework.backend.java.kil.Token;
 import org.kframework.backend.java.kil.Variable;
+import org.kframework.backend.java.util.Profiler;
 import org.kframework.kil.loader.Context;
 
 import java.util.ArrayDeque;
@@ -51,9 +58,16 @@ public class NonACPatternMatcher {
 
     private boolean failed = false;
 
+    private final boolean matchOnFunctionSymbol;
+
     private final TermContext termContext;
 
     public NonACPatternMatcher(TermContext context) {
+        this(false, context);
+    }
+
+    public NonACPatternMatcher(boolean matchOnFunctionSymbol, TermContext context) {
+        this.matchOnFunctionSymbol = matchOnFunctionSymbol;
         this.termContext = context;
     }
 
@@ -67,6 +81,13 @@ public class NonACPatternMatcher {
      * @return the substitution if the matching succeeds; otherwise, {@code null}
      */
     public Map<Variable, Term> patternMatch(Term subject, Term pattern) {
+        /*
+         * We make no assumption about whether the subject will be ground in the
+         * matching algorithm. As for the pattern, all symbolic terms inside it
+         * must be variables (no function KLabels, KItem projections, or
+         * data-structure lookup/update).
+         */
+
         substitution = Maps.newHashMapWithExpectedSize(32);
         tasks.clear();
         taskBuffer.clear();
@@ -106,7 +127,7 @@ public class NonACPatternMatcher {
                 /* add substitution */
                 addSubstitution(variable, subject);
             } else {
-                check(!subject.isSymbolic());
+                check(!subject.isSymbolic() || matchOnFunctionSymbol);
                 if (failed) {
                     return false;
                 }
@@ -234,7 +255,8 @@ public class NonACPatternMatcher {
 
         /* there will be no AC-matching involved if at least one of the cell
          * collections doesn't contain any multiplicity cell */
-        assert (!cellCollection.hasMultiplicityCell() || !otherCellCollection.hasMultiplicityCell());
+        assert (!cellCollection.hasMultiplicityCell() || !otherCellCollection.hasMultiplicityCell()) :
+            "AC-matching not supported; consider using the AC pattern matcher instead";
 
         for (CellLabel label : unifiableCellLabels) {
             /* these are non-multiplicity cells for sure */
@@ -360,6 +382,118 @@ public class NonACPatternMatcher {
 
     private void match(KLabelInjection kLabelInjection, KLabelInjection pattern) {
         addMatchingTask(kLabelInjection.term(), pattern.term());
+    }
+
+
+    /**
+     * Matches a subject term against a rule. Returns the instantiation when the
+     * rule can be applied for sure (all side-conditions are cleared). Note
+     * that, however, {@code null} doesn't mean that this rule cannot apply
+     * definitely; it is possible that side-conditions are blocked by symbolic
+     * argument(s).
+     *
+     * @param subject
+     *            the subject term
+     * @param rule
+     *            the rule
+     * @param context
+     *            the term context
+     * @return the instantiation of variables
+     */
+    public static Map<Variable, Term> patternMatch(Term subject, Rule rule, TermContext context) {
+        NonACPatternMatcher matcher = new NonACPatternMatcher(rule.isFunction() || rule.isLemma(), context);
+
+        Map<Variable, Term> result = matcher.patternMatch(subject, rule.leftHandSide());
+        return result != null ? evaluateConditions(rule, result, context) : null;
+    }
+
+    /**
+     * Evaluates the side-conditions of a rule against a list of possible
+     * instantiations.
+     *
+     * @param rule
+     * @param substitutions
+     * @param context
+     * @return a list of instantiations that satisfy the side-conditions; each
+     *         of which is updated with extra bindings introduced during the
+     *         evaluation
+     */
+    public static Map<Variable, Term> evaluateConditions(Rule rule, Map<Variable, Term> substitutions,
+            TermContext context) {
+        /* handle fresh variables, data structure lookups, and side conditions */
+
+        Map<Variable, Term> crntSubst = substitutions;
+        /* add bindings for fresh variables used in the rule */
+        for (Variable variable : rule.freshVariables()) {
+            crntSubst.put(variable, FreshOperations.fresh(variable.sort(), context));
+        }
+
+        /* evaluate data structure lookups/choices and add bindings for them */
+        for (UninterpretedConstraint.Equality equality : rule.lookups().equalities()) {
+            // TODO(YilongL): enforce the format of rule.lookups() in kompilation and simplify the following code
+            Term lookupOrChoice = equality.leftHandSide() instanceof DataStructureLookupOrChoice ?
+                    equality.leftHandSide() : equality.rightHandSide();
+                    Term nonLookupOrChoice = equality.leftHandSide() == lookupOrChoice ?
+                            equality.rightHandSide() : equality.leftHandSide();
+                    assert lookupOrChoice instanceof DataStructureLookupOrChoice :
+                        "one side of the equality should be an instance of DataStructureLookup or DataStructureChoice";
+
+                    Term evalLookupOrChoice = PatternMatcher.evaluateLookupOrChoice(lookupOrChoice, crntSubst, context);
+
+                    boolean resolved = false;
+                    if (evalLookupOrChoice instanceof Bottom
+                            || evalLookupOrChoice instanceof DataStructureLookupOrChoice) {
+                        /* the data-structure lookup or choice operation is either undefined or pending due to symbolic argument(s) */
+
+                        // when the operation is pending, it is not really a valid match
+                        // for example, matching ``<env>... X |-> V ...</env>''
+                        // against ``<env> Rho </env>'' will result in a pending
+                        // choice operation due to the unknown ``Rho''.
+                    } else {
+                        if (nonLookupOrChoice instanceof Variable) {
+                            Variable variable = (Variable) nonLookupOrChoice;
+                            if (context.definition().subsorts().isSubsortedEq(variable.sort(), evalLookupOrChoice.sort())) {
+                                Term term = crntSubst.put(variable, evalLookupOrChoice);
+                                resolved = term == null || BoolToken.TRUE.equals(
+                                        TermEquality.eq(term, evalLookupOrChoice, context));
+                            }
+                        } else {
+                            // the non-lookup term is not a variable and thus requires further pattern matching
+                            // for example: L:List[Int(#"0")] = '#ostream(_)(I:Int), where L is the output buffer
+                            //           => '#ostream(_)(Int(#"1")) =? '#ostream(_)(I:Int)
+                            NonACPatternMatcher lookupMatcher = new NonACPatternMatcher(rule.isLemma(), context);
+                            Map<Variable, Term> lookupResult = lookupMatcher.patternMatch(evalLookupOrChoice, nonLookupOrChoice);
+                            if (lookupResult != null) {
+                                resolved = true;
+                                crntSubst = PatternMatcher.composeSubstitution(crntSubst, lookupResult);
+                            }
+                        }
+                    }
+
+                    if (!resolved) {
+                        crntSubst = null;
+                        break;
+                    }
+        }
+
+
+        /* evaluate side conditions */
+        if (crntSubst != null) {
+            Profiler.startTimer(Profiler.EVALUATE_REQUIRES_TIMER);
+            for (Term require : rule.requires()) {
+                // TODO(YilongL): in the future, we may have to accumulate
+                // the substitution obtained from evaluating the side
+                // condition
+                Term evaluatedReq = require.substituteAndEvaluate(crntSubst, context);
+                if (!evaluatedReq.equals(BoolToken.TRUE)) {
+                    crntSubst = null;
+                    break;
+                }
+            }
+            Profiler.stopTimer(Profiler.EVALUATE_REQUIRES_TIMER);
+        }
+
+        return crntSubst;
     }
 
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/NonACPatternMatcher.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/NonACPatternMatcher.java
@@ -127,7 +127,7 @@ public class NonACPatternMatcher {
                 /* add substitution */
                 addSubstitution(variable, subject);
             } else {
-                check(!subject.isSymbolic() || matchOnFunctionSymbol);
+                check(!subject.isSymbolic() || subject instanceof KItem && matchOnFunctionSymbol);
                 if (failed) {
                     return false;
                 }

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/PatternMatcher.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/PatternMatcher.java
@@ -464,7 +464,7 @@ public class PatternMatcher extends AbstractMatcher {
 
             /* add substitution */
             addSubstitution(variable, subject);
-        } else if (subject.isSymbolic() && !matchOnFunctionSymbol) {
+        } else if (subject.isSymbolic() && (!(subject instanceof KItem) || !matchOnFunctionSymbol)) {
             fail(subject, pattern);
         } else {
             /* match */

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/PatternMatcher.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/PatternMatcher.java
@@ -25,7 +25,6 @@ import org.kframework.backend.java.kil.KLabelInjection;
 import org.kframework.backend.java.kil.KList;
 import org.kframework.backend.java.kil.KSequence;
 import org.kframework.backend.java.kil.Kind;
-import org.kframework.backend.java.kil.MetaVariable;
 import org.kframework.backend.java.kil.Rule;
 import org.kframework.backend.java.kil.Term;
 import org.kframework.backend.java.kil.TermContext;
@@ -223,7 +222,7 @@ public class PatternMatcher extends AbstractMatcher {
                         if (checkOrderedSortedCondition(variable, evalLookupOrChoice, context)) {
                             Term term = crntSubst.put(variable, evalLookupOrChoice);
                             resolved = term == null || BoolToken.TRUE.equals(
-                                    new TermEquality().eq(term, evalLookupOrChoice, context));
+                                    TermEquality.eq(term, evalLookupOrChoice, context));
                         }
                     } else {
                         // the non-lookup term is not a variable and thus requires further pattern matching
@@ -1048,16 +1047,8 @@ public class PatternMatcher extends AbstractMatcher {
         if(!(pattern instanceof KLabelInjection)) {
             fail(kLabelInjection, pattern);
         }
+
         KLabelInjection otherKLabelInjection = (KLabelInjection) pattern;
-
-        Kind injectionKind = kLabelInjection.term().kind();
-        Kind otherInjectionKind = otherKLabelInjection.term().kind();
-        if (injectionKind != otherInjectionKind
-                && !(injectionKind.isComputational() && otherInjectionKind.isComputational())
-                && !(injectionKind.isStructural() && otherInjectionKind.isStructural())) {
-            fail(kLabelInjection, otherKLabelInjection);
-        }
-
         match(kLabelInjection.term(), otherKLabelInjection.term());
     }
 
@@ -1158,15 +1149,6 @@ public class PatternMatcher extends AbstractMatcher {
             }
         } else {
             fail(kCollection, pattern);
-        }
-    }
-
-    @Override
-    public void match(MetaVariable metaVariable, Term pattern) {
-        assert !(pattern instanceof Variable);
-
-        if (!metaVariable.equals(pattern)) {
-            fail(metaVariable, pattern);
         }
     }
 


### PR DESCRIPTION
I was hoping to work more on this. However, I am busy with the matching logic prover so I would like to merge what I have right now.

The speedup of pattern matching gained by eliminating visitor pattern is consistent with the experiment in http://higherlogics.blogspot.com/2008/10/vtable-dispatching-vs-runtime-tests-and.html as well as the paper written by Scala guys http://lampwww.epfl.ch/~emir/written/MatchingObjectsWithPatterns-TR.pdf

@dwightguth @andreistefanescu please review
