### PR TITLE
Better fix for the rule attributes cache.

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/generator/CacheLookupFilter.java
+++ b/kernel/src/main/java/org/kframework/parser/generator/CacheLookupFilter.java
@@ -48,6 +48,8 @@ public class CacheLookupFilter extends ParseForestTransformer {
                 // load from cache
                 CachedSentence cs = cachedDef.get(key);
                 sentence = cs.sentence;
+                // take the attributes from the current StringSentence, since they are being parsed in the outer parser.
+                sentence.setAttributes(ss.getAttributes());
                 if (kept.containsKey(key)) {
                     Source source = ss.getSource();
                     Location location = ss.getLocation();


### PR DESCRIPTION
@dwightguth please review.
I'm copying the attributes from the StringSentence now, instead of taking them from the previous cached rule.
