### PR TITLE
Fix krun --graph

### DIFF
--- a/maude-backend/src/main/java/org/kframework/backend/maude/krun/MaudeExecutor.java
+++ b/maude-backend/src/main/java/org/kframework/backend/maude/krun/MaudeExecutor.java
@@ -3,6 +3,7 @@ package org.kframework.backend.maude.krun;
 
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
@@ -90,7 +91,6 @@ public class MaudeExecutor implements Executor {
     public static final String outFile = "maude_out";
     public static final String errFile = "maude_err";
     public static final String xmlOutFile = "maudeoutput.xml";
-    public static final String processedXmlOutFile = "maudeoutput_simplified.xml";
 
     private final KExceptionManager kem;
     private final KRunOptions options;
@@ -99,6 +99,7 @@ public class MaudeExecutor implements Executor {
     private final Context context;
     private final FileUtil files;
     private final KRunner runner;
+    private final File processedXmlOutFile;
 
     private int counter = 0;
 
@@ -118,6 +119,7 @@ public class MaudeExecutor implements Executor {
         this.maudeOptions = maudeOptions;
         this.files = files;
         this.runner = runner;
+        this.processedXmlOutFile = files.resolveTemp("maudeoutput_simplified.xml");
     }
 
     void executeKRun(StringBuilder maudeCmd) throws KRunExecutionException {
@@ -533,14 +535,14 @@ public class MaudeExecutor implements Executor {
                     + " and write to " + processedXmlOutFile, e);
         }
 
-        Document doc = XmlUtil.readXMLFromFile(files.resolveTemp(processedXmlOutFile).getAbsolutePath());
+        Document doc = XmlUtil.readXMLFromFile(processedXmlOutFile.getAbsolutePath());
         NodeList list;
         Node nod;
         list = doc.getElementsByTagName("graphml");
         assertXML(list.getLength() == 1);
         nod = list.item(0);
         assertXML(nod != null && nod.getNodeType() == Node.ELEMENT_NODE);
-        XmlUtil.serializeXML(nod, files.resolveTemp(processedXmlOutFile).getAbsolutePath());
+        XmlUtil.serializeXML(nod, processedXmlOutFile.getAbsolutePath());
 
         Transformer<GraphMetadata, DirectedGraph<KRunState, Transition>> graphTransformer = new Transformer<GraphMetadata, DirectedGraph<KRunState, Transition>>() {
             @Override


### PR DESCRIPTION
Apparently it was broken after files API change:

```
➜  lesson_1 git:(master) kompile lambda.k
➜  lesson_1 git:(master) krun tests/free-variable-capture.lambda --search --graph
[Error] Internal: Uncaught exception thrown of type RuntimeException.
Please file a bug report at https://github.com/kframework/k/issues
➜  lesson_1 git:(master) ✗ krun tests/free-variable-capture.lambda --search --graph --debug
java.lang.RuntimeException: java.io.FileNotFoundException: /home/omer/kframework/k-new-dist/k-distribution/tutorial/1_k/1_lambda/lesson_1/./.krun-2014-11-04-13-21-49-0ee4d666-28ea-4c8d-8a67-838322ecfc5b/maudeoutput_simplified.xml (No such file or directory)
        at org.kframework.krun.XmlUtil.readXMLFromFile(XmlUtil.java:28)
        at org.kframework.backend.maude.krun.MaudeExecutor.parseSearchGraph(MaudeExecutor.java:536)
        at org.kframework.backend.maude.krun.MaudeExecutor.search(MaudeExecutor.java:511)
        at org.kframework.krun.tools.Executor$Tool.search(Executor.java:138)
        at org.kframework.krun.tools.Executor$Tool.run(Executor.java:109)
        at org.kframework.krun.tools.Executor$Tool.run(Executor.java:77)
        at org.kframework.transformation.TransformationCompositionProvider$2.run(TransformationCompositionProvider.java:120)
        at org.kframework.krun.KRunFrontEnd.run(KRunFrontEnd.java:70)
        at org.kframework.main.FrontEnd.main(FrontEnd.java:43)
        at org.kframework.main.Main.main(Main.java:40)
Caused by: java.io.FileNotFoundException: /home/omer/kframework/k-new-dist/k-distribution/tutorial/1_k/1_lambda/lesson_1/./.krun-2014-11-04-13-21-49-0ee4d666-28ea-4c8d-8a67-838322ecfc5b/maudeoutput_simplified.xml (No such file or directory)
        at java.io.FileInputStream.open(Native Method)
        at java.io.FileInputStream.<init>(FileInputStream.java:138)
        at java.io.FileInputStream.<init>(FileInputStream.java:93)
        at org.kframework.krun.XmlUtil.readXMLFromFile(XmlUtil.java:25)
        ... 9 more
java.lang.RuntimeException: java.io.FileNotFoundException: /home/omer/kframework/k-new-dist/k-distribution/tutorial/1_k/1_lambda/lesson_1/./.krun-2014-11-04-13-21-49-0ee4d666-28ea-4c8d-8a67-838322ecfc5b/maudeoutput_simplified.xml (No such file or directory)
        at org.kframework.krun.XmlUtil.readXMLFromFile(XmlUtil.java:28)
        at org.kframework.backend.maude.krun.MaudeExecutor.parseSearchGraph(MaudeExecutor.java:536)
        at org.kframework.backend.maude.krun.MaudeExecutor.search(MaudeExecutor.java:511)
        at org.kframework.krun.tools.Executor$Tool.search(Executor.java:138)
        at org.kframework.krun.tools.Executor$Tool.run(Executor.java:109)
        at org.kframework.krun.tools.Executor$Tool.run(Executor.java:77)
        at org.kframework.transformation.TransformationCompositionProvider$2.run(TransformationCompositionProvider.java:120)
        at org.kframework.krun.KRunFrontEnd.run(KRunFrontEnd.java:70)
        at org.kframework.main.FrontEnd.main(FrontEnd.java:43)
        at org.kframework.main.Main.main(Main.java:40)
Caused by: java.io.FileNotFoundException: /home/omer/kframework/k-new-dist/k-distribution/tutorial/1_k/1_lambda/lesson_1/./.krun-2014-11-04-13-21-49-0ee4d666-28ea-4c8d-8a67-838322ecfc5b/maudeoutput_simplified.xml (No such file or directory)
        at java.io.FileInputStream.open(Native Method)
        at java.io.FileInputStream.<init>(FileInputStream.java:138)
        at java.io.FileInputStream.<init>(FileInputStream.java:93)
        at org.kframework.krun.XmlUtil.readXMLFromFile(XmlUtil.java:25)
        ... 9 more
[Error] Internal: Uncaught exception thrown of type RuntimeException.
Please file a bug report at https://github.com/kframework/k/issues
```

This patch fixes it. However, I think there's still a problem regarding to --graph. As far as I can see it doesn't print anything(or I'm using it wrong). I'll open an issue about this. I'd be great if we could add some tests about this feature, otherwise it'll probably get broken again(with Context changes etc.)
