### PR TITLE
Fix new disamb

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/ParseInModule.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/ParseInModule.java
@@ -75,7 +75,7 @@ public class ParseInModule implements Serializable {
         warn = rez2._2();
 
         Term rez3 = new PreferAvoidVisitor().apply(rez2._1().right().get());
-        rez2 = new AmbFilter().apply(rez.right().get());
+        rez2 = new AmbFilter().apply(rez3);
         warn = new AmbFilter().mergeWarnings(rez2._2(), warn);
 
         return new Tuple2<>(Right.apply(rez2._1().right().get()), warn);

--- a/kernel/src/test/java/org/kframework/parser/concrete2kore/RuleGrammarTest.java
+++ b/kernel/src/test/java/org/kframework/parser/concrete2kore/RuleGrammarTest.java
@@ -176,7 +176,7 @@ public class RuleGrammarTest {
                 "| r\"[0-9]+\" [token] " +
                 "endmodule";
         Tuple2<Either<Set<ParseFailedException>, Term>, Set<ParseFailedException>> rule = parseRule(def, "1+2*3");
-        Assert.assertEquals("Expected 1 warning: ", 0, rule._2().size());
+        Assert.assertEquals("Expected 0 warnings: ", 0, rule._2().size());
         Assert.assertTrue("Expected no errors here: ", rule._1().isRight());
         printout(rule);
     }

--- a/kernel/src/test/java/org/kframework/parser/concrete2kore/RuleGrammarTest.java
+++ b/kernel/src/test/java/org/kframework/parser/concrete2kore/RuleGrammarTest.java
@@ -165,4 +165,19 @@ public class RuleGrammarTest {
         Assert.assertTrue("Expected errors here: ", rule._1().isLeft());
         printout(rule);
     }
+
+    // test prefer and avoid
+    @Test
+    public void test8() {
+        String def = "" +
+                "module TEST " +
+                "syntax Exp ::= Exp \"+\" Exp [klabel('Plus), prefer] " +
+                "| Exp \"*\" Exp [klabel('Mul)] " +
+                "| r\"[0-9]+\" [token] " +
+                "endmodule";
+        Tuple2<Either<Set<ParseFailedException>, Term>, Set<ParseFailedException>> rule = parseRule(def, "1+2*3");
+        Assert.assertEquals("Expected 1 warning: ", 0, rule._2().size());
+        Assert.assertTrue("Expected no errors here: ", rule._1().isRight());
+        printout(rule);
+    }
 }


### PR DESCRIPTION
I found a bug in the wiring of disambiguation steps for prefer-avoid filter.
@dwightguth please review.
