### PR TITLE
various minor bug fixes and optimizxations to the rewriter

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/FloatToken.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/FloatToken.java
@@ -1,15 +1,13 @@
 // Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.builtins;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.commons.lang3.tuple.Pair;
 import org.kframework.backend.java.kil.MaximalSharing;
 import org.kframework.backend.java.kil.Sort;
 import org.kframework.backend.java.kil.Token;
 import org.kframework.backend.java.symbolic.Transformer;
 import org.kframework.backend.java.symbolic.Visitor;
+import org.kframework.backend.java.util.MapCache;
 import org.kframework.kil.ASTNode;
 import org.kframework.kil.Attribute;
 import org.kframework.kil.FloatBuiltin;
@@ -21,7 +19,7 @@ public class FloatToken extends Token implements MaximalSharing {
     public static final Sort SORT = Sort.FLOAT;
 
     /* Token cache */
-    private static final Map<Integer, Map<BigFloat, FloatToken>> cache = new HashMap<>();
+    private static final MapCache<Integer, MapCache<BigFloat, FloatToken>> cache = new MapCache<>();
 
     private final BigFloat value;
     private final int exponent;
@@ -38,21 +36,9 @@ public class FloatToken extends Token implements MaximalSharing {
      * and {@code int} exponent return the same {@code FloatToken} object).
      */
     public static FloatToken of(BigFloat value, int exponent) {
-        synchronized(cache) {
-            Map<BigFloat, FloatToken> exponentCache = cache.get(exponent);
-            if (exponentCache == null) {
-                exponentCache = new HashMap<>();
-                cache.put(exponent, exponentCache);
-            }
-
-            FloatToken cachedFloatToken = exponentCache.get(value);
-            if (cachedFloatToken == null) {
-                cachedFloatToken = new FloatToken(value, exponent);
-                exponentCache.put(value, cachedFloatToken);
-            }
-
-            return cachedFloatToken;
-        }
+        MapCache<BigFloat, FloatToken> exponentCache = cache.get(exponent, MapCache::new);
+        FloatToken cachedFloatToken = exponentCache.get(value, () -> new FloatToken(value, exponent));
+        return cachedFloatToken;
     }
 
     public static FloatToken of(String value) {
@@ -145,21 +131,9 @@ public class FloatToken extends Token implements MaximalSharing {
      * instance.
      */
     private Object readResolve() {
-        synchronized(cache) {
-            Map<BigFloat, FloatToken> exponentCache = cache.get(exponent);
-            if (exponentCache == null) {
-                exponentCache = new HashMap<>();
-                cache.put(exponent, exponentCache);
-            }
-
-            FloatToken cachedFloatToken = exponentCache.get(value);
-            if (cachedFloatToken == null) {
-                cachedFloatToken = this;
-                exponentCache.put(value, cachedFloatToken);
-            }
-
-            return cachedFloatToken;
-        }
+        MapCache<BigFloat, FloatToken> exponentCache = cache.get(exponent, MapCache::new);
+        FloatToken cachedFloatToken = exponentCache.get(value, () -> this);
+        return cachedFloatToken;
     }
 
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/FloatToken.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/FloatToken.java
@@ -38,19 +38,21 @@ public class FloatToken extends Token implements MaximalSharing {
      * and {@code int} exponent return the same {@code FloatToken} object).
      */
     public static FloatToken of(BigFloat value, int exponent) {
-        Map<BigFloat, FloatToken> exponentCache = cache.get(exponent);
-        if (exponentCache == null) {
-            exponentCache = new HashMap<>();
-            cache.put(exponent, exponentCache);
-        }
+        synchronized(cache) {
+            Map<BigFloat, FloatToken> exponentCache = cache.get(exponent);
+            if (exponentCache == null) {
+                exponentCache = new HashMap<>();
+                cache.put(exponent, exponentCache);
+            }
 
-        FloatToken cachedFloatToken = exponentCache.get(value);
-        if (cachedFloatToken == null) {
-            cachedFloatToken = new FloatToken(value, exponent);
-            exponentCache.put(value, cachedFloatToken);
-        }
+            FloatToken cachedFloatToken = exponentCache.get(value);
+            if (cachedFloatToken == null) {
+                cachedFloatToken = new FloatToken(value, exponent);
+                exponentCache.put(value, cachedFloatToken);
+            }
 
-        return cachedFloatToken;
+            return cachedFloatToken;
+        }
     }
 
     public static FloatToken of(String value) {
@@ -143,19 +145,21 @@ public class FloatToken extends Token implements MaximalSharing {
      * instance.
      */
     private Object readResolve() {
-        Map<BigFloat, FloatToken> exponentCache = cache.get(exponent);
-        if (exponentCache == null) {
-            exponentCache = new HashMap<>();
-            cache.put(exponent, exponentCache);
-        }
+        synchronized(cache) {
+            Map<BigFloat, FloatToken> exponentCache = cache.get(exponent);
+            if (exponentCache == null) {
+                exponentCache = new HashMap<>();
+                cache.put(exponent, exponentCache);
+            }
 
-        FloatToken cachedFloatToken = exponentCache.get(value);
-        if (cachedFloatToken == null) {
-            cachedFloatToken = this;
-            exponentCache.put(value, cachedFloatToken);
-        }
+            FloatToken cachedFloatToken = exponentCache.get(value);
+            if (cachedFloatToken == null) {
+                cachedFloatToken = this;
+                exponentCache.put(value, cachedFloatToken);
+            }
 
-        return cachedFloatToken;
+            return cachedFloatToken;
+        }
     }
 
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/IntToken.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/IntToken.java
@@ -38,14 +38,16 @@ public final class IntToken extends Token implements MaximalSharing {
      * method with the same {@code BigInteger} value return the same {@code IntToken} object).
      */
     public static IntToken of(BigInteger value) {
-        assert value != null;
+        synchronized(cache) {
+            assert value != null;
 
-        IntToken intToken = cache.get(value);
-        if (intToken == null) {
-            intToken = new IntToken(value);
-            cache.put(value, intToken);
+            IntToken intToken = cache.get(value);
+            if (intToken == null) {
+                intToken = new IntToken(value);
+                cache.put(value, intToken);
+            }
+            return intToken;
         }
-        return intToken;
     }
 
     public static IntToken of(long value) {
@@ -157,12 +159,14 @@ public final class IntToken extends Token implements MaximalSharing {
      * instance.
      */
     private Object readResolve() {
-        IntToken intToken = cache.get(value);
-        if (intToken == null) {
-            intToken = this;
-            cache.put(value, intToken);
+        synchronized(cache) {
+            IntToken intToken = cache.get(value);
+            if (intToken == null) {
+                intToken = this;
+                cache.put(value, intToken);
+            }
+            return intToken;
         }
-        return intToken;
     }
 
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/IntToken.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/IntToken.java
@@ -6,11 +6,10 @@ import org.kframework.backend.java.kil.Sort;
 import org.kframework.backend.java.kil.Token;
 import org.kframework.backend.java.symbolic.Transformer;
 import org.kframework.backend.java.symbolic.Visitor;
+import org.kframework.backend.java.util.MapCache;
 import org.kframework.kil.ASTNode;
 
 import java.math.BigInteger;
-import java.util.HashMap;
-import java.util.Map;
 
 
 /**
@@ -23,7 +22,7 @@ public final class IntToken extends Token implements MaximalSharing {
     public static final Sort SORT = Sort.INT;
 
     /* IntToken cache */
-    private static final Map<BigInteger, IntToken> cache = new HashMap<BigInteger, IntToken>();
+    private static final MapCache<BigInteger, IntToken> cache = new MapCache<BigInteger, IntToken>();
 
     /* BigInteger value wrapped by this IntToken */
     private final BigInteger value;
@@ -38,16 +37,8 @@ public final class IntToken extends Token implements MaximalSharing {
      * method with the same {@code BigInteger} value return the same {@code IntToken} object).
      */
     public static IntToken of(BigInteger value) {
-        synchronized(cache) {
-            assert value != null;
-
-            IntToken intToken = cache.get(value);
-            if (intToken == null) {
-                intToken = new IntToken(value);
-                cache.put(value, intToken);
-            }
-            return intToken;
-        }
+        assert value != null;
+        return cache.get(value, () -> new IntToken(value));
     }
 
     public static IntToken of(long value) {
@@ -159,14 +150,7 @@ public final class IntToken extends Token implements MaximalSharing {
      * instance.
      */
     private Object readResolve() {
-        synchronized(cache) {
-            IntToken intToken = cache.get(value);
-            if (intToken == null) {
-                intToken = this;
-                cache.put(value, intToken);
-            }
-            return intToken;
-        }
+        return cache.get(value, () -> this);
     }
 
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/StringToken.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/StringToken.java
@@ -6,6 +6,7 @@ import org.kframework.backend.java.kil.Sort;
 import org.kframework.backend.java.kil.Token;
 import org.kframework.backend.java.symbolic.Transformer;
 import org.kframework.backend.java.symbolic.Visitor;
+import org.kframework.backend.java.util.MapCache;
 import org.kframework.kil.ASTNode;
 import org.kframework.utils.StringUtil;
 
@@ -15,8 +16,6 @@ import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CodingErrorAction;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A string token. String tokens represent a sequence of unicode code points.
@@ -30,7 +29,7 @@ public final class StringToken extends Token implements MaximalSharing {
     public static final Sort SORT = Sort.STRING;
 
     /* StringToken cache */
-    private static final Map<String, StringToken> cache = new HashMap<String, StringToken>();
+    private static final MapCache<String, StringToken> cache = new MapCache<>();
 
     /* String value wrapped by this StringToken */
     private final String value;
@@ -47,16 +46,7 @@ public final class StringToken extends Token implements MaximalSharing {
      * @param value A UTF-16 representation of this sequence of code points.
      */
     public static StringToken of(String value) {
-        synchronized(cache) {
-            assert value != null;
-
-            StringToken stringToken = cache.get(value);
-            if (stringToken == null) {
-                stringToken = new StringToken(value);
-                cache.put(value, stringToken);
-            }
-            return stringToken;
-        }
+        return cache.get(value, () -> new StringToken(value));
     }
 
     /**
@@ -136,14 +126,7 @@ public final class StringToken extends Token implements MaximalSharing {
      * instance.
      */
     private Object readResolve() {
-        synchronized(cache) {
-            StringToken stringToken = cache.get(value);
-            if (stringToken == null) {
-                stringToken = this;
-                cache.put(value, stringToken);
-            }
-            return stringToken;
-        }
+        return cache.get(value, () -> this);
     }
 
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/StringToken.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/StringToken.java
@@ -47,14 +47,16 @@ public final class StringToken extends Token implements MaximalSharing {
      * @param value A UTF-16 representation of this sequence of code points.
      */
     public static StringToken of(String value) {
-        assert value != null;
+        synchronized(cache) {
+            assert value != null;
 
-        StringToken stringToken = cache.get(value);
-        if (stringToken == null) {
-            stringToken = new StringToken(value);
-            cache.put(value, stringToken);
+            StringToken stringToken = cache.get(value);
+            if (stringToken == null) {
+                stringToken = new StringToken(value);
+                cache.put(value, stringToken);
+            }
+            return stringToken;
         }
-        return stringToken;
     }
 
     /**
@@ -134,12 +136,14 @@ public final class StringToken extends Token implements MaximalSharing {
      * instance.
      */
     private Object readResolve() {
-        StringToken stringToken = cache.get(value);
-        if (stringToken == null) {
-            stringToken = this;
-            cache.put(value, stringToken);
+        synchronized(cache) {
+            StringToken stringToken = cache.get(value);
+            if (stringToken == null) {
+                stringToken = this;
+                cache.put(value, stringToken);
+            }
+            return stringToken;
         }
-        return stringToken;
     }
 
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/UninterpretedToken.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/UninterpretedToken.java
@@ -38,19 +38,21 @@ public final class UninterpretedToken extends Token implements MaximalSharing {
      * this method with the same sort and value return the same {@code UninterpretedToken} object).
      */
     public static UninterpretedToken of(Sort sort, String value) {
-        Map<String, UninterpretedToken> sortCache = cache.get(sort);
-        if (sortCache == null) {
-            sortCache = new HashMap<String, UninterpretedToken>();
-            cache.put(sort, sortCache);
-        }
+        synchronized(cache) {
+            Map<String, UninterpretedToken> sortCache = cache.get(sort);
+            if (sortCache == null) {
+                sortCache = new HashMap<String, UninterpretedToken>();
+                cache.put(sort, sortCache);
+            }
 
-        UninterpretedToken cachedGenericToken = sortCache.get(value);
-        if (cachedGenericToken == null) {
-            cachedGenericToken = new UninterpretedToken(sort, value);
-            sortCache.put(value, cachedGenericToken);
-        }
+            UninterpretedToken cachedGenericToken = sortCache.get(value);
+            if (cachedGenericToken == null) {
+                cachedGenericToken = new UninterpretedToken(sort, value);
+                sortCache.put(value, cachedGenericToken);
+            }
 
-        return cachedGenericToken;
+            return cachedGenericToken;
+        }
     }
 
     @Override
@@ -95,19 +97,21 @@ public final class UninterpretedToken extends Token implements MaximalSharing {
      * instance.
      */
     private Object readResolve() {
-        Map<String, UninterpretedToken> sortCache = cache.get(sort);
-        if (sortCache == null) {
-            sortCache = new HashMap<String, UninterpretedToken>();
-            cache.put(sort, sortCache);
-        }
+        synchronized(cache) {
+            Map<String, UninterpretedToken> sortCache = cache.get(sort);
+            if (sortCache == null) {
+                sortCache = new HashMap<String, UninterpretedToken>();
+                cache.put(sort, sortCache);
+            }
 
-        UninterpretedToken cachedGenericToken = sortCache.get(value);
-        if (cachedGenericToken == null) {
-            cachedGenericToken = this;
-            sortCache.put(value, cachedGenericToken);
-        }
+            UninterpretedToken cachedGenericToken = sortCache.get(value);
+            if (cachedGenericToken == null) {
+                cachedGenericToken = this;
+                sortCache.put(value, cachedGenericToken);
+            }
 
-        return cachedGenericToken;
+            return cachedGenericToken;
+        }
     }
 
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/UninterpretedToken.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/UninterpretedToken.java
@@ -6,11 +6,9 @@ import org.kframework.backend.java.kil.Sort;
 import org.kframework.backend.java.kil.Token;
 import org.kframework.backend.java.symbolic.Transformer;
 import org.kframework.backend.java.symbolic.Visitor;
+import org.kframework.backend.java.util.MapCache;
 import org.kframework.backend.java.util.Utils;
 import org.kframework.kil.ASTNode;
-
-import java.util.HashMap;
-import java.util.Map;
 
 
 /**
@@ -22,7 +20,7 @@ import java.util.Map;
 public final class UninterpretedToken extends Token implements MaximalSharing {
 
     /* Token cache */
-    private static final Map<Sort, Map<String, UninterpretedToken>> cache = new HashMap<>();
+    private static final MapCache<Sort, MapCache<String, UninterpretedToken>> cache = new MapCache<>();
 
     private final Sort sort;
     private final String value;
@@ -38,21 +36,8 @@ public final class UninterpretedToken extends Token implements MaximalSharing {
      * this method with the same sort and value return the same {@code UninterpretedToken} object).
      */
     public static UninterpretedToken of(Sort sort, String value) {
-        synchronized(cache) {
-            Map<String, UninterpretedToken> sortCache = cache.get(sort);
-            if (sortCache == null) {
-                sortCache = new HashMap<String, UninterpretedToken>();
-                cache.put(sort, sortCache);
-            }
-
-            UninterpretedToken cachedGenericToken = sortCache.get(value);
-            if (cachedGenericToken == null) {
-                cachedGenericToken = new UninterpretedToken(sort, value);
-                sortCache.put(value, cachedGenericToken);
-            }
-
-            return cachedGenericToken;
-        }
+        MapCache<String, UninterpretedToken> sortCache = cache.get(sort, MapCache::new);
+        return sortCache.get(value, () -> new UninterpretedToken(sort, value));
     }
 
     @Override
@@ -97,21 +82,8 @@ public final class UninterpretedToken extends Token implements MaximalSharing {
      * instance.
      */
     private Object readResolve() {
-        synchronized(cache) {
-            Map<String, UninterpretedToken> sortCache = cache.get(sort);
-            if (sortCache == null) {
-                sortCache = new HashMap<String, UninterpretedToken>();
-                cache.put(sort, sortCache);
-            }
-
-            UninterpretedToken cachedGenericToken = sortCache.get(value);
-            if (cachedGenericToken == null) {
-                cachedGenericToken = this;
-                sortCache.put(value, cachedGenericToken);
-            }
-
-            return cachedGenericToken;
-        }
+        MapCache<String, UninterpretedToken> sortCache = cache.get(sort, MapCache::new);
+        return sortCache.get(value, () -> this);
     }
 
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/CellLabel.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/CellLabel.java
@@ -5,6 +5,7 @@ import java.io.ObjectStreamException;
 import java.io.Serializable;
 
 import org.apache.commons.collections4.trie.PatriciaTrie;
+import org.kframework.backend.java.util.MapCache;
 import org.kframework.compile.transformers.Cell2DataStructure;
 import org.kframework.compile.utils.MetaK;
 
@@ -16,7 +17,7 @@ import org.kframework.compile.utils.MetaK;
  */
 public final class CellLabel implements MaximalSharing, Serializable {
 
-    private static final PatriciaTrie<CellLabel> cache = new PatriciaTrie<>();
+    private static final MapCache<String, CellLabel> cache = new MapCache<>(new PatriciaTrie<>());
 
     public static final CellLabel GENERATED_TOP =   CellLabel.of(MetaK.Constants.generatedTopCellLabel);
     public static final CellLabel K             =   CellLabel.of("k");
@@ -35,14 +36,7 @@ public final class CellLabel implements MaximalSharing, Serializable {
      * @return the cell label
      */
     public static CellLabel of(String name) {
-        synchronized(cache) {
-            CellLabel cellLabel = cache.get(name);
-            if (cellLabel == null) {
-                cellLabel = new CellLabel(name);
-                cache.put(name, cellLabel);
-            }
-            return cellLabel;
-        }
+        return cache.get(name, () -> new CellLabel(name));
     }
 
     private CellLabel(String name) {
@@ -82,14 +76,7 @@ public final class CellLabel implements MaximalSharing, Serializable {
      * there is a cached instance.
      */
     Object readResolve() throws ObjectStreamException {
-        synchronized(cache) {
-            CellLabel cellLabel = cache.get(name);
-            if (cellLabel == null) {
-                cellLabel = this;
-                cache.put(name, cellLabel);
-            }
-            return cellLabel;
-        }
+        return cache.get(name, () -> this);
     }
 
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/CellLabel.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/CellLabel.java
@@ -35,12 +35,14 @@ public final class CellLabel implements MaximalSharing, Serializable {
      * @return the cell label
      */
     public static CellLabel of(String name) {
-        CellLabel cellLabel = cache.get(name);
-        if (cellLabel == null) {
-            cellLabel = new CellLabel(name);
-            cache.put(name, cellLabel);
+        synchronized(cache) {
+            CellLabel cellLabel = cache.get(name);
+            if (cellLabel == null) {
+                cellLabel = new CellLabel(name);
+                cache.put(name, cellLabel);
+            }
+            return cellLabel;
         }
-        return cellLabel;
     }
 
     private CellLabel(String name) {
@@ -80,12 +82,14 @@ public final class CellLabel implements MaximalSharing, Serializable {
      * there is a cached instance.
      */
     Object readResolve() throws ObjectStreamException {
-        CellLabel cellLabel = cache.get(name);
-        if (cellLabel == null) {
-            cellLabel = this;
-            cache.put(name, cellLabel);
+        synchronized(cache) {
+            CellLabel cellLabel = cache.get(name);
+            if (cellLabel == null) {
+                cellLabel = this;
+                cache.put(name, cellLabel);
+            }
+            return cellLabel;
         }
-        return cellLabel;
     }
 
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KLabelConstant.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KLabelConstant.java
@@ -1,16 +1,14 @@
 // Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.kil;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.collections4.trie.PatriciaTrie;
 import org.kframework.backend.java.symbolic.Matcher;
 import org.kframework.backend.java.symbolic.Transformer;
 import org.kframework.backend.java.symbolic.Unifier;
 import org.kframework.backend.java.symbolic.Visitor;
+import org.kframework.backend.java.util.MapCache;
 import org.kframework.kil.ASTNode;
 import org.kframework.kil.Attribute;
 import org.kframework.kil.Production;
@@ -30,7 +28,7 @@ import com.google.common.collect.Multimap;
 public class KLabelConstant extends KLabel implements MaximalSharing {
 
     /* KLabelConstant cache */
-    private static final Map<ImmutableSet<Production>, PatriciaTrie<KLabelConstant>> cache = new HashMap<>();
+    private static final MapCache<ImmutableSet<Production>, MapCache<String, KLabelConstant>> cache = new MapCache<>();
 
     /* un-escaped label */
     private final String label;
@@ -140,22 +138,9 @@ public class KLabelConstant extends KLabel implements MaximalSharing {
      * @return AST term representation the the KLabel;
      */
     public static KLabelConstant of(String label, Context context) {
-        synchronized(cache) {
-            assert label != null;
-
-            ImmutableSet<Production> productions = ImmutableSet.copyOf(context.productionsOf(label));
-            PatriciaTrie<KLabelConstant> trie = cache.get(productions);
-            if (trie == null) {
-                trie = new PatriciaTrie<>();
-                cache.put(productions, trie);
-            }
-            KLabelConstant kLabelConstant = trie.get(label);
-            if (kLabelConstant == null) {
-                kLabelConstant = new KLabelConstant(label, productions, context);
-                trie.put(label, kLabelConstant);
-            }
-            return kLabelConstant;
-        }
+        ImmutableSet<Production> productions = ImmutableSet.copyOf(context.productionsOf(label));
+        MapCache<String, KLabelConstant> trie = cache.get(productions, () -> new MapCache<>(new PatriciaTrie<>()));
+        return trie.get(label, () -> new KLabelConstant(label, productions, context));
     }
 
     /**
@@ -275,19 +260,8 @@ public class KLabelConstant extends KLabel implements MaximalSharing {
      * instance.
      */
     private Object readResolve() {
-        synchronized(cache) {
-            PatriciaTrie<KLabelConstant> trie = cache.get(productions);
-            if (trie == null) {
-                trie = new PatriciaTrie<>();
-                cache.put(productions, trie);
-            }
-            KLabelConstant kLabelConstant = trie.get(label);
-            if (kLabelConstant == null) {
-                kLabelConstant = this;
-                trie.put(label, kLabelConstant);
-            }
-            return kLabelConstant;
-        }
+        MapCache<String, KLabelConstant> trie = cache.get(productions, () -> new MapCache<>(new PatriciaTrie<>()));
+        return trie.get(label, () -> this);
     }
 
     public boolean isMetaBinder() {

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/Sort.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/Sort.java
@@ -7,6 +7,8 @@ import java.util.Collection;
 import java.util.Set;
 
 import org.apache.commons.collections4.trie.PatriciaTrie;
+import org.kframework.backend.java.util.MapCache;
+
 import com.google.common.collect.ImmutableSet;
 
 /**
@@ -17,7 +19,7 @@ import com.google.common.collect.ImmutableSet;
  */
 public final class Sort implements MaximalSharing, Serializable {
 
-    private static final PatriciaTrie<Sort> cache = new PatriciaTrie<>();
+    private static final MapCache<String, Sort> cache = new MapCache<>(new PatriciaTrie<>());
 
     public static final Sort KITEM          =   Sort.of("KItem");
     public static final Sort KSEQUENCE      =   Sort.of("K");
@@ -59,14 +61,7 @@ public final class Sort implements MaximalSharing, Serializable {
      * @return the sort
      */
     public static Sort of(String name) {
-        synchronized(cache) {
-            Sort sort = cache.get(name);
-            if (sort == null) {
-                sort = new Sort(name);
-                cache.put(name, sort);
-            }
-            return sort;
-        }
+        return cache.get(name, () -> new Sort(name));
     }
 
     public static Sort of(org.kframework.kil.Sort sort) {
@@ -118,14 +113,7 @@ public final class Sort implements MaximalSharing, Serializable {
      * there is a cached instance.
      */
     Object readResolve() throws ObjectStreamException {
-        synchronized(cache) {
-            Sort sort = cache.get(name);
-            if (sort == null) {
-                sort = this;
-                cache.put(name, sort);
-            }
-            return sort;
-        }
+        return cache.get(name, () -> this);
     }
 
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/Variable.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/Variable.java
@@ -174,12 +174,14 @@ public class Variable extends Term implements Immutable {
         if (anonymous) {
             int id = Integer.parseInt(name.substring(VARIABLE_PREFIX.length()));
             if (id < counter) {
-                Variable variable = deserializationAnonymousVariableMap.get(id);
-                if (variable == null) {
-                    variable = getFreshCopy();
-                    deserializationAnonymousVariableMap.put(id, variable);
+                synchronized(deserializationAnonymousVariableMap) {
+                    Variable variable = deserializationAnonymousVariableMap.get(Pair.of(id, sort));
+                    if (variable == null) {
+                        variable = getFreshCopy();
+                        deserializationAnonymousVariableMap.put(Pair.of(id, sort), variable);
+                    }
+                    return variable;
                 }
-                return variable;
             } else {
                 counter = id + 1;
                 return this;

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/Variable.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/Variable.java
@@ -1,18 +1,18 @@
 // Copyright (c) 2013-2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.kil;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.kframework.backend.java.symbolic.Matcher;
 import org.kframework.backend.java.symbolic.Unifier;
 import org.kframework.backend.java.symbolic.Transformer;
 import org.kframework.backend.java.symbolic.Visitor;
+import org.kframework.backend.java.util.MapCache;
 import org.kframework.backend.java.util.Utils;
 import org.kframework.kil.ASTNode;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 
 
@@ -25,7 +25,7 @@ public class Variable extends Term implements Immutable {
 
     protected static final String VARIABLE_PREFIX = "_";
     protected static int counter = 0;
-    private static Map<Integer, Variable> deserializationAnonymousVariableMap = new HashMap<>();
+    private static MapCache<Pair<Integer, Sort>, Variable> deserializationAnonymousVariableMap = new MapCache<>();
 
     /**
      * Given a set of {@link Variable}s, returns a substitution that maps each
@@ -174,14 +174,7 @@ public class Variable extends Term implements Immutable {
         if (anonymous) {
             int id = Integer.parseInt(name.substring(VARIABLE_PREFIX.length()));
             if (id < counter) {
-                synchronized(deserializationAnonymousVariableMap) {
-                    Variable variable = deserializationAnonymousVariableMap.get(Pair.of(id, sort));
-                    if (variable == null) {
-                        variable = getFreshCopy();
-                        deserializationAnonymousVariableMap.put(Pair.of(id, sort), variable);
-                    }
-                    return variable;
-                }
+                return deserializationAnonymousVariableMap.get(Pair.of(id, sort), this::getFreshCopy);
             } else {
                 counter = id + 1;
                 return this;

--- a/java-backend/src/main/java/org/kframework/backend/java/rewritemachine/GenerateRHSInstructions.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/rewritemachine/GenerateRHSInstructions.java
@@ -146,11 +146,7 @@ public class GenerateRHSInstructions extends BottomUpVisitor {
             node.kLabel().accept(this);
             rhsSchedule.add(RHSInstruction.CONSTRUCT(
                     new Constructor(ConstructorType.KITEM)));
-            if (!(node.kLabel() instanceof KLabelConstant)
-                    || (node.isAnywhereApplicable(context)
-                            || ((KLabelConstant)node.kLabel()).isFunction())) {
-                rhsSchedule.add(RHSInstruction.EVAL);
-            }
+            rhsSchedule.add(RHSInstruction.EVAL);
         }
     }
 

--- a/java-backend/src/main/java/org/kframework/backend/java/rewritemachine/MatchingInstruction.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/rewritemachine/MatchingInstruction.java
@@ -32,12 +32,14 @@ public final class MatchingInstruction implements Serializable {
     private final int hashCode;
 
     public static MatchingInstruction GOTO(CellLabel cellLabel) {
-        MatchingInstruction instr = cachedGOTOInstructions.get(cellLabel);
-        if (instr == null) {
-            instr = new MatchingInstruction(Type.GOTO, cellLabel);
-            cachedGOTOInstructions.put(cellLabel, instr);
+        synchronized(cachedGOTOInstructions) {
+            MatchingInstruction instr = cachedGOTOInstructions.get(cellLabel);
+            if (instr == null) {
+                instr = new MatchingInstruction(Type.GOTO, cellLabel);
+                cachedGOTOInstructions.put(cellLabel, instr);
+            }
+            return instr;
         }
-        return instr;
     }
 
     private MatchingInstruction(Type type, CellLabel cellLabel) {
@@ -82,12 +84,14 @@ public final class MatchingInstruction implements Serializable {
         case CHOICE:
             return CHOICE;
         case GOTO:
-            MatchingInstruction instr = cachedGOTOInstructions.get(cellLabel);
-            if (instr == null) {
-                instr = new MatchingInstruction(type, cellLabel);
-                cachedGOTOInstructions.put(cellLabel, instr);
+            synchronized(cachedGOTOInstructions) {
+                MatchingInstruction instr = cachedGOTOInstructions.get(cellLabel);
+                if (instr == null) {
+                    instr = new MatchingInstruction(type, cellLabel);
+                    cachedGOTOInstructions.put(cellLabel, instr);
+                }
+                return instr;
             }
-            return instr;
         default:
             assert false;
             return null;

--- a/java-backend/src/main/java/org/kframework/backend/java/util/MapCache.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/MapCache.java
@@ -1,0 +1,27 @@
+package org.kframework.backend.java.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class MapCache<K, V> {
+
+    private final Map<K, V> cache;
+
+    public MapCache(Map<K, V> cache) {
+        this.cache = cache;
+    }
+
+    public MapCache() {
+        this.cache = new HashMap<>();
+    }
+
+    public synchronized V get(K key, Supplier<V> value) {
+        V cachedVal = cache.get(key);
+        if (cachedVal == null) {
+            cachedVal = value.get();
+            cache.put(key, cachedVal);
+        }
+        return cachedVal;
+    }
+}

--- a/java-backend/src/main/java/org/kframework/backend/java/util/MapCache.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/MapCache.java
@@ -1,3 +1,4 @@
+// Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.util;
 
 import java.util.HashMap;

--- a/java-backend/src/main/java/org/kframework/backend/java/util/Profiler.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/Profiler.java
@@ -1,11 +1,7 @@
 // Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.backend.java.util;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.ThreadMXBean;
-
 import com.google.common.base.Stopwatch;
-import com.google.common.base.Ticker;
 
 /**
  * Profiling class.
@@ -71,16 +67,7 @@ public class Profiler {
         private final ThreadLocal<Stopwatch> stopwatch = new ThreadLocal<Stopwatch>() {
             @Override
             protected Stopwatch initialValue() {
-                return Stopwatch.createUnstarted(new Ticker() {
-
-                    ThreadMXBean bean = ManagementFactory.getThreadMXBean();
-
-                    @Override
-                    public long read() {
-                        assert bean.isCurrentThreadCpuTimeSupported();
-                        return bean.getCurrentThreadCpuTime();
-                    }
-                });
+                return Stopwatch.createUnstarted();
             }
         };
 

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.kast;
 
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +74,7 @@ public class KastFrontEnd extends FrontEnd {
      */
     @Override
     public boolean run() {
-        String stringToParse = options.stringToParse();
+        Reader stringToParse = options.stringToParse();
         Source source = options.source();
 
         Context context = contextProvider.get();

--- a/kernel/src/main/java/org/kframework/kast/KastOptions.java
+++ b/kernel/src/main/java/org/kframework/kast/KastOptions.java
@@ -1,6 +1,8 @@
 // Copyright (c) 2014 K Team. All Rights Reserved.
 package org.kframework.kast;
 
+import java.io.Reader;
+import java.io.StringReader;
 import java.util.List;
 
 import com.beust.jcommander.IStringConverter;
@@ -30,12 +32,12 @@ public final class KastOptions {
     @Parameter(description="<file>")
     private List<String> parameters;
 
-    public String stringToParse() {
+    public Reader stringToParse() {
         if (parameters != null && parameters.size() > 0 && expression != null) {
             throw KExceptionManager.criticalError("It is an error to provide both a file and an expression to parse.");
         }
         if (expression != null) {
-            return expression;
+            return new StringReader(expression);
         }
         if (parameters != null && parameters.size() > 1) {
             throw KExceptionManager.criticalError("You can only parse one program at a time.");
@@ -43,7 +45,7 @@ public final class KastOptions {
         if (parameters == null || parameters.size() != 1) {
             throw KExceptionManager.criticalError("You have to provide a file in order to kast a program.");
         }
-        return files.loadFromWorkingDirectory(parameters.get(0));
+        return files.readFromWorkingDirectory(parameters.get(0));
     }
 
     private FileUtil files;

--- a/kernel/src/main/java/org/kframework/krun/RunProcess.java
+++ b/kernel/src/main/java/org/kframework/krun/RunProcess.java
@@ -21,6 +21,8 @@ import com.google.inject.Provider;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -116,40 +118,36 @@ public class RunProcess {
         if (startSymbol == null) {
             startSymbol = context.startSymbolPgm();
         }
-        String content = value;
+        Reader content = new StringReader(value);
         Source source = Sources.fromCommandLine("parameters");
 
         switch (parser) {
             case "kast":
                 if (!isNotFile) {
-                    content = context.files.loadFromWorkingDirectory(value);
+                    content = context.files.readFromWorkingDirectory(value);
                     source = Sources.fromFile(context.files.resolveWorkingDirectory(value));
                 }
-                term = loader.processPgm(content, source, startSymbol, context, ParserType.PROGRAM);
-                break;
             case "kast -e":
-                term = loader.processPgm(value, source, startSymbol, context, ParserType.PROGRAM);
+                term = loader.processPgm(content, source, startSymbol, context, ParserType.PROGRAM);
                 break;
             case "kast --parser ground":
                 if (!isNotFile) {
-                    content = context.files.loadFromWorkingDirectory(value);
+                    content = context.files.readFromWorkingDirectory(value);
                     source = Sources.fromFile(context.files.resolveWorkingDirectory(value));
                 }
-                term = loader.processPgm(content, source, startSymbol, context, ParserType.GROUND);
-                break;
             case "kast --parser ground -e":
-                term = loader.processPgm(value, source, startSymbol, context, ParserType.GROUND);
+                term = loader.processPgm(content, source, startSymbol, context, ParserType.GROUND);
                 break;
             case "kast --parser rules":
                 if (!isNotFile) {
-                    content = context.files.loadFromWorkingDirectory(value);
+                    content = context.files.readFromWorkingDirectory(value);
                     source = Sources.fromFile(context.files.resolveWorkingDirectory(value));
                 }
                 term = loader.processPgm(content, source, startSymbol, context, ParserType.RULES);
                 break;
             case "kast --parser binary":
                 if (!isNotFile) {
-                    content = context.files.loadFromWorkingDirectory(value);
+                    content = context.files.readFromWorkingDirectory(value);
                     source = Sources.fromFile(context.files.resolveWorkingDirectory(value));
                 }
                 term = loader.processPgm(content, source, startSymbol, context, ParserType.BINARY);

--- a/kernel/src/main/java/org/kframework/krun/tools/LtlModelChecker.java
+++ b/kernel/src/main/java/org/kframework/krun/tools/LtlModelChecker.java
@@ -3,14 +3,15 @@ package org.kframework.krun.tools;
 
 import org.kframework.kil.Attributes;
 import org.kframework.kil.Sort;
+import org.kframework.kil.Sources;
 import org.kframework.kil.Term;
 import org.kframework.kil.loader.Context;
 import org.kframework.krun.KRunExecutionException;
 import org.kframework.krun.KRunOptions;
-import org.kframework.krun.RunProcess;
 import org.kframework.krun.api.KRunGraph;
 import org.kframework.krun.api.KRunProofResult;
 import org.kframework.krun.api.KRunResult;
+import org.kframework.parser.ProgramLoader;
 import org.kframework.transformation.Transformation;
 import org.kframework.utils.Stopwatch;
 import org.kframework.utils.errorsystem.KExceptionManager;
@@ -43,7 +44,7 @@ public interface LtlModelChecker {
         private final Context context;
         private final Stopwatch sw;
         private final LtlModelChecker modelChecker;
-        private final RunProcess rp;
+        private final ProgramLoader loader;
         private final FileUtil files;
 
         @Inject
@@ -53,14 +54,14 @@ public interface LtlModelChecker {
                 @Main Context context,
                 Stopwatch sw,
                 @Main LtlModelChecker modelChecker,
-                RunProcess rp,
+                ProgramLoader loader,
                 @Main FileUtil files) {
             this.options = options;
             this.initialConfiguration = initialConfiguration;
             this.context = context;
             this.sw = sw;
             this.modelChecker = modelChecker;
-            this.rp = rp;
+            this.loader = loader;
             this.files = files;
         }
 
@@ -68,8 +69,8 @@ public interface LtlModelChecker {
         public KRunProofResult<KRunGraph> run(Void v, Attributes a) {
             a.add(Context.class, context);
             try {
-                Term formula = rp.runParser("kast -e",
-                        ltlmc(), false, Sort.of("LtlFormula"), context);
+                Term formula = (Term) loader.loadPgmAst(ltlmc(), Sources.fromCommandLine("parameters"),
+                        Sort.of("LtlFormula"), context);
                 KRunProofResult<KRunGraph> result = modelChecker.modelCheck(
                                 formula,
                                 initialConfiguration.get());

--- a/kernel/src/main/java/org/kframework/parser/ProgramLoader.java
+++ b/kernel/src/main/java/org/kframework/parser/ProgramLoader.java
@@ -1,12 +1,13 @@
 // Copyright (c) 2012-2014 K Team. All Rights Reserved.
 package org.kframework.parser;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.util.Map;
 
 import org.apache.commons.codec.binary.Base64InputStream;
+import org.apache.commons.io.input.ReaderInputStream;
 import org.kframework.compile.transformers.AddEmptyLists;
 import org.kframework.compile.transformers.FlattenTerms;
 import org.kframework.compile.transformers.RemoveBrackets;
@@ -40,6 +41,7 @@ import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.errorsystem.ParseFailedException;
 import org.kframework.utils.errorsystem.KException.ExceptionType;
 import org.kframework.utils.errorsystem.KException.KExceptionGroup;
+import org.kframework.utils.file.FileUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -106,7 +108,7 @@ public class ProgramLoader {
      *
      * Save it in kompiled cache under pgm.maude.
      */
-    public Term processPgm(String content, Source source, Sort startSymbol,
+    public Term processPgm(Reader content, Source source, Sort startSymbol,
             Context context, ParserType whatParser) throws ParseFailedException {
         sw.printIntermediate("Importing Files");
         if (!context.getAllSorts().contains(startSymbol)) {
@@ -116,13 +118,13 @@ public class ProgramLoader {
 
         ASTNode out;
         if (whatParser == ParserType.GROUND) {
-            out = termLoader.parseCmdString(content, source, startSymbol, context);
+            out = termLoader.parseCmdString(FileUtil.read(content), source, startSymbol, context);
             out = new RemoveBrackets(context).visitNode(out);
             out = new AddEmptyLists(context, kem).visitNode(out);
             out = new RemoveSyntacticCasts(context).visitNode(out);
             out = new FlattenTerms(context).visitNode(out);
         } else if (whatParser == ParserType.RULES) {
-            out = termLoader.parsePattern(content, source, startSymbol, context);
+            out = termLoader.parsePattern(FileUtil.read(content), source, startSymbol, context);
             out = new RemoveBrackets(context).visitNode(out);
             out = new AddEmptyLists(context, kem).visitNode(out);
             out = new RemoveSyntacticCasts(context).visitNode(out);
@@ -130,7 +132,7 @@ public class ProgramLoader {
             out = new FlattenTerms(context).visitNode(out);
             out = ((Sentence) out).getBody();
         } else if (whatParser == ParserType.BINARY) {
-            try (InputStream in = new Base64InputStream(new ByteArrayInputStream(content.getBytes()))) {
+            try (InputStream in = new Base64InputStream(new ReaderInputStream(content))) {
                 out = loader.loadOrDie(Term.class, in);
             } catch (IOException e) {
                 throw KExceptionManager.internalError("Error reading from binary file", e);
@@ -141,13 +143,13 @@ public class ProgramLoader {
             // TODO(Radu): (the default one) with this branch of the 'if'
             Grammar grammar = loader.loadOrDie(Grammar.class, context.files.resolveKompiled("newParser.bin"));
 
-            out = newParserParse(content, grammar.get(startSymbol.toString()), source, context);
+            out = newParserParse(FileUtil.read(content), grammar.get(startSymbol.toString()), source, context);
             out = new AmbFilter(context, kem).visitNode(out);
             out = new RemoveBrackets(context).visitNode(out);
             out = new FlattenTerms(context).visitNode(out);
             out = new ResolveVariableAttribute(context).visitNode(out);
         } else {
-            out = loadPgmAst(content, source, startSymbol, context);
+            out = loadPgmAst(FileUtil.read(content), source, startSymbol, context);
             out = new ResolveVariableAttribute(context).visitNode(out);
         }
         sw.printIntermediate("Parsing Program");

--- a/kernel/src/main/java/org/kframework/utils/file/FileUtil.java
+++ b/kernel/src/main/java/org/kframework/utils/file/FileUtil.java
@@ -3,6 +3,7 @@ package org.kframework.utils.file;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.kframework.main.GlobalOptions;
 import org.kframework.utils.errorsystem.KExceptionManager;
@@ -200,6 +201,23 @@ public class FileUtil {
             return Pair.of(out, in);
         } catch (IOException e) {
             throw KExceptionManager.internalError("Error creating input/output pipe", e);
+        }
+    }
+
+    public static String read(Reader reader) {
+        try {
+            return IOUtils.toString(reader);
+        } catch (IOException e) {
+            throw KExceptionManager.internalError("Error reading from " + reader, e);
+        }
+    }
+
+    public Reader readFromWorkingDirectory(String path) {
+        File f = resolveWorkingDirectory(path);
+        try {
+            return new FileReader(f);
+        } catch (FileNotFoundException e) {
+            throw KExceptionManager.criticalError("Could not read from file " + f.getAbsolutePath(), e);
         }
     }
 }


### PR DESCRIPTION
Comprises:
- add auditing for anywhere rules
- fix race conditions associated with get/put critical pairs in static caches
- disable user time (apparently JMX is really slow)
- fix for bug with anywhere rules not applying because the eval instruction was not generated (due to Definition.anywhereRules() not being set yet at compilation time)
- fix to use Reader instead of String for parts of the parser in order to avoid creating large arrays in memory

@yilongli please review
