### PR TITLE
Don't do strict type checking on semantic casts.

### DIFF
--- a/k-distribution/tests/regression/regression.k
+++ b/k-distribution/tests/regression/regression.k
@@ -291,4 +291,8 @@ module REGRESSION
   syntax Int ::= foo1219(Map) [function]
   rule foo1219((K1 |-> K2) M:Map) => foo1219(M)
   rule foo1219(.Map) => 0
+  
+  // semantic casts shouldn't strictly type check terms
+  syntax Id ::= "foo25"
+  rule foo25:Exp => .K
 endmodule

--- a/k-distribution/tests/regression/regression.k
+++ b/k-distribution/tests/regression/regression.k
@@ -291,7 +291,7 @@ module REGRESSION
   syntax Int ::= foo1219(Map) [function]
   rule foo1219((K1 |-> K2) M:Map) => foo1219(M)
   rule foo1219(.Map) => 0
-  
+
   // semantic casts shouldn't strictly type check terms
   syntax Id ::= "foo25"
   rule foo25:Exp => .K

--- a/kernel/src/main/java/org/kframework/parser/concrete/disambiguate/TypeSystemFilter.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete/disambiguate/TypeSystemFilter.java
@@ -46,8 +46,9 @@ public class TypeSystemFilter extends ParseForestTransformer {
 
     @Override
     public ASTNode visit(Cast cast, Void _void) throws ParseFailedException {
+        // don't do type checking for outer casts, and be strict about it only for syntactic ones
         if (cast.getType() != Cast.CastType.OUTER)
-            cast.setContent((Term) new TypeSystemFilter2(cast.getInnerSort(), true, context).visitNode(cast.getContent()));
+            cast.setContent((Term) new TypeSystemFilter2(cast.getInnerSort(), cast.getType() != Cast.CastType.SEMANTIC, context).visitNode(cast.getContent()));
         return super.visit(cast, _void);
     }
 }


### PR DESCRIPTION
@dwightguth please review.
This is related to the issue reported yesterday by @laurayuwen.
