### PR TITLE
lazily evaluate sort of KItem

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/DeepCloner.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/DeepCloner.java
@@ -41,7 +41,7 @@ public class DeepCloner {
 
         @Override
         protected Object fastClone(final Object o, final Map<Object, Object> clones) throws IllegalAccessException {
-            if ((o instanceof Term && !((Term) o).isMutable())) {
+            if (o instanceof Term && !((Term) o).isMutable()) {
                 return o;
             } else {
                 return super.fastClone(o, clones);

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/DeepCloner.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/DeepCloner.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.kframework.backend.java.kil.Immutable;
 import org.kframework.backend.java.kil.Term;
+import org.kframework.backend.java.kil.TermContext;
 import org.kframework.backend.java.util.Profiler;
 
 import com.rits.cloning.Cloner;
@@ -21,6 +22,7 @@ public class DeepCloner {
 
     static {
         cloner.dontCloneInstanceOf(Immutable.class);
+        cloner.dontCloneInstanceOf(TermContext.class);
     }
 
     public static Term clone(Term term) {
@@ -39,7 +41,7 @@ public class DeepCloner {
 
         @Override
         protected Object fastClone(final Object o, final Map<Object, Object> clones) throws IllegalAccessException {
-            if (o instanceof Term && !((Term) o).isMutable()) {
+            if ((o instanceof Term && !((Term) o).isMutable())) {
                 return o;
             } else {
                 return super.fastClone(o, clones);


### PR DESCRIPTION
@yilongli please review

I'm not going to run the complete suite of performance info again, but here is the before/after for collatz n=100

Before:
[210220, 9.495 s]
7.772 s(mc=1.266 s, eval=4.421 s[3.261 s, 1.053 s], rew=813.1 ms) + 724.3 ms
564.6 ms
17.66 ms

After:
[210220, 7.209 s]
5.862 s(mc=947.7 ms, eval=3.379 s[2.352 s, 940.2 ms], rew=744.7 ms) + 536.9 ms
459.9 ms
19.94 ms

Note that this compares favorably as well to the statistics from before Andrei's refactoring of lookups: 
[210220, 9.284 s]
7.193 s(mc=1.262 s, eval=3.663 s[356.0 ms, 1.519 s], rew=1.294 s) + 975.0 ms
617.1 ms
19.14 ms

The numbers aren't directly comparable because we're timing different regions, but note that while it is still a little more expensive doing lookups as function evaluations, the overall time has improved and is now only marginally slower than before after taking into account the difference in requires time.
