### PR TITLE
fix failing test in c semantics due to warning

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/BuiltinIntOperations.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/BuiltinIntOperations.java
@@ -24,11 +24,19 @@ public class BuiltinIntOperations {
     }
 
     public static IntToken div(IntToken term1, IntToken term2, TermContext context) {
-        return IntToken.of(term1.bigIntegerValue().divide(term2.bigIntegerValue()));
+        try {
+            return IntToken.of(term1.bigIntegerValue().divide(term2.bigIntegerValue()));
+        } catch (ArithmeticException e) {
+            return null;
+        }
     }
 
     public static IntToken rem(IntToken term1, IntToken term2, TermContext context) {
-        return IntToken.of(term1.bigIntegerValue().remainder(term2.bigIntegerValue()));
+        try {
+            return IntToken.of(term1.bigIntegerValue().remainder(term2.bigIntegerValue()));
+        } catch (ArithmeticException e) {
+            return null;
+        }
     }
 
     public static IntToken mod(IntToken term1, IntToken term2, TermContext context) {


### PR DESCRIPTION
@radumereuta accidentally broke the -w flag which was surpressing the warning from  the exception thrown by this hook. It's rather time-sensitive, so I'm fixing the warning while he fixes the bug. @yilongli please review
