### PR TITLE
Fixed READMEs in lambda++

### DIFF
--- a/k-distribution/tutorial/1_k/3_lambda++/lesson_3/README.md
+++ b/k-distribution/tutorial/1_k/3_lambda++/lesson_3/README.md
@@ -8,17 +8,17 @@ semantics of language features without having to make any change!
 
 Although the definitional style of the basic LAMBDA language changed quite
 radically in our previous lesson, compared to its original definition in
-Part 1 of the tutorial, we fortunately can reuse a large portion of the previous
-definition.  For example, let us just cut-and-paste the rest of the definition
-from Lesson 7 in Part 1 of the tutorial.
+Part 1 of the tutorial, we fortunately can reuse a large portion of the
+previous definition.  For example, let us just cut-and-paste the rest of the
+definition from Lesson 7 in Part 1 of the tutorial.
 
-Let us `kompile` and `krun` all the remaining programs from Part 1 of the tutorial.
-Everything should work fine, although the store contains lots of garbage.
-Garbage collection is an interesting topic, but we do not do it here.
+Let us `kompile` and `krun` all the remaining programs from Part 1 of the
+tutorial.  Everything should work fine, although the store contains lots of
+garbage.  Garbage collection is an interesting topic, but we do not do it here.
 Nevertheless, much of this garbage is caused by the intricate use of the
-fixed-point combinator to define recursion.  In a future lesson in this tutorial
-we will see that a different, environment-based definition of fixed-points will
-allocate much less memory.
+fixed-point combinator to define recursion.  In a future lesson in this
+tutorial we will see that a different, environment-based definition of
+fixed-points will allocate much less memory.
 
 One interesting question at this stage is: how do we know when we can reuse
 an existing semantics of a language feature?  Well, I'm afraid the answer is:

--- a/k-distribution/tutorial/1_k/3_lambda++/lesson_4/NOTES
+++ b/k-distribution/tutorial/1_k/3_lambda++/lesson_4/NOTES
@@ -11,4 +11,8 @@ seqstrict(2,1).
 
 Also, callcc-env2.lambda evaluates to 3 instead of 4, because of the
 particular order in which the strictness of the application operation is
-applied.  If you make application seqstrict(2,1) then you get 4. 
+applied.  If you make application seqstrict(2,1) then you get 4.
+
+Dec 06, 2014: Looks like we should discuss the --search and --transition
+options before this lesson, and then kompile the definition with option
+--transition = computational and krun it with --search.

--- a/k-distribution/tutorial/1_k/3_lambda++/lesson_4/README.md
+++ b/k-distribution/tutorial/1_k/3_lambda++/lesson_4/README.md
@@ -24,32 +24,73 @@ Let's try to illustrate this bug with `callcc-env1.lambda`
     let x = 1 in
       ((callcc lambda k . (let x = 2 in (k x))) + x)
 
-where the second argument of `+`, `x`, should be bound to the top `x`, which is `1`.
-However, since `callcc` does not restore the environment, that `x` should
-be looked up in the wrong, callcc-inner environment, so we should see the
-overall result `4`.
+where the second argument of `+`, `x`, should be bound to the top `x`, which
+is `1`.  However, since `callcc` does not restore the environment, that `x`
+should be looked up in the wrong, callcc-inner environment, so we should see
+the overall result `4`.
 
-Hm, we get the right result, `3` ... This sort of thing is quite annoying when
-it happens.  So, why do we get `3`?  Well, recall that `+` is strict, which means
-that it can evaluate its arguments in any order.  It just happened that in the
-execution that we saw, its second argument was evaluated first, to `1`, and then
-the `callcc` was evaluated, but its `cc` value K had already included the `1` instead
-of `x` ...  In Part 4 of the tutorial we will see how to explore all non-deterministic 
-behaviors of a program; we could use that feature of K to debug semantics, too.
+Hm, we get the right result, `3` ... This sort of thing is quite annoying
+when it happens.  So, why do we get `3`?  Well, recall that `+` is strict,
+which means that it can evaluate its arguments in any order.  It just
+happened that in the execution that we saw, its second argument was evaluated
+first, to `1`, and then the `callcc` was evaluated, but its `cc` value K had
+already included the `1` instead of `x` ...  In Part 4 of the tutorial we will
+see how to explore all non-deterministic behaviors of a program; we could use
+that feature of K to debug semantics, too.  For example, in this case, we
+could search for all behaviors of this program and we would indeed get two
+possible value results: 3 and 4.
 
-There are two simple ways to fix this problem and thus illustrate the semantic
-problem that we have here.  One is to make `+` `seqstrict` in the semantics, to
-enforce its evaluation from left-to-right.  Do it to convince yourself that
-the program evaluates to `4` then.  Another is to modify the program, to
-enforce the left-to-right evaluation order using let binders, as we do in
-`callcc-env2.lambda`:
+NOTE: we warn the reader that the result 3 above was obtained with version 3.4
+of the K implementation.  Different versions may employ different execution
+orders in non-deterministic program, so it can be quite possible that the
+program above may evaluate to 4 with another version of K.
+
+One may think that the problem is the non-deterministic evaluation order
+of `+`, and thus that all we need to do is to enforce a deterministic order
+in which the arguments of + are evaluated.  Let us follow this path to
+see what happens.  There are two simple ways to make the evaluation order
+of `+`'s arguments deterministic.  One is to make `+` `seqstrict` in the
+semantics, to enforce its evaluation from left-to-right.  Do it and then
+run the program above again; you should get only one behavior for the
+program above, 4, which therefore shows that copy-and-pasting our old
+definition of callcc was incorrect.  However, as seen shortly, that only
+fixed the problem for the particular example above, but not in general.
+Another conventional approach to enforce the desired evaluation order is to
+modify the program to enforce the left-to-right evaluation order using let
+binders, as we do in `callcc-env2.lambda`:
 
     let x = 1 in
       let a = callcc lambda k . (let x = 2 in (k x)) in
         let b = x in
 	      (a + b)
 
