### PR TITLE
make initial config obtained only once via provider instead of singleton

### DIFF
--- a/kernel/src/main/java/org/kframework/krun/KRunModule.java
+++ b/kernel/src/main/java/org/kframework/krun/KRunModule.java
@@ -200,7 +200,7 @@ public class KRunModule extends AbstractModule {
 
             bind(Debugger.class).to(ExecutorDebugger.class);
 
-            bind(Term.class).toProvider(InitialConfigurationProvider.class).in(Singleton.class);
+            bind(Term.class).toProvider(InitialConfigurationProvider.class);
 
             bind(FileUtil.class);
 

--- a/kernel/src/main/java/org/kframework/krun/tools/Debugger.java
+++ b/kernel/src/main/java/org/kframework/krun/tools/Debugger.java
@@ -37,6 +37,7 @@ import org.kframework.utils.inject.Main;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import com.sun.org.apache.xerces.internal.impl.dv.util.Base64;
 
 public interface Debugger {
@@ -121,7 +122,7 @@ public interface Debugger {
     public static class Tool implements Transformation<Void, Void> {
 
         private final KExceptionManager kem;
-        private final Term initialConfiguration;
+        private final Provider<Term> initialConfiguration;
         private final KompileOptions kompileOptions;
         private final BinaryLoader loader;
         @InjectGeneric private Transformation<KRunState, String> statePrinter;
@@ -135,7 +136,7 @@ public interface Debugger {
         @Inject
         Tool(
                 KExceptionManager kem,
-                @Main Term initialConfiguration,
+                @Main Provider<Term> initialConfiguration,
                 @Main KompileOptions kompileOptions,
                 BinaryLoader loader,
                 @Main Debugger debugger,
@@ -152,7 +153,7 @@ public interface Debugger {
 
         Tool(
                 KExceptionManager kem,
-                @Main Term initialConfiguration,
+                @Main Provider<Term> initialConfiguration,
                 @Main KompileOptions kompileOptions,
                 BinaryLoader loader,
                 Transformation<KRunState, String> statePrinter,
@@ -196,7 +197,7 @@ public interface Debugger {
             reader.addCompletor(new MultiCompletor(completors));
 
             try {
-                debugger.start(initialConfiguration);
+                debugger.start(initialConfiguration.get());
                 System.out.println("After running one step of execution the result is:\n");
                 System.out.println(statePrinter.run(debugger.getState(debugger.getCurrentState()), a));
             } catch (UnsupportedBackendOptionException e) {

--- a/kernel/src/main/java/org/kframework/krun/tools/Executor.java
+++ b/kernel/src/main/java/org/kframework/krun/tools/Executor.java
@@ -27,6 +27,7 @@ import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.inject.Main;
 
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 public interface Executor {
 
@@ -77,7 +78,7 @@ public interface Executor {
     public static class Tool implements Transformation<Void, KRunResult<?>> {
 
         private final KRunOptions options;
-        private final Term initialConfiguration;
+        private final Provider<Term> initialConfiguration;
         private final Context context;
         private final Stopwatch sw;
         private final KExceptionManager kem;
@@ -87,7 +88,7 @@ public interface Executor {
         @Inject
         Tool(
                 KRunOptions options,
-                @Main Term initialConfiguration,
+                @Main Provider<Term> initialConfiguration,
                 Stopwatch sw,
                 @Main Context context,
                 KExceptionManager kem,
@@ -140,7 +141,7 @@ public interface Executor {
                         options.depth,
                         options.searchType(),
                         searchPattern.patternRule,
-                        initialConfiguration, searchPattern.steps);
+                        initialConfiguration.get(), searchPattern.steps);
 
             sw.printIntermediate("Search total");
             return result;
@@ -149,10 +150,10 @@ public interface Executor {
         public KRunResult<?> execute() throws ParseFailedException, KRunExecutionException {
             KRunResult<?> result;
             if (options.depth != null) {
-                result = executor.step(initialConfiguration, options.depth);
+                result = executor.step(initialConfiguration.get(), options.depth);
                 sw.printIntermediate("Bounded execution total");
             } else {
-                result = executor.run(initialConfiguration);
+                result = executor.run(initialConfiguration.get());
                 sw.printIntermediate("Normal execution total");
             }
             ASTNode pattern = pattern();

--- a/kernel/src/main/java/org/kframework/krun/tools/LtlModelChecker.java
+++ b/kernel/src/main/java/org/kframework/krun/tools/LtlModelChecker.java
@@ -17,6 +17,7 @@ import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.inject.Main;
 
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 public interface LtlModelChecker {
 
@@ -36,7 +37,7 @@ public interface LtlModelChecker {
     public static class Tool implements Transformation<Void, KRunResult<?>> {
 
         private final KRunOptions options;
-        private final Term initialConfiguration;
+        private final Provider<Term> initialConfiguration;
         private final Context context;
         private final Stopwatch sw;
         private final LtlModelChecker modelChecker;
@@ -46,7 +47,7 @@ public interface LtlModelChecker {
         @Inject
         protected Tool(
                 KRunOptions options,
-                @Main Term initialConfiguration,
+                @Main Provider<Term> initialConfiguration,
                 @Main Context context,
                 Stopwatch sw,
                 @Main LtlModelChecker modelChecker,
@@ -69,7 +70,7 @@ public interface LtlModelChecker {
                         options.experimental.ltlmc(), false, Sort.of("LtlFormula"), context);
                 KRunProofResult<KRunGraph> result = modelChecker.modelCheck(
                                 formula,
-                                initialConfiguration);
+                                initialConfiguration.get());
                 sw.printIntermediate("Model checking total");
                 return result;
             } catch (KRunExecutionException e) {

--- a/kernel/src/main/java/org/kframework/krun/tools/Prover.java
+++ b/kernel/src/main/java/org/kframework/krun/tools/Prover.java
@@ -21,6 +21,7 @@ import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.inject.Main;
 
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 public interface Prover {
 
@@ -40,7 +41,7 @@ public interface Prover {
         private final KRunOptions options;
         private final Context context;
         private final Stopwatch sw;
-        private final Term initialConfiguration;
+        private final Provider<Term> initialConfiguration;
         private final Prover prover;
         private final FileUtil files;
         private final TermLoader termLoader;
@@ -50,7 +51,7 @@ public interface Prover {
                 KRunOptions options,
                 @Main Context context,
                 Stopwatch sw,
-                @Main Term initialConfiguration,
+                @Main Provider<Term> initialConfiguration,
                 @Main Prover prover,
                 @Main FileUtil files,
                 TermLoader termLoader) {
@@ -72,7 +73,7 @@ public interface Prover {
                 Definition parsed = termLoader.parseString(content,
                         Sources.fromFile(files.resolveWorkingDirectory(proofFile)), context);
                 Module mod = parsed.getSingletonModule();
-                KRunProofResult<Set<Term>> result = prover.prove(mod, initialConfiguration);
+                KRunProofResult<Set<Term>> result = prover.prove(mod, initialConfiguration.get());
                 sw.printIntermediate("Proof total");
                 return result;
             } catch (KRunExecutionException e) {


### PR DESCRIPTION
@yilongli please review

I did this because singletons rely on a static lock in Guice which causes a deadlock if process A spawns process B while provisioning, and then waits for the process to complete. This was causing external parsers to not work.
