### PR TITLE
Added better error message for when SDF crashes

### DIFF
--- a/k-core/src/main/java/org/kframework/parser/generator/ParseConfigsFilter.java
+++ b/k-core/src/main/java/org/kframework/parser/generator/ParseConfigsFilter.java
@@ -75,7 +75,7 @@ public class ParseConfigsFilter extends ParseForestTransformer {
                 } else {
                     try {
                         parsed = org.kframework.parser.concrete.KParser.ParseKConfigString(ss.getContent());
-                    } catch (Exception e) {
+                    } catch (RuntimeException e) {
                         String msg = "SDF failed to parse a configuration by throwing: " + e.getCause().getLocalizedMessage();
                         throw new ParseFailedException(new KException(ExceptionType.ERROR, KExceptionGroup.CRITICAL, msg, ss.getSource(), ss.getLocation()));
                     }

--- a/k-core/src/main/java/org/kframework/parser/generator/ParseConfigsFilter.java
+++ b/k-core/src/main/java/org/kframework/parser/generator/ParseConfigsFilter.java
@@ -11,6 +11,9 @@ import org.kframework.kil.loader.Constants;
 import org.kframework.kil.loader.Context;
 import org.kframework.kil.loader.JavaClassesFactory;
 import org.kframework.kil.visitors.ParseForestTransformer;
+import org.kframework.utils.errorsystem.KException;
+import org.kframework.utils.errorsystem.KException.ExceptionType;
+import org.kframework.utils.errorsystem.KException.KExceptionGroup;
 import org.kframework.utils.errorsystem.ParseFailedException;
 import org.kframework.parser.concrete.disambiguate.AmbDuplicateFilter;
 import org.kframework.parser.concrete.disambiguate.AmbFilter;
@@ -69,8 +72,14 @@ public class ParseConfigsFilter extends ParseForestTransformer {
                     parsed = org.kframework.parser.concrete.KParser.ParseKoreString(ss.getContent());
                     if (globalOptions.verbose)
                         System.out.println("Parsing with Kore: " + ss.getSource() + ":" + ss.getLocation() + " - " + (System.currentTimeMillis() - startTime));
-                } else
-                    parsed = org.kframework.parser.concrete.KParser.ParseKConfigString(ss.getContent());
+                } else {
+                    try {
+                        parsed = org.kframework.parser.concrete.KParser.ParseKConfigString(ss.getContent());
+                    } catch (Exception e) {
+                        String msg = "SDF failed to parse a configuration by throwing: " + e.getCause().getLocalizedMessage();
+                        throw new ParseFailedException(new KException(ExceptionType.ERROR, KExceptionGroup.CRITICAL, msg, ss.getSource(), ss.getLocation()));
+                    }
+                }
                 Document doc = XmlLoader.getXMLDoc(parsed);
 
                 // replace the old xml node with the newly parsed sentence

--- a/k-core/src/main/java/org/kframework/parser/generator/ParseRulesFilter.java
+++ b/k-core/src/main/java/org/kframework/parser/generator/ParseRulesFilter.java
@@ -66,8 +66,14 @@ public class ParseRulesFilter extends ParseForestTransformer {
                 parsed = org.kframework.parser.concrete.KParser.ParseKoreString(ss.getContent());
                 if (globalOptions.verbose)
                     System.out.println("Parsing with Kore: " + ss.getSource() + ":" + ss.getLocation() + " - " + (System.currentTimeMillis() - koreStartTime));
-            } else
-                parsed = org.kframework.parser.concrete.KParser.ParseKConfigString(ss.getContent());
+            } else {
+                try {
+                    parsed = org.kframework.parser.concrete.KParser.ParseKConfigString(ss.getContent());
+                } catch (Exception e) {
+                    String msg = "SDF failed to parse a rule by throwing: " + e.getCause().getLocalizedMessage();
+                    throw new ParseFailedException(new KException(ExceptionType.ERROR, KExceptionGroup.CRITICAL, msg, ss.getSource(), ss.getLocation()));
+                }
+            }
             Document doc = XmlLoader.getXMLDoc(parsed);
 
             // replace the old xml node with the newly parsed sentence

--- a/k-core/src/main/java/org/kframework/parser/generator/ParseRulesFilter.java
+++ b/k-core/src/main/java/org/kframework/parser/generator/ParseRulesFilter.java
@@ -69,7 +69,7 @@ public class ParseRulesFilter extends ParseForestTransformer {
             } else {
                 try {
                     parsed = org.kframework.parser.concrete.KParser.ParseKConfigString(ss.getContent());
-                } catch (Exception e) {
+                } catch (RuntimeException  e) {
                     String msg = "SDF failed to parse a rule by throwing: " + e.getCause().getLocalizedMessage();
                     throw new ParseFailedException(new KException(ExceptionType.ERROR, KExceptionGroup.CRITICAL, msg, ss.getSource(), ss.getLocation()));
                 }

--- a/src/main/config/checkstyle-suppress.xml
+++ b/src/main/config/checkstyle-suppress.xml
@@ -8,6 +8,6 @@
 <suppressions>
   <suppress checks="IllegalThrows" files="src[\\/]test[\\/]"/>
   <suppress checks="IllegalThrows" files="[\\/]src[\\/]main[\\/]sdf[\\/]editor[\\/]java"/>
-  <suppress checks="IllegalThrows" files="/src/main/java/org/kframework/parser/generator/ParseRulesFilter.java"/>
-  <suppress checks="IllegalThrows" files="/src/main/java/org/kframework/parser/generator/ParseConfigsFilter.java"/>
+  <suppress checks="IllegalThrows" files="ParseRulesFilter.java"/>
+  <suppress checks="IllegalThrows" files="ParseConfigsFilter.java"/>
 </suppressions>

--- a/src/main/config/checkstyle-suppress.xml
+++ b/src/main/config/checkstyle-suppress.xml
@@ -8,4 +8,6 @@
 <suppressions>
   <suppress checks="IllegalThrows" files="src[\\/]test[\\/]"/>
   <suppress checks="IllegalThrows" files="[\\/]src[\\/]main[\\/]sdf[\\/]editor[\\/]java"/>
+  <suppress checks="IllegalThrows" files="/src/main/java/org/kframework/parser/generator/ParseRulesFilter.java"/>
+  <suppress checks="IllegalThrows" files="/src/main/java/org/kframework/parser/generator/ParseConfigsFilter.java"/>
 </suppressions>

--- a/src/main/config/checkstyle-suppress.xml
+++ b/src/main/config/checkstyle-suppress.xml
@@ -8,6 +8,6 @@
 <suppressions>
   <suppress checks="IllegalThrows" files="src[\\/]test[\\/]"/>
   <suppress checks="IllegalThrows" files="[\\/]src[\\/]main[\\/]sdf[\\/]editor[\\/]java"/>
-  <suppress checks="IllegalThrows" files="ParseRulesFilter.java"/>
-  <suppress checks="IllegalThrows" files="ParseConfigsFilter.java"/>
+  <suppress checks="IllegalCatch" files="ParseRulesFilter.java"/>
+  <suppress checks="IllegalCatch" files="ParseConfigsFilter.java"/>
 </suppressions>


### PR DESCRIPTION
 to indicate the line number of the rule in question.

@dwightguth please review.

I've added a catch for any type of exception that SDF might throw since I'm the only one interested in them, and replace it with a K localized message to indicate which is the rule that doesn't parse and crashes the parser.
