### PR TITLE
Reduce heap size option in kserver.

### DIFF
--- a/k-distribution/src/main/scripts/bin/kserver
+++ b/k-distribution/src/main/scripts/bin/kserver
@@ -2,7 +2,7 @@
 source "$(dirname "$0")/../lib/setenv"
 ulimit -s `ulimit -H -s`
 if [ -z "$K_OPTS" ];
-  then export K_OPTS="-Xms64m -Xmx24G -Xss32m -XX:+TieredCompilation"
+  then export K_OPTS="-Xms64m -Xmx4G -Xss32m -XX:+TieredCompilation"
 fi
 if "$(dirname "$0")/../lib/checkJava"; then
   java -Djava.awt.headless=true -Djansi.force=true $K_OPTS -ea -cp "$(dirname "$0")/../lib/java/*" com.martiansoftware.nailgun.NGServer "$@"


### PR DESCRIPTION
With the previous large value the ktest run in mvn verify
would approach or exceed 8GB ram
(which is bad on my laptop that only has 8GB ram),
this change seems to keep it at least down to 5GB or so.
We suspect the GC was being too lazy when started with a huge
maximum heap size.
There also seem to be issues, not addressed by this commit,
with extra threads hanging around from threadpools that are not
properly cleaned up.
