### PR TITLE
revert DefinitionScope of java kil Definition because of race in JS sema...

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/JavaSymbolicObject.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/JavaSymbolicObject.java
@@ -119,7 +119,7 @@ public abstract class JavaSymbolicObject extends ASTNode
      * {@link JavaSymbolicObject#getVariableSet()}.
      */
     public Set<Variable> variableSet() {
-        synchronized(lock) {
+//        synchronized(lock) {
             if (variableSet == null) {
                 IncrementalCollector<Variable> visitor = new IncrementalCollector<>(
                         (set, term) -> term.setVariableSet(set),
@@ -134,7 +134,7 @@ public abstract class JavaSymbolicObject extends ASTNode
                 variableSet = visitor.getResultSet();
             }
             return Collections.unmodifiableSet(variableSet);
-        }
+//        }
     }
 
      /**
@@ -146,7 +146,7 @@ public abstract class JavaSymbolicObject extends ASTNode
      * {@link JavaSymbolicObject#getUserVariableSet()}.
      */
     public Set<Term> userVariableSet(TermContext context) {
-        synchronized(lock) {
+//        synchronized(lock) {
             if (userVariableSet == null) {
                 IncrementalCollector<Term> visitor = new IncrementalCollector<>(
                         (set, term) -> term.setUserVariableSet(set),
@@ -163,7 +163,7 @@ public abstract class JavaSymbolicObject extends ASTNode
                 userVariableSet = visitor.getResultSet();
             }
             return Collections.unmodifiableSet(userVariableSet);
-        }
+//        }
     }
 
 
@@ -176,7 +176,7 @@ public abstract class JavaSymbolicObject extends ASTNode
      * computation instead of simply returning {@code null}.
      */
     public boolean isNormal() {
-        synchronized(lock) {
+//        synchronized(lock) {
             if (functionKLabels == null) {
                 IncrementalCollector<Term> visitor = new IncrementalCollector<>(
                         (set, term) -> term.functionKLabels = set,
@@ -198,7 +198,7 @@ public abstract class JavaSymbolicObject extends ASTNode
                 functionKLabels = visitor.getResultSet();
             }
             return functionKLabels.size() == 0;
-        }
+//        }
     }
 
     @Override

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaSymbolicKRunModule.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaSymbolicKRunModule.java
@@ -69,7 +69,7 @@ public class JavaSymbolicKRunModule extends AbstractModule {
             executorBinder.addBinding("java").to(JavaSymbolicExecutor.class);
         }
 
-        @Provides @DefinitionScoped
+        @Provides @RequestScoped
         Definition javaDefinition(BinaryLoader loader, Context context, FileUtil files, KExceptionManager kem) {
             Definition def = loader.loadOrDie(Definition.class,
                     files.resolveKompiled(JavaSymbolicBackend.DEFINITION_FILENAME));


### PR DESCRIPTION
...ntics

@yilongli please review

If the bulk of the ~7min performance optimization on the C semantics test suite is lost by this diff, I will track down and deal with the remaining mutable state in the Definition object. But I want to get this revert in today in order to unbreak the build.
