### PR TITLE
fix #1336 - slows down build slightly, but should no longer need to peri...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,6 @@
           <configuration>
             <source>1.8</source>
             <target>1.8</target>
-            <useIncrementalCompilation>false</useIncrementalCompilation>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
...odically clean

It looks like whatever issue was causing us to need to disable maven's incremental compilation because it was completely broken is no longer affecting the project. Second build goes up from 15 seconds to 30 seconds, but 3rd and following builds remain at 15 seconds, and in exchange, you should no longer ever have to run `mvn clean`.

@yilongli please review
