### PR TITLE
Fix a bug in circularity detection of poset.

### DIFF
--- a/k-core/src/main/java/org/kframework/utils/Poset.java
+++ b/k-core/src/main/java/org/kframework/utils/Poset.java
@@ -362,7 +362,8 @@ public class Poset<T> implements Serializable {
                             }
                             if (!visited.contains(nextNode)) {
                                 nodesStack.push(nextNode);
-                                iteratorStack.push(nodes.iterator());
+                                currentIterator = nodes.iterator();
+                                iteratorStack.push(currentIterator);
                                 visited.add(nextNode);
                                 break;
                             }

--- a/k-core/src/test/java/org/kframework/utils/PosetTest.java
+++ b/k-core/src/test/java/org/kframework/utils/PosetTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 
 import com.google.common.collect.Sets;
 
+import java.util.List;
+
 public class PosetTest {
 
     private Poset<String> poset;
@@ -69,5 +71,14 @@ public class PosetTest {
         poset.addRelation("LUB", "B1");
         poset.transitiveClosure();
         Assert.assertEquals("LUB", poset.getLUB(Sets.newHashSet("B0", "B1")));
+    }
+
+    @Test
+    public void testCircularity() throws Exception {
+        poset.addRelation("S1", "S2");
+        poset.addRelation("S2", "S1");
+        List<String> circle = poset.checkForCycles();
+        Assert.assertNotNull("The circuit should have 2 elements.", circle);
+        Assert.assertEquals("The circuit should have 2 elements.", 2, circle.size());
     }
 }


### PR DESCRIPTION
I'm not sure how we didn't detect this one until now, but it was a bug in the actual algorithm.
@dwightguth please review.
