### PR TITLE
Improve error message when List is not declared

### DIFF
--- a/kernel/src/main/java/org/kframework/compile/transformers/DesugarStreams.java
+++ b/kernel/src/main/java/org/kframework/compile/transformers/DesugarStreams.java
@@ -68,7 +68,7 @@ public class DesugarStreams extends CopyOnWriteTransformer {
                     "Make sure you give the correct stream names: " + channels.toString(),
                     this, node);
         }
-        DataStructureSort myList = context.dataStructureListSortOf(DataStructureSort.DEFAULT_LIST_SORT);
+        DataStructureSort myList = context.getDefaultListDataStructureSort();
         Term newItems = DataStructureSort.listOf(context, items.toArray(new Term[] {}));
         if (addAtBeginning != null) {
             newItems = KApp.of(KLabelConstant.of(myList.constructorLabel()), addAtBeginning, newItems);
@@ -80,7 +80,7 @@ public class DesugarStreams extends CopyOnWriteTransformer {
     }
 
     private Term newListItem(Term element) {
-        DataStructureSort myList = context.dataStructureListSortOf(DataStructureSort.DEFAULT_LIST_SORT);
+        DataStructureSort myList = context.getDefaultListDataStructureSort();
         return KApp.of(KLabelConstant.of(myList.elementLabel()), element);
     }
 

--- a/kernel/src/main/java/org/kframework/compile/transformers/ResolveBlockingInput.java
+++ b/kernel/src/main/java/org/kframework/compile/transformers/ResolveBlockingInput.java
@@ -198,8 +198,7 @@ public class ResolveBlockingInput extends GetLhsPattern {
 
 //        ctor(List)[replaceS[emptyCt(List),parseTerm(string(Ty),nilK)],ioBuffer(mkVariable('BI,K))]
         Term list;
-        DataStructureSort myList = context.dataStructureListSortOf(
-            DataStructureSort.DEFAULT_LIST_SORT);
+        DataStructureSort myList = context.getDefaultListDataStructureSort();
         Term term1 = new Rewrite(
             KApp.of(KLabelConstant.of(myList.unitLabel())),
             KApp.of(KLabelConstant.of(myList.elementLabel()), parseTerm),

--- a/kernel/src/main/java/org/kframework/kil/DataStructureSort.java
+++ b/kernel/src/main/java/org/kframework/kil/DataStructureSort.java
@@ -138,7 +138,7 @@ public class DataStructureSort implements Serializable {
      * Returns a term of sort List containing one ListItem element per argument.
      */
     public static Term listOf(Context context, Term... listItems) {
-        DataStructureSort myList = context.dataStructureListSortOf(DEFAULT_LIST_SORT);
+        DataStructureSort myList = context.getDefaultListDataStructureSort();
         if (listItems.length == 0) {
             return KApp.of(KLabelConstant.of(myList.unitLabel()));
         }

--- a/kernel/src/main/java/org/kframework/kil/loader/Context.java
+++ b/kernel/src/main/java/org/kframework/kil/loader/Context.java
@@ -423,15 +423,39 @@ public class Context implements Serializable {
         this.dataStructureSorts = new HashMap<>(dataStructureSorts);
     }
 
+    /**
+     * Return the DataStructureSort corresponding to the given Sort, or null if
+     * the sort is not known as a data structure sort.
+     */
     public DataStructureSort dataStructureSortOf(Sort sort) {
         return dataStructureSorts.get(sort);
     }
 
+    /**
+     * Like dataStructureSortOf, except it returns null also if
+     * the sort corresponds to a DataStructureSort which isn't a list sort.
+     */
     public DataStructureSort dataStructureListSortOf(Sort sort) {
         DataStructureSort dataStructSort = dataStructureSorts.get(sort);
         if (dataStructSort == null) return null;
         if (!dataStructSort.type().equals(Sort.LIST)) return null;
         return dataStructSort;
+    }
+
+    /**
+     * Get a DataStructureSort for the default list sort, or raise a nice exception.
+     * Equivalent to
+     * <code>dataStructureListSortOf(DataStructureSort.DEFAULT_LIST_SORT)</code>,
+     * if it succeeds.
+     */
+    public DataStructureSort getDefaultListDataStructureSort() {
+        DataStructureSort list = dataStructureListSortOf(DataStructureSort.DEFAULT_LIST_SORT);
+        if (list == null) {
+            throw KExceptionManager.internalError(
+                    "A sort List must exist and be recognized as a data structure sort."
+                    + " Installation is corrupt or --no-prelude used with incomplete definition.");
+        }
+        return list;
     }
 
     /**


### PR DESCRIPTION
A NullPointerException was the only error when using --no-prelude on a definition that didn't include a List sorts. This pull requests changes all places that assume context.dataStructureListSortOf(DataStructureSort.DEFAULT_LIST_SORT) succeeds with calls to a new method that will raise a nice exception if List isn't a recognized sort.
