### PR TITLE
Fixing #1153.

### DIFF
--- a/kernel/src/main/java/org/kframework/kil/Definition.java
+++ b/kernel/src/main/java/org/kframework/kil/Definition.java
@@ -102,8 +102,8 @@ public class Definition extends ASTNode implements Interfaces.MutableList<Defini
         // Collect information
         // this.accept(new AddSymbolicVariablesDeclaration(context, this.getMainSyntaxModule()));
         new UpdateReferencesVisitor(context).visitNode(this);
-        new UpdateAssocVisitor(context).visitNode(this);
         new CollectProductionsVisitor(context).visitNode(this);
+        new UpdateAssocVisitor(context).visitNode(this);
         context.computeConses();
         new CollectBracketsVisitor(context).visitNode(this);
         new CollectSubsortsVisitor(context).visitNode(this);


### PR DESCRIPTION
@osa1 you are right in #1153. The dependency between the two is not respected.
Nothing crashed until now since we weren't using that production in any definition, and SDF handled this somehow by default.

So, please review.
