### PR TITLE
fixed incorrect K Abstract Machine instructions ...

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/compile/AddLocalRewritesUnderCells.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/compile/AddLocalRewritesUnderCells.java
@@ -139,12 +139,6 @@ public class AddLocalRewritesUnderCells extends CopyOnWriteTransformer {
 
     @Override
     public ASTNode visit(Cell cell, Void _)  {
-//        // TODO(YilongL): rewrite this!!!!
-//        if (!crntRule.getAttribute(JavaBackendRuleData.class).getCellsOfInterest().contains(cell.getLabel())
-//                && outerWriteCell == null) {
-//            return super.visit(cell, _);
-//        }
-
         if (status == Status.LHS) {
             if (crntRule.getAttribute(JavaBackendRuleData.class).getReadCells().contains(cell.getLabel())) {
                 if (hasAssocCommMatching(cell)) {

--- a/java-backend/src/main/java/org/kframework/backend/java/compile/ComputeCellsOfInterest.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/compile/ComputeCellsOfInterest.java
@@ -17,6 +17,7 @@ import org.kframework.kil.Bag;
 import org.kframework.kil.Cell;
 import org.kframework.kil.Configuration;
 import org.kframework.kil.Definition;
+import org.kframework.kil.KApp;
 import org.kframework.kil.Rewrite;
 import org.kframework.kil.Rule;
 import org.kframework.kil.Syntax;
@@ -156,6 +157,13 @@ public class ComputeCellsOfInterest extends CopyOnWriteTransformer {
         }
 
         return cell;
+    }
+
+    @Override
+    public ASTNode visit(KApp kApp, Void _) {
+        /* YilongL: this prevents collecting cells injected inside KItems, e.g.:
+         *   rule <k> loadObj(<threads> G:Bag </threads>) => . ...</k>  */
+        return kApp;
     }
 
     @Override

--- a/java-backend/src/main/java/org/kframework/backend/java/compile/GenerateKRewriteMachineInstructions.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/compile/GenerateKRewriteMachineInstructions.java
@@ -18,6 +18,7 @@ import org.kframework.backend.java.rewritemachine.KAbstractRewriteMachine;
 import org.kframework.kil.ASTNode;
 import org.kframework.kil.Cell;
 import org.kframework.kil.Configuration;
+import org.kframework.kil.KApp;
 import org.kframework.kil.Module;
 import org.kframework.kil.ModuleItem;
 import org.kframework.kil.Rewrite;
@@ -117,6 +118,12 @@ public class GenerateKRewriteMachineInstructions extends CopyOnWriteTransformer 
 //        System.out.println(rule.getRewritingSchedule());
 
         return rule;
+    }
+
+    @Override
+    public ASTNode visit(KApp kApp, Void _) {
+        /* YilongL: this prevents collecting cells injected inside KItems */
+        return kApp;
     }
 
     @Override


### PR DESCRIPTION
... caused by cells injected under KItems in rules.

For example:`rule <k> loadObj(<threads> G:Bag </threads>) => . ...</k>`

@dwightguth please review
