### PR TITLE
Context refactoring

### DIFF
--- a/kernel/src/main/java/org/kframework/compile/checks/CheckSyntaxDecl.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckSyntaxDecl.java
@@ -90,7 +90,7 @@ public class CheckSyntaxDecl extends BasicVisitor {
                 sorts++;
                 NonTerminal s = (NonTerminal) pi;
                 if (!s.getSort().isCellSort()) {
-                    if (!context.definedSorts.contains(s.getSort())) {
+                    if (!context.getAllSorts().contains(s.getSort())) {
                         String msg = "Undefined sort " + s;
                         throw KExceptionManager.compilerError(msg, this, s);
                     }
@@ -103,7 +103,7 @@ public class CheckSyntaxDecl extends BasicVisitor {
             if (pi instanceof UserList) {
                 sorts++;
                 UserList s = (UserList) pi;
-                if (!s.getSort().getName().startsWith("#") && !context.definedSorts.contains(s.getSort())) {
+                if (!s.getSort().getName().startsWith("#") && !context.getAllSorts().contains(s.getSort())) {
                     String msg = "Undefined sort " + s.getSort();
                     throw KExceptionManager.compilerError(msg, this, s);
                 }

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -107,7 +107,7 @@ public class KastFrontEnd extends FrontEnd {
             if (env.get("KRUN_SORT") != null) {
                 sort = Sort.of(env.get("KRUN_SORT"));
             } else {
-                sort = context.startSymbolPgm;
+                sort = context.startSymbolPgm();
             }
         }
         return sort;

--- a/kernel/src/main/java/org/kframework/kil/Definition.java
+++ b/kernel/src/main/java/org/kframework/kil/Definition.java
@@ -111,7 +111,6 @@ public class Definition extends ASTNode implements Interfaces.MutableList<Defini
         new CollectStartSymbolPgmVisitor(context).visitNode(this);
         new CollectConfigCellsVisitor(context).visitNode(this);
         new CollectLocationsVisitor(context).visitNode(this);
-        new CountNodesVisitor(context).visitNode(this);
         new CollectVariableTokens(context).visitNode(this);
 
         /* collect lexical token sorts */

--- a/kernel/src/main/java/org/kframework/kil/Definition.java
+++ b/kernel/src/main/java/org/kframework/kil/Definition.java
@@ -123,9 +123,6 @@ public class Definition extends ASTNode implements Interfaces.MutableList<Defini
         context.setDataStructureSorts(dataStructureSortCollector.getSorts());
 
         context.makeFreshFunctionNamesMap(this.getSyntaxByTag(Attribute.FRESH_GENERATOR, context));
-
-        /* set the initialized flag */
-        context.initialized = true;
     }
 
     public Map<String, Module> getModulesMap() {

--- a/kernel/src/main/java/org/kframework/kil/Definition.java
+++ b/kernel/src/main/java/org/kframework/kil/Definition.java
@@ -9,6 +9,7 @@ import org.kframework.parser.DefinitionLoader;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.Poset;
 import java.io.File;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +29,7 @@ public class Definition extends ASTNode implements Interfaces.MutableList<Defini
     private Map<String, Module> modulesMap;
     private String mainSyntaxModule;
     private Poset<String> modules = Poset.create();
+    public Map<String, ASTNode> locations = new HashMap<>();
 
     public Definition() {
         super();
@@ -39,6 +41,7 @@ public class Definition extends ASTNode implements Interfaces.MutableList<Defini
         this.mainModule = d.mainModule;
         this.mainSyntaxModule = d.mainSyntaxModule;
         this.items = d.items;
+        this.locations = d.locations;
     }
 
     @Override
@@ -110,7 +113,7 @@ public class Definition extends ASTNode implements Interfaces.MutableList<Defini
         new CollectPrioritiesVisitor(context).visitNode(this);
         new CollectStartSymbolPgmVisitor(context).visitNode(this);
         new CollectConfigCellsVisitor(context).visitNode(this);
-        new CollectLocationsVisitor(context).visitNode(this);
+        new CollectLocationsVisitor().visitNode(this);
         new CollectVariableTokens(context).visitNode(this);
 
         /* collect lexical token sorts */

--- a/kernel/src/main/java/org/kframework/kil/loader/CollectLocationsVisitor.java
+++ b/kernel/src/main/java/org/kframework/kil/loader/CollectLocationsVisitor.java
@@ -6,20 +6,19 @@ import org.kframework.kil.Sentence;
 import org.kframework.kil.visitors.BasicVisitor;
 
 public class CollectLocationsVisitor extends BasicVisitor {
-    public CollectLocationsVisitor(Context context) {
-        super(context);
-        // TODO Auto-generated constructor stub
+    public CollectLocationsVisitor() {
+        super(null);
     }
 
     @Override
     public Void visit(Production node, Void _) {
-        context.locations.put(node.getSource() + ":" + node.getLocation(), node);
+        getCurrentDefinition().locations.put(node.getSource() + ":" + node.getLocation(), node);
         return null;
     }
 
     @Override
     public Void visit(Sentence node, Void _) {
-        context.locations.put(node.getSource() + ":" + node.getLocation(), node);
+        getCurrentDefinition().locations.put(node.getSource() + ":" + node.getLocation(), node);
         return null;
     }
 }

--- a/kernel/src/main/java/org/kframework/kil/loader/CollectStartSymbolPgmVisitor.java
+++ b/kernel/src/main/java/org/kframework/kil/loader/CollectStartSymbolPgmVisitor.java
@@ -36,9 +36,6 @@ public class CollectStartSymbolPgmVisitor extends BasicVisitor {
 
     @Override
     public Void visit(Variable node, Void _) {
-        if (node.getName().equals("$PGM")) {
-            context.startSymbolPgm = node.getSort();
-        }
         assert node.getName().startsWith("$") : "Configuration variables must start with $ symbol.";
         context.configVarSorts.put(node.getName().substring(1), node.getSort());
         return null;

--- a/kernel/src/main/java/org/kframework/kil/loader/Context.java
+++ b/kernel/src/main/java/org/kframework/kil/loader/Context.java
@@ -67,11 +67,11 @@ public class Context implements Serializable {
      */
     public SetMultimap<String, Production> klabels = HashMultimap.create();
     public SetMultimap<String, Production> tags = HashMultimap.create();
-    public Map<String, Cell> cells = new HashMap<String, Cell>();
+    public Map<String, Cell> cells = new HashMap<>();
     public Map<String, Sort> cellSorts = new HashMap<>();
     public Map<Sort, Production> listProductions = new LinkedHashMap<>();
     public SetMultimap<String, Production> listKLabels = HashMultimap.create();
-    public Map<String, ASTNode> locations = new HashMap<String, ASTNode>();
+    public Map<String, ASTNode> locations = new HashMap<>();
 
     public Map<Sort, Production> canonicalBracketForSort = new HashMap<>();
     private Poset<Sort> subsorts = Poset.create();
@@ -311,10 +311,6 @@ public class Context implements Serializable {
 
     /**
      * Check to see if the two klabels are in the wrong order according to the priority filter.
-     *
-     * @param klabelParent
-     * @param klabelChild
-     * @return
      */
     public boolean isPriorityWrong(String klabelParent, String klabelChild) {
         return priorities.isInRelation(klabelParent, klabelChild);
@@ -362,10 +358,6 @@ public class Context implements Serializable {
 
     /**
      * Check to see if smallSort is subsorted to bigSort (strict)
-     *
-     * @param bigSort
-     * @param smallSort
-     * @return
      */
     public boolean isSubsorted(Sort bigSort, Sort smallSort) {
         return subsorts.isInRelation(bigSort, smallSort);
@@ -373,10 +365,6 @@ public class Context implements Serializable {
 
     /**
      * Check to see if smallSort is subsorted or equal to bigSort
-     *
-     * @param bigSort
-     * @param smallSort
-     * @return
      */
     public boolean isSubsortedEq(Sort bigSort, Sort smallSort) {
         if (bigSort.equals(smallSort))
@@ -390,9 +378,6 @@ public class Context implements Serializable {
      * In particular, elements of a user cons list are syntactically
      * but not semantically subsorted to the list type.
      *
-     * @param bigSort
-     * @param smallSort
-     * @return
      */
     public boolean isSyntacticSubsorted(Sort bigSort, Sort smallSort) {
         return syntacticSubsorts.isInRelation(bigSort, smallSort);
@@ -403,10 +388,6 @@ public class Context implements Serializable {
      * (any term parsing as smallSort also parses as bigSort).
      * In particular, elements of a user cons list are syntactically
      * but not semantically subsorted to the list type.
-     *
-     * @param bigSort
-     * @param smallSort
-     * @return
      */
     public boolean isSyntacticSubsortedEq(Sort bigSort, Sort smallSort) {
         if (bigSort.equals(smallSort))
@@ -440,7 +421,7 @@ public class Context implements Serializable {
     }
 
     public void setDataStructureSorts(Map<Sort, DataStructureSort> dataStructureSorts) {
-        this.dataStructureSorts = new HashMap<Sort, DataStructureSort>(dataStructureSorts);
+        this.dataStructureSorts = new HashMap<>(dataStructureSorts);
     }
 
     public DataStructureSort dataStructureSortOf(Sort sort) {

--- a/kernel/src/main/java/org/kframework/kil/loader/Context.java
+++ b/kernel/src/main/java/org/kframework/kil/loader/Context.java
@@ -23,7 +23,6 @@ import org.kframework.utils.file.FileUtil;
 
 import java.io.Serializable;
 import java.util.Collections;
-import java.util.Formatter;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -91,17 +90,6 @@ public class Context implements Serializable {
     public HashMap<Sort, String> freshFunctionNames = new HashMap<>();
 
     private BiMap<String, Production> conses;
-
-    public int numModules, numSentences, numProductions, numCells;
-
-    public void printStatistics() {
-        Formatter f = new Formatter(System.out);
-        f.format("%n");
-        f.format("%-60s = %5d%n", "Number of Modules", numModules);
-        f.format("%-60s = %5d%n", "Number of Sentences", numSentences);
-        f.format("%-60s = %5d%n", "Number of Productions", numProductions);
-        f.format("%-60s = %5d%n", "Number of Cells", numCells);
-    }
 
     /**
      * The two structures below are populated by the InitializeConfigurationStructure step of the compilation.

--- a/kernel/src/main/java/org/kframework/kil/loader/Context.java
+++ b/kernel/src/main/java/org/kframework/kil/loader/Context.java
@@ -76,7 +76,6 @@ public class Context implements Serializable {
     public Map<Sort, Production> canonicalBracketForSort = new HashMap<>();
     private Poset<Sort> subsorts = Poset.create();
     private Poset<Sort> syntacticSubsorts = Poset.create();
-    public java.util.Set<Sort> definedSorts = Sort.getBaseSorts();
     private Poset<String> priorities = Poset.create();
     private Poset<String> assocLeft = Poset.create();
     private Poset<String> assocRight = Poset.create();

--- a/kernel/src/main/java/org/kframework/kil/loader/Context.java
+++ b/kernel/src/main/java/org/kframework/kil/loader/Context.java
@@ -2,7 +2,6 @@
 package org.kframework.kil.loader;
 
 import org.kframework.compile.utils.ConfigurationStructureMap;
-import org.kframework.kil.ASTNode;
 import org.kframework.kil.Attribute;
 import org.kframework.kil.Attribute.Key;
 import org.kframework.kil.Cell;
@@ -71,7 +70,6 @@ public class Context implements Serializable {
     public Map<String, Sort> cellSorts = new HashMap<>();
     public Map<Sort, Production> listProductions = new LinkedHashMap<>();
     public SetMultimap<String, Production> listKLabels = HashMultimap.create();
-    public Map<String, ASTNode> locations = new HashMap<>();
 
     public Map<Sort, Production> canonicalBracketForSort = new HashMap<>();
     private Poset<Sort> subsorts = Poset.create();

--- a/kernel/src/main/java/org/kframework/kil/loader/Context.java
+++ b/kernel/src/main/java/org/kframework/kil/loader/Context.java
@@ -79,7 +79,6 @@ public class Context implements Serializable {
     private Poset<String> priorities = Poset.create();
     private Poset<String> assocLeft = Poset.create();
     private Poset<String> assocRight = Poset.create();
-    public Sort startSymbolPgm = Sort.K;
     public Map<String, Sort> configVarSorts = new HashMap<>();
     @Deprecated
     public transient FileUtil files;
@@ -141,6 +140,10 @@ public class Context implements Serializable {
     public Context() {
         initSubsorts(subsorts);
         initSubsorts(syntacticSubsorts);
+    }
+
+    public Sort startSymbolPgm() {
+        return configVarSorts.getOrDefault("PGM", Sort.K);
     }
 
     public void addProduction(Production p) {

--- a/kernel/src/main/java/org/kframework/kil/loader/Context.java
+++ b/kernel/src/main/java/org/kframework/kil/loader/Context.java
@@ -83,7 +83,6 @@ public class Context implements Serializable {
     public Map<String, Sort> configVarSorts = new HashMap<>();
     @Deprecated
     public transient FileUtil files;
-    public boolean initialized = false;
     public Map<String, CellDataStructure> cellDataStructures = new HashMap<>();
     public Set<Sort> variableTokenSorts = new HashSet<>();
     public HashMap<Sort, String> freshFunctionNames = new HashMap<>();
@@ -441,19 +440,14 @@ public class Context implements Serializable {
     }
 
     public void setDataStructureSorts(Map<Sort, DataStructureSort> dataStructureSorts) {
-        assert !initialized;
-
         this.dataStructureSorts = new HashMap<Sort, DataStructureSort>(dataStructureSorts);
     }
 
     public DataStructureSort dataStructureSortOf(Sort sort) {
-        assert initialized : "Context is not initialized yet";
-
         return dataStructureSorts.get(sort);
     }
 
     public DataStructureSort dataStructureListSortOf(Sort sort) {
-        assert initialized : "Context is not initialized yet";
         DataStructureSort dataStructSort = dataStructureSorts.get(sort);
         if (dataStructSort == null) return null;
         if (!dataStructSort.type().equals(Sort.LIST)) return null;
@@ -468,8 +462,6 @@ public class Context implements Serializable {
     }
 
     public void setTokenSorts(Set<Sort> tokenSorts) {
-        assert !initialized;
-
         this.tokenSorts = new HashSet<>(tokenSorts);
     }
 

--- a/kernel/src/main/java/org/kframework/kil/loader/CountNodesVisitor.java
+++ b/kernel/src/main/java/org/kframework/kil/loader/CountNodesVisitor.java
@@ -1,7 +1,6 @@
 // Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.kil.loader;
 
-import org.kframework.kil.loader.Context;
 import org.kframework.kil.Cell;
 import org.kframework.kil.Configuration;
 import org.kframework.kil.Module;
@@ -10,19 +9,24 @@ import org.kframework.kil.Sentence;
 
 import org.kframework.kil.visitors.BasicVisitor;
 
+import java.util.Formatter;
+
 public class CountNodesVisitor extends BasicVisitor {
-    public CountNodesVisitor(Context context) {
-        super(context);
-        context.numModules = 0;
-        context.numSentences = 0;
-        context.numProductions = 0;
-        context.numCells = 0;
+
+    public int numModules, numSentences, numProductions, numCells;
+
+    public CountNodesVisitor() {
+        super(null);
+        numModules = 0;
+        numSentences = 0;
+        numProductions = 0;
+        numCells = 0;
     }
 
     @Override
     public Void visit(Module module, Void _) {
         if (!module.isPredefined()) {
-            context.numModules++;
+            numModules++;
             super.visit(module, _);
         }
         return null;
@@ -30,13 +34,13 @@ public class CountNodesVisitor extends BasicVisitor {
 
     @Override
     public Void visit(Sentence rule, Void _) {
-        context.numSentences++;
+        numSentences++;
         return super.visit(rule, _);
     }
 
     @Override
     public Void visit(Production production, Void _) {
-        context.numProductions++;
+        numProductions++;
         return super.visit(production, _);
     }
 
@@ -46,16 +50,25 @@ public class CountNodesVisitor extends BasicVisitor {
         inConfig = true;
         super.visit(config, _);
         inConfig = false;
-        context.numSentences++;
+        numSentences++;
         return null;
     }
 
     @Override
     public Void visit(Cell cell, Void _) {
         if (inConfig) {
-            context.numCells++;
+            numCells++;
             super.visit(cell, _);
         }
         return null;
+    }
+
+    public void printStatistics() {
+        Formatter f = new Formatter(System.out);
+        f.format("%n");
+        f.format("%-60s = %5d%n", "Number of Modules", numModules);
+        f.format("%-60s = %5d%n", "Number of Sentences", numSentences);
+        f.format("%-60s = %5d%n", "Number of Productions", numProductions);
+        f.format("%-60s = %5d%n", "Number of Cells", numCells);
     }
 }

--- a/kernel/src/main/java/org/kframework/kil/loader/ResolveVariableAttribute.java
+++ b/kernel/src/main/java/org/kframework/kil/loader/ResolveVariableAttribute.java
@@ -3,22 +3,14 @@ package org.kframework.kil.loader;
 
 import org.kframework.compile.transformers.AddSymbolicK;
 import org.kframework.kil.*;
-import org.kframework.kil.loader.Context;
 import org.kframework.kil.visitors.CopyOnWriteTransformer;
 
-/**
- * Created with IntelliJ IDEA.
- * User: Andrei
- * Date: 14.11.2013
- * Time: 10:37
- * To change this template use File | Settings | File Templates.
- */
 public class ResolveVariableAttribute extends CopyOnWriteTransformer {
     public ResolveVariableAttribute(Context context) {
         super("Resolve 'variable' attribute", context);
     }
 
-    @java.lang.Override
+    @Override
     public ASTNode visit(KApp kapp, Void _)  {
         if (kapp.getLabel() instanceof Token) {
             Token node = (Token) kapp.getLabel();

--- a/kernel/src/main/java/org/kframework/kil/loader/UpdateReferencesVisitor.java
+++ b/kernel/src/main/java/org/kframework/kil/loader/UpdateReferencesVisitor.java
@@ -26,7 +26,6 @@ public class UpdateReferencesVisitor extends BasicVisitor {
     @Override
     public Void visit(Syntax syn, Void _) {
         prodRoot = syn;
-        context.definedSorts.add(prodRoot.getDeclaredSort().getSort());
         return super.visit(syn, _);
     }
 

--- a/kernel/src/main/java/org/kframework/kompile/KompileFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileFrontEnd.java
@@ -1,7 +1,6 @@
 // Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.kompile;
 
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -88,6 +87,7 @@ public class KompileFrontEnd extends FrontEnd {
         Definition def = genericCompile(options.experimental.step);
 
         loader.saveOrDie(files.resolveKompiled("context.bin"), context);
+        loader.saveOrDie(files.resolveKompiled("definition.bin"), def);
 
         verbose(def);
         return true;

--- a/kernel/src/main/java/org/kframework/kompile/KompileFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileFrontEnd.java
@@ -85,29 +85,28 @@ public class KompileFrontEnd extends FrontEnd {
 
         context.files = files;
 
-        genericCompile(options.experimental.step);
+        Definition def = genericCompile(options.experimental.step);
 
         loader.saveOrDie(files.resolveKompiled("context.bin"), context);
 
-        verbose();
+        verbose(def);
         return true;
     }
 
-    private void verbose() {
+    private void verbose(Definition def) {
         sw.printTotal("Total");
         if (context.globalOptions.verbose) {
-            context.printStatistics();
+            CountNodesVisitor visitor = new CountNodesVisitor();
+            visitor.visitNode(def);
+            visitor.printStatistics();
         }
     }
 
-
-    private void genericCompile(String step) {
+    private Definition genericCompile(String step) {
         org.kframework.kil.Definition javaDef;
         sw.start();
         javaDef = defLoader.loadDefinition(options.mainDefinitionFile(), options.mainModule(),
                 context);
-
-        new CountNodesVisitor(context).visitNode(javaDef);
 
         CompilerSteps<Definition> steps = backend.getCompilationSteps();
 
@@ -125,6 +124,7 @@ public class KompileFrontEnd extends FrontEnd {
 
         backend.run(javaDef);
 
+        return javaDef;
     }
 }
 

--- a/kernel/src/main/java/org/kframework/krun/RunProcess.java
+++ b/kernel/src/main/java/org/kframework/krun/RunProcess.java
@@ -116,7 +116,7 @@ public class RunProcess {
         Term term;
 
         if (startSymbol == null) {
-            startSymbol = context.startSymbolPgm;
+            startSymbol = context.startSymbolPgm();
         }
         String content = value;
         Source source = Sources.fromCommandLine("parameters");

--- a/kernel/src/main/java/org/kframework/parser/ProgramLoader.java
+++ b/kernel/src/main/java/org/kframework/parser/ProgramLoader.java
@@ -107,7 +107,7 @@ public class ProgramLoader {
     public Term processPgm(String content, Source source, Sort startSymbol,
             Context context, ParserType whatParser) throws ParseFailedException {
         sw.printIntermediate("Importing Files");
-        if (!context.definedSorts.contains(startSymbol)) {
+        if (!context.getAllSorts().contains(startSymbol)) {
             throw new ParseFailedException(new KException(ExceptionType.ERROR, KExceptionGroup.CRITICAL,
                     "The start symbol must be declared in the definition. Found: " + startSymbol));
         }

--- a/kernel/src/main/java/org/kframework/parser/TermLoader.java
+++ b/kernel/src/main/java/org/kframework/parser/TermLoader.java
@@ -81,9 +81,6 @@ public class TermLoader {
     }
 
     public Term parseCmdString(String content, Source source, Sort startSymbol, Context context) throws ParseFailedException {
-        if (!context.initialized) {
-            assert false : "You need to load the definition before you call parsePattern!";
-        }
         String parsed = org.kframework.parser.concrete.DefinitionLocalKParser.ParseKCmdString(content, context.files.resolveKompiled("."));
         Document doc = XmlLoader.getXMLDoc(parsed);
         XmlLoader.addSource(doc.getFirstChild(), source);
@@ -123,10 +120,6 @@ public class TermLoader {
     }
 
     public ASTNode parsePattern(String pattern, Source source, Sort startSymbol, Context context) throws ParseFailedException {
-        if (!context.initialized) {
-            assert false : "You need to load the definition before you call parsePattern!";
-        }
-
         String parsed = org.kframework.parser.concrete.DefinitionLocalKParser.ParseKRuleString(pattern, context.files.resolveKompiled("."));
         Document doc = XmlLoader.getXMLDoc(parsed);
 
@@ -167,10 +160,6 @@ public class TermLoader {
     }
 
     public ASTNode parsePatternAmbiguous(String pattern, Context context) throws ParseFailedException {
-        if (!context.initialized) {
-            assert false : "You need to load the definition before you call parsePattern!";
-        }
-
         String parsed = org.kframework.parser.concrete.DefinitionLocalKParser.ParseKRuleString(pattern, context.files.resolveKompiled("."));
         Document doc = XmlLoader.getXMLDoc(parsed);
 

--- a/kernel/src/main/java/org/kframework/parser/concrete/disambiguate/VariableTypeInferenceFilter.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete/disambiguate/VariableTypeInferenceFilter.java
@@ -96,7 +96,7 @@ public class VariableTypeInferenceFilter extends ParseForestTransformer {
                 for (String key : variant.keySet()) {
                     Collection<String> values = variant.get(key);
                     Set<String> mins = new HashSet<String>();
-                    for (Sort sort : context.definedSorts) { // for every declared sort
+                    for (Sort sort : context.getAllSorts()) { // for every declared sort
                         boolean min = true;
                         for (String var : values) {
                             if (!context.isSyntacticSubsortedEq(Sort.of(var), sort)) {

--- a/kernel/src/main/java/org/kframework/parser/concrete2/KSyntax2GrammarStatesFilter.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2/KSyntax2GrammarStatesFilter.java
@@ -42,7 +42,7 @@ public class KSyntax2GrammarStatesFilter extends BasicVisitor {
         this.kem = kem;
 
         // create a NonTerminal for every declared sort
-        for (Sort sort : context.definedSorts) {
+        for (Sort sort : context.getAllSorts()) {
             grammar.add(new NonTerminal(sort.getName()));
         }
     }

--- a/kernel/src/main/java/org/kframework/utils/inject/DefinitionLoadingModule.java
+++ b/kernel/src/main/java/org/kframework/utils/inject/DefinitionLoadingModule.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.util.Map;
 
+import org.kframework.kil.Definition;
 import org.kframework.kil.loader.Context;
 import org.kframework.kompile.KompileOptions;
 import org.kframework.main.GlobalOptions;
@@ -43,6 +44,11 @@ public class DefinitionLoadingModule extends AbstractModule {
 
         sw.printIntermediate("Initializing definition paths");
         return context;
+    }
+
+    @Provides
+    Definition definition(BinaryLoader loader, FileUtil files) {
+        return loader.loadOrDie(Definition.class, files.resolveKompiled("definition.bin"));
     }
 
     @Provides

--- a/kernel/src/test/java/org/kframework/utils/BaseTestCase.java
+++ b/kernel/src/test/java/org/kframework/utils/BaseTestCase.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.kframework.kil.Configuration;
+import org.kframework.kil.Definition;
 import org.kframework.kil.loader.Context;
 import org.kframework.kompile.KompileOptions;
 import org.kframework.krun.RunProcess;
@@ -24,6 +25,9 @@ public abstract class BaseTestCase {
 
     @Mock
     protected Context context;
+
+    @Mock
+    protected Definition definition;
 
     @Mock
     protected Configuration configuration;
@@ -59,6 +63,7 @@ public abstract class BaseTestCase {
         @Override
         protected void configure() {
             bind(Context.class).toInstance(context);
+            bind(Definition.class).toInstance(definition);
             bind(Configuration.class).toInstance(configuration);
         }
 

--- a/maude-backend/src/main/java/org/kframework/backend/maude/krun/MaudeExecutor.java
+++ b/maude-backend/src/main/java/org/kframework/backend/maude/krun/MaudeExecutor.java
@@ -413,7 +413,7 @@ public class MaudeExecutor implements Executor {
                 assertXMLTerm(list.size() == 0 && sort.equals(Sort.KITEM.toString()));
                 //return new Hole(sort);
                 return Hole.KITEM_HOLE;
-            } else if (op.matches(".*:.*") && op.endsWith(sort) && context.definedSorts.contains(Sort.of(sort))) {
+            } else if (op.matches(".*:.*") && op.endsWith(sort) && context.getAllSorts().contains(Sort.of(sort))) {
                 return new Variable(op.substring(0, op.indexOf(":")), Sort.of(sort));
             } else {
                 Set<Production> prods = context.klabels.get(StringUtil.unescapeMaude(op));

--- a/maude-backend/src/main/java/org/kframework/backend/maude/krun/MaudeExecutor.java
+++ b/maude-backend/src/main/java/org/kframework/backend/maude/krun/MaudeExecutor.java
@@ -1,25 +1,14 @@
 // Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.maude.krun;
 
-import java.io.BufferedOutputStream;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Reader;
-import java.io.Writer;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Scanner;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import com.google.inject.Inject;
+import edu.uci.ics.jung.graph.DirectedGraph;
+import edu.uci.ics.jung.io.GraphIOException;
+import edu.uci.ics.jung.io.graphml.EdgeMetadata;
+import edu.uci.ics.jung.io.graphml.GraphMLReader2;
+import edu.uci.ics.jung.io.graphml.GraphMetadata;
+import edu.uci.ics.jung.io.graphml.HyperEdgeMetadata;
+import edu.uci.ics.jung.io.graphml.NodeMetadata;
 import org.apache.commons.collections15.Transformer;
 import org.kframework.backend.maude.MaudeFilter;
 import org.kframework.backend.maude.MaudeKRunOptions;
@@ -32,6 +21,7 @@ import org.kframework.kil.BoolBuiltin;
 import org.kframework.kil.Cell;
 import org.kframework.kil.DataStructureBuiltin;
 import org.kframework.kil.DataStructureSort;
+import org.kframework.kil.Definition;
 import org.kframework.kil.FloatBuiltin;
 import org.kframework.kil.FreezerLabel;
 import org.kframework.kil.GenericToken;
@@ -76,15 +66,24 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import com.google.inject.Inject;
-
-import edu.uci.ics.jung.graph.DirectedGraph;
-import edu.uci.ics.jung.io.GraphIOException;
-import edu.uci.ics.jung.io.graphml.EdgeMetadata;
-import edu.uci.ics.jung.io.graphml.GraphMLReader2;
-import edu.uci.ics.jung.io.graphml.GraphMetadata;
-import edu.uci.ics.jung.io.graphml.HyperEdgeMetadata;
-import edu.uci.ics.jung.io.graphml.NodeMetadata;
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class MaudeExecutor implements Executor {
 
@@ -101,6 +100,7 @@ public class MaudeExecutor implements Executor {
     private final FileUtil files;
     private final KRunner runner;
     private final File processedXmlOutFile;
+    private final Definition def;
 
     private int counter = 0;
 
@@ -112,7 +112,8 @@ public class MaudeExecutor implements Executor {
             KExceptionManager kem,
             MaudeKRunOptions maudeOptions,
             FileUtil files,
-            KRunner runner) {
+            KRunner runner,
+            Definition def) {
         this.options = options;
         this.sw = sw;
         this.context = context;
@@ -121,6 +122,7 @@ public class MaudeExecutor implements Executor {
         this.files = files;
         this.runner = runner;
         this.processedXmlOutFile = files.resolveTemp("maudeoutput_simplified.xml");
+        this.def = def;
     }
 
     void executeKRun(StringBuilder maudeCmd) throws KRunExecutionException {
@@ -592,7 +594,7 @@ public class MaudeExecutor implements Executor {
                         return Transition.label(labelAttribute);
                     }
                 }
-                return Transition.rule(context.locations.get(filename + ":(" + location + ")"));
+                return Transition.rule(def.locations.get(filename + ":(" + location + ")"));
             }
         };
 


### PR DESCRIPTION
Second part of https://github.com/kframework/k/wiki/Design-of-the-new-compiler-parser .

Some things listed in the wiki link may not be possible:
- ~~`Map<String, ASTNode> locations`: Not possible to move to Maude executor, because generated by `DefinitionLoader` which runs in kompile. We have to serialize this field and load in Maude krun.~~
- ~~`Set<Sort> variableTokenSorts`: This is still used, are we sure that this won't break anyting? Or is it a mistake in the wiki page?~~

These are also missing:
- `SetMultiMap<String, Production> tags`: This should be possible, but it's a bit tricky. The problem is that currently it's collecting while productions are parsed to prevent redundant computations. I need to find a way to generate it after productions are added.
