### PR TITLE
remove shared .k generation in maude backend

### DIFF
--- a/k-core/src/main/java/org/kframework/utils/inject/DefinitionLoadingModule.java
+++ b/k-core/src/main/java/org/kframework/utils/inject/DefinitionLoadingModule.java
@@ -33,14 +33,6 @@ public class DefinitionLoadingModule extends AbstractModule {
 
         sw.printIntermediate("Loading serialized context");
 
-        context.dotk = new File(
-                options.definition().getParent() + File.separator
-                        + ".k");
-        if (!context.dotk.exists()) {
-            if (!context.dotk.mkdirs()) {
-                kem.registerCriticalError("could not create directory " + context.dotk);
-            }
-        }
         context.kompiled = options.definition();
 
         sw.printIntermediate("Initializing definition paths");

--- a/maude-backend/src/main/java/org/kframework/backend/maude/krun/MaudeExecutor.java
+++ b/maude-backend/src/main/java/org/kframework/backend/maude/krun/MaudeExecutor.java
@@ -122,7 +122,8 @@ public class MaudeExecutor implements Executor {
         this.maudeOptions = maudeOptions;
 
 
-        krunTempDir = new File(context.dotk, FileUtil.generateUniqueFolderName("krun"));
+        krunTempDir = new File(System.getProperty("user.dir"),
+                FileUtil.generateUniqueFolderName(".krun"));
         inFile = new File(krunTempDir, "maude_in");
         outFile = new File(krunTempDir, "maude_out");
         errFile = new File(krunTempDir, "maude_err");


### PR DESCRIPTION
If this works as expected this means that we finally get rid of all dotk directories left on the filesystem.