-Now we also get `4`.
+With version 3.5 of K, we get the expected result `4` when we execute this
+program, so it may look like our non-deterministic problem is fixed.
+Unfortunately, it is not.  Using the K tool to search for all the behaviors
+in the program above reveals that the final result `3` is still possible.
+Moreover, both the `3` and the `4` behaviors are possible regardless of whether
+`+` is declared to be `seqstrict` or just `strict`.  How is that possible?
+The problem is now the non-deterministic evaluation strategy of the function
+application construct.  Indeed, recall that the semantics of the let-in
+construct is defined by desugaring to lambda application:
+
+    rule let X = E in E' => (lambda X . E') E     [macro]
+
+With this, the program above eventually reduces to
+
+    (lambda a . ((lambda b . a + b) x))
+    (callcc lambda k . (let x = 2 in (k x)))
+
+in an environment where `x` is `1`.  If the first expression evaluates first,
+then it does so to a closure in which `x` is bound to a location holding `1`,
+so when applied later on to the `x` inside the argument of `callcc` (which is
+`2`), it will correctly lookup `x` in its enclosed environment and thus the
+program will evaluate to `3`.  On the other hand, if the second expression
+evaluates first, then the `cc` value will freeze the first expression as is,
+breaking the relationship between its `x` and the current environment in which
+it is bound to `1`, being inadvertently captured by the environment of the
+let-in construct inside the `callcc` and thus making the entire expression
+evaluate to `4`.
 
 So the morale is: Do not reuse blindly.  *Think!*
 

--- a/k-distribution/tutorial/1_k/3_lambda++/lesson_5/README.md
+++ b/k-distribution/tutorial/1_k/3_lambda++/lesson_5/README.md
@@ -8,16 +8,16 @@ computational items, and how useful they can be.  Specifically, we fix the
 environment-based definition of `callcc` and give an environment-based
 definition of the `mu` construct for recursion.
 
-Let us first fix `callcc`.  As discussed in Lesson 4, the problem that we noticed
-there was that we only recovered the computation, but not the environment, when
-a value was passed to the current continuation.  This is quite easy to fix:
-we modify `cc` to take both an environment and a computation, and its rules
-to take a snapshot of the current environment with it, and to recover it at
-invocation time:
+Let us first fix `callcc`.  As discussed in Lesson 4, the problem that we
+noticed there was that we only recovered the computation, but not the
+environment, when a value was passed to the current continuation.  This is
+quite easy to fix: we modify `cc` to take both an environment and a
+computation, and its rules to take a snapshot of the current environment with
+it, and to recover it at invocation time:
 
     syntax Val ::= cc(Map,K)
     rule <k> (callcc V:Val => V cc(Rho,K)) ~> K </k> <env> Rho </env>
-    rule <k> cc(Rho,K) V ~> _ =>  V ~> K </k> <env> _ => Rho </env>
+    rule <k> cc(Rho,K) V:Val ~> _ =>  V ~> K </k> <env> _ => Rho </env>
 
 Let us kompile and make sure it works with the `callcc-env2.lambda` program,
 which should evaluate to `3`, not to `4`.
@@ -38,8 +38,8 @@ We removed the `binder` annotation of `mu`, because it is not necessary
 anymore (since we do not work with substitutions anymore).
 
 To save the number of locations needed to evaluate `mu X . E`, let us replace
-it with a special closure which already binds `X` to a fresh location holding the
-closure itself:
+it with a special closure which already binds `X` to a fresh location holding
+the closure itself:
 
     syntax Exp ::= muclosure(Map,Exp)
 
@@ -49,8 +49,8 @@ closure itself:
       when fresh(N:Nat)  [structural]
 
 Since each time `mu X . E` is encountered during the evaluation it needs to
-evaluate `E`, we conclude that `muclosure` cannot be a value.  We can declare it
-as either an expression or as a computation.  Let's go with the former.
+evaluate `E`, we conclude that `muclosure` cannot be a value.  We can declare
+it as either an expression or as a computation.  Let's go with the former.
 
 Finally, here is the rule unrolling the `muclosure`:
 
@@ -63,8 +63,8 @@ from a context with a completely different environment from the one
 in which `mu X . E` was declared.
 
 We are done.  Let us now `kompile` and `krun` `factorial-letrec.lambda` from
-Lesson 7 in Part 1 of the tutorial on LAMBDA.  Recall that in the previous lesson
-this program generated a lot of garbage into the store, due to the
+Lesson 7 in Part 1 of the tutorial on LAMBDA.  Recall that in the previous
+lesson this program generated a lot of garbage into the store, due to the
 need to allocate space for the arguments of all those lambda abstractions
 needed to run the fixed-point combinator.  Now we need much fewer locations,
 essentially only locations for the argument of the factorial function, one at


### PR DESCRIPTION
@dwightguth please take a quick look and merge.  All these changes were triggered by the recent problem you found with the semantics of callcc in lambda++.  I wonder whether we should not change the config.xml to test all these examples with --transition = computational in kompile and --search in krun (eventually).
