### PR TITLE
Refactoring and work on tiny

### DIFF
--- a/k-distribution/src/test/java/org/kframework/kore/convertors/TstTinyOnKORE.java
+++ b/k-distribution/src/test/java/org/kframework/kore/convertors/TstTinyOnKORE.java
@@ -60,7 +60,7 @@ public class TstTinyOnKORE extends BaseTest {
                                 ))),
                 cons.KLabel("'<state>").apply(
                         cons.KLabel("'_Map_").apply(
-                                cons.KLabel("'_|->_").apply((K) cons.stringToId("n"), (K) cons.intToToken(10)),
+                                cons.KLabel("'_|->_").apply((K) cons.stringToId("n"), (K) cons.intToToken(200)),
                                 cons.KLabel("'_|->_").apply((K) cons.stringToId("s"), (K) cons.intToToken(0)))
                 ),
                 cons.KLabel("'<s>").apply()

--- a/k-distribution/src/test/java/org/kframework/kore/convertors/TstTinyOnKORE.java
+++ b/k-distribution/src/test/java/org/kframework/kore/convertors/TstTinyOnKORE.java
@@ -60,7 +60,7 @@ public class TstTinyOnKORE extends BaseTest {
                                 ))),
                 cons.KLabel("'<state>").apply(
                         cons.KLabel("'_Map_").apply(
-                                cons.KLabel("'_|->_").apply((K) cons.stringToId("n"), (K) cons.intToToken(100)),
+                                cons.KLabel("'_|->_").apply((K) cons.stringToId("n"), (K) cons.intToToken(10)),
                                 cons.KLabel("'_|->_").apply((K) cons.stringToId("s"), (K) cons.intToToken(0)))
                 ),
                 cons.KLabel("'<s>").apply()

--- a/k-distribution/src/test/java/org/kframework/kore/convertors/TstTinyOnKORE.java
+++ b/k-distribution/src/test/java/org/kframework/kore/convertors/TstTinyOnKORE.java
@@ -12,6 +12,7 @@ import org.kframework.tiny.Constructors;
 import org.kframework.tiny.FreeTheory;
 import org.kframework.tiny.K;
 import org.kframework.tiny.KApp;
+import org.kframework.tiny.KIndex$;
 import org.kframework.tiny.Rewriter;
 import org.kframework.tiny.Rule;
 import org.kframework.tiny.package$;
@@ -42,28 +43,27 @@ public class TstTinyOnKORE extends BaseTest {
 
         Constructors cons = new Constructors(module);
 
-        K program = cons.KLabel("'<top>").apply(
-                cons.KLabel("'<k>").apply(
-                        cons.KLabel("'while__").apply(
-                                cons.KLabel("'_<=_").apply((K) cons.intToToken(0),(K) cons.stringToId("n")),
-                                cons.KLabel("'__").apply(
-                                        cons.KLabel("'_=_;").apply(
+        K program = cons.KLabel("<top>").apply(
+                cons.KLabel("<k>").apply(
+                        cons.KLabel("while__").apply(
+                                cons.KLabel("_<=_").apply((K) cons.intToToken(0),(K) cons.stringToId("n")),
+                                cons.KLabel("__").apply(
+                                        cons.KLabel("_=_;").apply(
                                                 (K) cons.stringToId("s"),
-                                                cons.KLabel("'_+_").apply(
+                                                cons.KLabel("_+_").apply(
                                                         (K) cons.stringToId("s"),
                                                         (K) cons.stringToId("n"))),
-                                        cons.KLabel("'_=_;").apply(
+                                        cons.KLabel("_=_;").apply(
                                                 (K) cons.stringToId("n"),
-                                                cons.KLabel("'_+_").apply(
+                                                cons.KLabel("_+_").apply(
                                                         (K) cons.stringToId("n"),
                                                         (K) cons.intToToken(-1)))
                                 ))),
-                cons.KLabel("'<state>").apply(
-                        cons.KLabel("'_Map_").apply(
-                                cons.KLabel("'_|->_").apply((K) cons.stringToId("n"), (K) cons.intToToken(10)),
-                                cons.KLabel("'_|->_").apply((K) cons.stringToId("s"), (K) cons.intToToken(0)))
-                ),
-                cons.KLabel("'<s>").apply()
+                cons.KLabel("<state>").apply(
+                        cons.KLabel("_Map_").apply(
+                                cons.KLabel("_|->_").apply((K) cons.stringToId("n"), (K) cons.intToToken(10)),
+                                cons.KLabel("_|->_").apply((K) cons.stringToId("s"), (K) cons.intToToken(0)))
+                )
         );
 
 //        KApp program = cons.KApply(cons.KLabel("'<top>"),
@@ -78,7 +78,7 @@ public class TstTinyOnKORE extends BaseTest {
 
         System.out.println("module = " + module);
 
-        Rewriter rewriter = new Rewriter(module);
+        Rewriter rewriter = new Rewriter(module, KIndex$.MODULE$);
 
 //        long l = System.nanoTime();
 //        Set<K> results = rewriter.rewrite(program, Set());

--- a/k-distribution/src/test/java/org/kframework/kore/convertors/TstTinyOnKORE.java
+++ b/k-distribution/src/test/java/org/kframework/kore/convertors/TstTinyOnKORE.java
@@ -60,7 +60,7 @@ public class TstTinyOnKORE extends BaseTest {
                                 ))),
                 cons.KLabel("'<state>").apply(
                         cons.KLabel("'_Map_").apply(
-                                cons.KLabel("'_|->_").apply((K) cons.stringToId("n"), (K) cons.intToToken(200)),
+                                cons.KLabel("'_|->_").apply((K) cons.stringToId("n"), (K) cons.intToToken(10)),
                                 cons.KLabel("'_|->_").apply((K) cons.stringToId("s"), (K) cons.intToToken(0)))
                 ),
                 cons.KLabel("'<s>").apply()

--- a/k-distribution/src/test/resources/convertor-tests/complex-expected.k
+++ b/k-distribution/src/test/resources/convertor-tests/complex-expected.k
@@ -4,6 +4,6 @@ module TEST [org.kframework.attributes.Location(#token(Int,"3"),#token(Int,"1"),
   syntax Bool ::= #Bool [org.kframework.attributes.Location(#token(Int,"6"),#token(Int,"19"),#token(Int,"6"),#token(Int,"23"))]
   syntax #Bool ::= "true" [org.kframework.attributes.Location(#token(Int,"4"),#token(Int,"20"),#token(Int,"4"),#token(Int,"25"))]
   syntax #Bool ::= "false" [org.kframework.attributes.Location(#token(Int,"5"),#token(Int,"20"),#token(Int,"5"),#token(Int,"26"))]
-  rule #token(#Bool,"true")=>INJECTED-KLIST() requires '_andBool_(#token(Bool,"true"),#token(Bool,"true")) ensures #token(Bool,"true") [org.kframework.attributes.Location(#token(Int,"8"),#token(Int,"3"),#token(Int,"8"),#token(Int,"21"))]
-  rule #token(#Bool,"true")=>INJECTED-KLIST(#token(#Bool,"true")) requires '_andBool_(#token(Bool,"true"),#token(Bool,"true")) ensures #token(Bool,"true") [org.kframework.attributes.Location(#token(Int,"9"),#token(Int,"3"),#token(Int,"9"),#token(Int,"29"))]
+  rule #token(#Bool,"true")=>INJECTED-KLIST() requires _andBool_(#token(Bool,"true"),#token(Bool,"true")) ensures #token(Bool,"true") [org.kframework.attributes.Location(#token(Int,"8"),#token(Int,"3"),#token(Int,"8"),#token(Int,"21"))]
+  rule #token(#Bool,"true")=>INJECTED-KLIST(#token(#Bool,"true")) requires _andBool_(#token(Bool,"true"),#token(Bool,"true")) ensures #token(Bool,"true") [org.kframework.attributes.Location(#token(Int,"9"),#token(Int,"3"),#token(Int,"9"),#token(Int,"29"))]
 endmodule

--- a/k-distribution/src/test/resources/convertor-tests/complex-kilexpected.k
+++ b/k-distribution/src/test/resources/convertor-tests/complex-kilexpected.k
@@ -1,8 +1,8 @@
 // Copyright (c) 2014-2015 K Team. All Rights Reserved.
 DEF: null -> null
 module TEST
-  rule #token("#Bool", "true")() => INJECTED-KLIST(#token("#Bool", "true")()) requires '_andBool_(#token("Bool", "true")(),, #token("Bool", "true")())
-  rule #token("#Bool", "true")() => INJECTED-KLIST() requires '_andBool_(#token("Bool", "true")(),, #token("Bool", "true")())
+  rule #token("#Bool", "true")() => 'INJECTED-KLIST(#token("#Bool", "true")()) requires '_andBool_(#token("Bool", "true")(),, #token("Bool", "true")())
+  rule #token("#Bool", "true")() => 'INJECTED-KLIST() requires '_andBool_(#token("Bool", "true")(),, #token("Bool", "true")())
   syntax #Bool ::= "false"
 
   syntax #Bool ::= "true"
@@ -11,4 +11,3 @@ module TEST
 
 
 endmodule
-

--- a/k-distribution/src/test/resources/convertor-tests/configuration-expected.k
+++ b/k-distribution/src/test/resources/convertor-tests/configuration-expected.k
@@ -12,5 +12,5 @@ endmodule
 
 module TEST [org.kframework.attributes.Location(#token(Int,"4"),#token(Int,"1"),#token(Int,"7"),#token(Int,"9"))]
   imports INCLUDE [org.kframework.attributes.Location(#token(Int,"5"),#token(Int,"3"),#token(Int,"5"),#token(Int,"17"))]
-  Configuration(t(KBag(k(.K),env('.Map()),stack(KBag()))),#token(Bool,"true"),[org.kframework.attributes.Location(#token(Int,"6"),#token(Int,"17"),#token(Int,"6"),#token(Int,"108"))])
+  Configuration(t(KBag(k(.K),env(.Map()),stack(KBag()))),#token(Bool,"true"),[org.kframework.attributes.Location(#token(Int,"6"),#token(Int,"17"),#token(Int,"6"),#token(Int,"108"))])
 endmodule

--- a/k-distribution/src/test/resources/convertor-tests/context-expected.k
+++ b/k-distribution/src/test/resources/convertor-tests/context-expected.k
@@ -13,6 +13,6 @@ endmodule
 module TEST [org.kframework.attributes.Location(#token(Int,"5"),#token(Int,"1"),#token(Int,"13"),#token(Int,"9"))]
   syntax Exp ::= Exp "+" Exp [org.kframework.attributes.Location(#token(Int,"8"),#token(Int,"18"),#token(Int,"8"),#token(Int,"28"))]
   imports INCLUDE [org.kframework.attributes.Location(#token(Int,"6"),#token(Int,"3"),#token(Int,"6"),#token(Int,"17"))]
-  context '_+_(_,HOLE(#token(KItem,""))) requires #token(Bool,"true")
-  context '_+_(HOLE(#token(KItem,"")),_) requires #token(Bool,"true")
+  context _+_(_,HOLE(#token(KItem,""))) requires #token(Bool,"true")
+  context _+_(HOLE(#token(KItem,"")),_) requires #token(Bool,"true")
 endmodule

--- a/k-distribution/src/test/resources/convertor-tests/kapp-expected.k
+++ b/k-distribution/src/test/resources/convertor-tests/kapp-expected.k
@@ -1,15 +1,15 @@
 // Copyright (c) 2014-2015 K Team. All Rights Reserved.
 
 module TEST [org.kframework.attributes.Location(#token(Int,"3"),#token(Int,"1"),#token(Int,"18"),#token(Int,"9"))]
-  syntax Bools ::= Bools "," Bools [#klabel(#token(KString,"'_,_")) org.kframework.attributes.Location(#token(Int,"15"),#token(Int,"20"),#token(Int,"15"),#token(Int,"34")) userList(#token(KString,"Bools"))]
+  syntax Bools ::= Bools "," Bools [#klabel(#token(KString,"_,_")) org.kframework.attributes.Location(#token(Int,"15"),#token(Int,"20"),#token(Int,"15"),#token(Int,"34")) userList(#token(KString,"Bools"))]
   syntax Bools ::= Bool [org.kframework.attributes.Location(#token(Int,"15"),#token(Int,"20"),#token(Int,"15"),#token(Int,"34")) userList(#token(KString,"Bools"))]
-  syntax Bools ::= ".Bools" [#klabel(#token(KString,"'.List{\"'_,_\"}")) org.kframework.attributes.Location(#token(Int,"15"),#token(Int,"20"),#token(Int,"15"),#token(Int,"34")) userList(#token(KString,"Bools"))]
+  syntax Bools ::= ".Bools" [#klabel(#token(KString,".List{\"'_,_\"}")) org.kframework.attributes.Location(#token(Int,"15"),#token(Int,"20"),#token(Int,"15"),#token(Int,"34")) userList(#token(KString,"Bools"))]
   syntax Bool ::= #Bool [org.kframework.attributes.Location(#token(Int,"6"),#token(Int,"19"),#token(Int,"6"),#token(Int,"23"))]
   syntax Bool ::= "notBool" Bool [org.kframework.attributes.Location(#token(Int,"8"),#token(Int,"19"),#token(Int,"8"),#token(Int,"32"))]
   syntax #Bool ::= "true" [org.kframework.attributes.Location(#token(Int,"4"),#token(Int,"20"),#token(Int,"4"),#token(Int,"25"))]
   syntax #Bool ::= "false" [org.kframework.attributes.Location(#token(Int,"5"),#token(Int,"20"),#token(Int,"5"),#token(Int,"26"))]
-  rule 'notBool_(#token(#Bool,"true"))=>#token(#Bool,"false") requires '_andBool_(#token(Bool,"true"),#token(Bool,"true")) ensures #token(Bool,"true") [org.kframework.attributes.Location(#token(Int,"10"),#token(Int,"3"),#token(Int,"10"),#token(Int,"28"))]
-  rule 'notBool_(#token(#Bool,"false"))=>#token(#Bool,"true") requires '_andBool_(#token(Bool,"true"),#token(Bool,"true")) ensures #token(Bool,"true") [org.kframework.attributes.Location(#token(Int,"11"),#token(Int,"3"),#token(Int,"11"),#token(Int,"28"))]
-  rule 'notBool(#token(#Bool,"true"))=>#token(#Bool,"false") requires '_andBool_(#token(Bool,"true"),#token(Bool,"true")) ensures #token(Bool,"true") [org.kframework.attributes.Location(#token(Int,"13"),#token(Int,"3"),#token(Int,"13"),#token(Int,"30"))]
-  rule '_,_(#token(#Bool,"true"),#token(#Bool,"true"))=>'.List{"'_,_"}() requires '_andBool_(#token(Bool,"true"),#token(Bool,"true")) ensures #token(Bool,"true") [org.kframework.attributes.Location(#token(Int,"17"),#token(Int,"3"),#token(Int,"17"),#token(Int,"27"))]
+  rule notBool_(#token(#Bool,"true"))=>#token(#Bool,"false") requires _andBool_(#token(Bool,"true"),#token(Bool,"true")) ensures #token(Bool,"true") [org.kframework.attributes.Location(#token(Int,"10"),#token(Int,"3"),#token(Int,"10"),#token(Int,"28"))]
+  rule notBool_(#token(#Bool,"false"))=>#token(#Bool,"true") requires _andBool_(#token(Bool,"true"),#token(Bool,"true")) ensures #token(Bool,"true") [org.kframework.attributes.Location(#token(Int,"11"),#token(Int,"3"),#token(Int,"11"),#token(Int,"28"))]
+  rule notBool(#token(#Bool,"true"))=>#token(#Bool,"false") requires _andBool_(#token(Bool,"true"),#token(Bool,"true")) ensures #token(Bool,"true") [org.kframework.attributes.Location(#token(Int,"13"),#token(Int,"3"),#token(Int,"13"),#token(Int,"30"))]
+  rule _,_(#token(#Bool,"true"),#token(#Bool,"true"))=>.List{"'_,_"}() requires _andBool_(#token(Bool,"true"),#token(Bool,"true")) ensures #token(Bool,"true") [org.kframework.attributes.Location(#token(Int,"17"),#token(Int,"3"),#token(Int,"17"),#token(Int,"27"))]
 endmodule

--- a/k-distribution/src/test/resources/convertor-tests/kore_imp_tiny-tiny-expected.txt
+++ b/k-distribution/src/test/resources/convertor-tests/kore_imp_tiny-tiny-expected.txt
@@ -1,2 +1,2 @@
 // Copyright (c) 2014-2015 K Team. All Rights Reserved.
-'<top>('<k>(~>()),'<state>('_Map_(Tuple2(x:Id,11),Tuple2(y:Id,2))))
+'<top>('<k>(~>()),'<state>('_Map_(Tuple2(n:Id,-1),Tuple2(s:Id,55))))

--- a/k-distribution/src/test/resources/convertor-tests/kore_imp_tiny.k
+++ b/k-distribution/src/test/resources/convertor-tests/kore_imp_tiny.k
@@ -42,9 +42,9 @@ module TEST
 
 
   syntax Map ::= Map Map        [klabel('_Map_), function, hook(Map:__)]
-  syntax Map ::= ".Map"         [klabel('.Map),  function, hook(Map:.Map)]
+  syntax Map ::= ".Map"         [klabel('_Map_),  function, hook(Map:.Map)]
   syntax Map ::= K "|->" K      [klabel('_|->_), function, hook(Map:_|->_)]
-  syntax priorities '_|->_ > '_Map_ '.Map
+  syntax priorities '_|->_ > '_Map_
 
   syntax Set ::= "keys" "(" Map ")"     [klabel('keys), function, hook(Map:keys)]
   syntax Bool ::= K "in" Set            [klabel('_in_), function, hook(Set:in)]
@@ -169,7 +169,7 @@ module TEST
 
   // Pgm
   rule
-    '<top>('<k>('int_;_('_`,_(X:Id,, Xs:Ids),, S:Stmt) ~> K:K),, '<state>('_Map_(Rho:Map,, '.Map(.KList))))
+    '<top>('<k>('int_;_('_`,_(X:Id,, Xs:Ids),, S:Stmt) ~> K:K),, '<state>('_Map_(Rho:Map,, '_Map_(.KList))))
   =>
     '<top>('<k>('int_;_(Xs:Ids,,               S:Stmt) ~> K:K),, '<state>('_Map_(Rho:Map,, '_|->_(X:Id,, 0))))
   when 'notBool_('_in_(X:Id,, 'keys(Rho:Map)))

--- a/k-distribution/src/test/resources/convertor-tests/kore_imp_tiny.k
+++ b/k-distribution/src/test/resources/convertor-tests/kore_imp_tiny.k
@@ -24,7 +24,6 @@ module TEST
 
   syntax priority '_==K_ '_=/=K_ > 'notBool_ > '_andBool_
 
-
   syntax Int ::= Int "+Int" Int     [klabel('_+Int_), function, hook(#INT:_+Int_), left]
   syntax Int ::= Int "-Int" Int     [klabel('_-Int_), function, hook(#INT:_-Int_), left]
   syntax Int ::= Int "*Int" Int     [klabel('_*Int_), function, hook(#INT:_*Int_), left]
@@ -191,7 +190,7 @@ module TEST
       '<top>('<k>(C:KResult ~> 'if__else_([],,  S:Stmt,, _:Stmt) ~> K:K),, SC:StateCell)
     =>
       '<top>('<k>('if__else_(C,,  S:Stmt,, _:Stmt) ~> K:K),, SC:StateCell)
-  [heat]
+  [cool]
 
   // '_/_
   rule

--- a/k-distribution/src/test/resources/convertor-tests/ruleWithRequiresEnsures-expected.k
+++ b/k-distribution/src/test/resources/convertor-tests/ruleWithRequiresEnsures-expected.k
@@ -2,7 +2,7 @@
 
 module TEST [org.kframework.attributes.Location(#token(Int,"3"),#token(Int,"1"),#token(Int,"9"),#token(Int,"9"))]
   syntax Exp [org.kframework.attributes.Location(#token(Int,"4"),#token(Int,"3"),#token(Int,"4"),#token(Int,"12"))]
-  rule A=>A requires '_andBool_(A,isExp(A)) ensures A [org.kframework.attributes.Location(#token(Int,"8"),#token(Int,"3"),#token(Int,"8"),#token(Int,"38"))]
-  rule A=>A requires '_andBool_(A,isExp(A)) ensures #token(Bool,"true") [org.kframework.attributes.Location(#token(Int,"6"),#token(Int,"3"),#token(Int,"6"),#token(Int,"28"))]
-  rule A=>A requires '_andBool_(#token(Bool,"true"),isExp(A)) ensures A [org.kframework.attributes.Location(#token(Int,"7"),#token(Int,"3"),#token(Int,"7"),#token(Int,"27"))]
+  rule A=>A requires _andBool_(A,isExp(A)) ensures A [org.kframework.attributes.Location(#token(Int,"8"),#token(Int,"3"),#token(Int,"8"),#token(Int,"38"))]
+  rule A=>A requires _andBool_(A,isExp(A)) ensures #token(Bool,"true") [org.kframework.attributes.Location(#token(Int,"6"),#token(Int,"3"),#token(Int,"6"),#token(Int,"28"))]
+  rule A=>A requires _andBool_(#token(Bool,"true"),isExp(A)) ensures A [org.kframework.attributes.Location(#token(Int,"7"),#token(Int,"3"),#token(Int,"7"),#token(Int,"27"))]
 endmodule

--- a/k-distribution/src/test/resources/convertor-tests/simpleRule-expected.k
+++ b/k-distribution/src/test/resources/convertor-tests/simpleRule-expected.k
@@ -2,5 +2,5 @@
 
 module TEST [org.kframework.attributes.Location(#token(Int,"3"),#token(Int,"1"),#token(Int,"6"),#token(Int,"9"))]
   syntax Exp [org.kframework.attributes.Location(#token(Int,"4"),#token(Int,"3"),#token(Int,"4"),#token(Int,"12"))]
-  rule A=>A requires '_andBool_(#token(Bool,"true"),isExp(A)) ensures #token(Bool,"true") [org.kframework.attributes.Location(#token(Int,"5"),#token(Int,"3"),#token(Int,"5"),#token(Int,"17"))]
+  rule A=>A requires _andBool_(#token(Bool,"true"),isExp(A)) ensures #token(Bool,"true") [org.kframework.attributes.Location(#token(Int,"5"),#token(Int,"3"),#token(Int,"5"),#token(Int,"17"))]
 endmodule

--- a/k-distribution/src/test/resources/convertor-tests/syntaxWithPriorities-expected.k
+++ b/k-distribution/src/test/resources/convertor-tests/syntaxWithPriorities-expected.k
@@ -1,9 +1,9 @@
 // Copyright (c) 2014-2015 K Team. All Rights Reserved.
 
 module TEST [org.kframework.attributes.Location(#token(Int,"3"),#token(Int,"1"),#token(Int,"13"),#token(Int,"9"))]
-  syntax priority 'x > 'y 'z > 't > 'u
-  syntax associativity right 'y
-  syntax associativity left 'x
+  syntax priority x > y z > t > u
+  syntax associativity right y
+  syntax associativity left x
   syntax Foo ::= "z" [org.kframework.attributes.Location(#token(Int,"6"),#token(Int,"18"),#token(Int,"6"),#token(Int,"20"))]
   syntax Foo ::= "y" [org.kframework.attributes.Location(#token(Int,"5"),#token(Int,"18"),#token(Int,"5"),#token(Int,"40")) someattribute(#token(AttributeValue,""))]
   syntax Foo ::= "x" [org.kframework.attributes.Location(#token(Int,"4"),#token(Int,"18"),#token(Int,"4"),#token(Int,"20"))]

--- a/k-distribution/src/test/resources/convertor-tests/userList-expected.k
+++ b/k-distribution/src/test/resources/convertor-tests/userList-expected.k
@@ -1,8 +1,8 @@
 // Copyright (c) 2014-2015 K Team. All Rights Reserved.
 
 module TEST [org.kframework.attributes.Location(#token(Int,"3"),#token(Int,"1"),#token(Int,"6"),#token(Int,"9"))]
-  syntax Stxs ::= Stxs "," Stxs [#klabel(#token(KString,"'_,_")) foo(#token(AttributeValue,"")) org.kframework.attributes.Location(#token(Int,"5"),#token(Int,"21"),#token(Int,"5"),#token(Int,"42")) userList(#token(KString,"Stxs"))]
+  syntax Stxs ::= Stxs "," Stxs [#klabel(#token(KString,"_,_")) foo(#token(AttributeValue,"")) org.kframework.attributes.Location(#token(Int,"5"),#token(Int,"21"),#token(Int,"5"),#token(Int,"42")) userList(#token(KString,"Stxs"))]
   syntax Stxs ::= Stx [foo(#token(AttributeValue,"")) org.kframework.attributes.Location(#token(Int,"5"),#token(Int,"21"),#token(Int,"5"),#token(Int,"42")) userList(#token(KString,"Stxs"))]
-  syntax Stxs ::= ".Stxs" [#klabel(#token(KString,"'.List{\"'_,_\"}")) foo(#token(AttributeValue,"")) org.kframework.attributes.Location(#token(Int,"5"),#token(Int,"21"),#token(Int,"5"),#token(Int,"42")) userList(#token(KString,"Stxs"))]
+  syntax Stxs ::= ".Stxs" [#klabel(#token(KString,".List{\"'_,_\"}")) foo(#token(AttributeValue,"")) org.kframework.attributes.Location(#token(Int,"5"),#token(Int,"21"),#token(Int,"5"),#token(Int,"42")) userList(#token(KString,"Stxs"))]
   syntax Stx ::= "1" [org.kframework.attributes.Location(#token(Int,"4"),#token(Int,"20"),#token(Int,"4"),#token(Int,"22"))]
 endmodule

--- a/k-distribution/src/test/resources/convertor-tests/userListNonEmpty-expected.k
+++ b/k-distribution/src/test/resources/convertor-tests/userListNonEmpty-expected.k
@@ -1,7 +1,7 @@
 // Copyright (c) 2014-2015 K Team. All Rights Reserved.
 
 module TEST [org.kframework.attributes.Location(#token(Int,"3"),#token(Int,"1"),#token(Int,"6"),#token(Int,"9"))]
-  syntax Stxs ::= Stxs "," Stxs [#klabel(#token(KString,"'_,_")) org.kframework.attributes.Location(#token(Int,"5"),#token(Int,"19"),#token(Int,"5"),#token(Int,"33")) userList(#token(KString,"Stxs"))]
+  syntax Stxs ::= Stxs "," Stxs [#klabel(#token(KString,"_,_")) org.kframework.attributes.Location(#token(Int,"5"),#token(Int,"19"),#token(Int,"5"),#token(Int,"33")) userList(#token(KString,"Stxs"))]
   syntax Stxs ::= Stx [org.kframework.attributes.Location(#token(Int,"5"),#token(Int,"19"),#token(Int,"5"),#token(Int,"33")) userList(#token(KString,"Stxs"))]
   syntax Stx ::= "1" [org.kframework.attributes.Location(#token(Int,"4"),#token(Int,"18"),#token(Int,"4"),#token(Int,"20"))]
 endmodule

--- a/kernel/src/main/java/org/kframework/kore/convertors/KILtoKORE.java
+++ b/kernel/src/main/java/org/kframework/kore/convertors/KILtoKORE.java
@@ -187,7 +187,7 @@ public class KILtoKORE extends KILTransformation<Object> {
         Set<Tuple2<K, Sort>> expSorts = gatherSorts.apply(body);
         System.out.println("gatherSorts = " + expSorts);
 
-        BinaryOperator<K> makeAnd = (a, b) -> KApply(KLabel("'_andBool_"), KList(a, b));
+        BinaryOperator<K> makeAnd = (a, b) -> KApply(KLabel("_andBool_"), KList(a, b));
         K sortPredicates = expSorts
                 .stream()
                 .map(t -> (K) KApply(KLabel("is" + t._2().name()), KList(t._1())))
@@ -229,7 +229,7 @@ public class KILtoKORE extends KILTransformation<Object> {
     }
 
     public scala.collection.immutable.Set<Tag> toTags(List<KLabelConstant> labels) {
-        return immutable(labels.stream().map(l -> Tag(l.getLabel())).collect(Collectors.toSet()));
+        return immutable(labels.stream().map(l -> Tag(dropQuote(l.getLabel()))).collect(Collectors.toSet()));
     }
 
     public org.kframework.definition.Sentence apply(Import s) {
@@ -323,20 +323,27 @@ public class KILtoKORE extends KILTransformation<Object> {
                 kilProductionId);
         prod1 = Production(sort,
                 Seq(NonTerminal(sort), Terminal(userList.getSeparator()), NonTerminal(sort)),
-                attrsWithKilProductionId.add("#klabel", p.getKLabel()));
+                attrsWithKilProductionId.add("#klabel", dropQuote(p.getKLabel())));
 
         // lst ::= elem
         prod2 = Production(sort, Seq(NonTerminal(elementSort)), attrsWithKilProductionId);
 
         // lst ::= .UserList
         prod3 = Production(sort, Seq(Terminal("." + sort.toString())),
-                attrsWithKilProductionId.add("#klabel", p.getTerminatorKLabel()));
+                attrsWithKilProductionId.add("#klabel", dropQuote(p.getTerminatorKLabel())));
 
         res.add(prod1);
         res.add(prod2);
         if (!nonEmpty) {
             res.add(prod3);
         }
+    }
+
+    public String dropQuote(String s) {
+        if (s.startsWith("'"))
+            return s.substring(1);
+        else
+            return s;
     }
 
     public org.kframework.kore.Sort apply(org.kframework.kil.Sort sort) {

--- a/kernel/src/main/java/org/kframework/kore/convertors/KOREtoKIL.java
+++ b/kernel/src/main/java/org/kframework/kore/convertors/KOREtoKIL.java
@@ -390,7 +390,7 @@ public class KOREtoKIL implements Function<Definition, org.kframework.kil.Defini
     }
 
     public org.kframework.kil.KLabelConstant convertTag(Tag tag) {
-        return new org.kframework.kil.KLabelConstant(tag.name());
+        return new org.kframework.kil.KLabelConstant(addQuote(tag.name()));
     }
 
     public org.kframework.kil.ProductionItem convertProdItem(ProductionItem prodItem) {
@@ -438,6 +438,13 @@ public class KOREtoKIL implements Function<Definition, org.kframework.kil.Defini
 
         });
         return kilAttributes;
+    }
+
+    private String addQuote(String name) {
+        if (name.startsWith("is") || name.startsWith("'") || name == "HOLE")
+            return name;
+        else
+            return "'" + name;
     }
 
     public org.kframework.kil.Term convertConfBody(K k) {
@@ -559,10 +566,9 @@ public class KOREtoKIL implements Function<Definition, org.kframework.kil.Defini
     }
 
     public org.kframework.kil.Term convertKApply(KApply kApply) {
-        KLabel label = kApply.klabel();
+        String label = addQuote(kApply.klabel().name());
         List<K> contents = kApply.klist().items();
-        if (label.name() == labels.Hole().name()) {
-            System.out.println("label = " + label);
+        if (label == labels.Hole().name()) {
             Sort sort = ((KToken) contents.get(0)).sort();
             return new org.kframework.kil.Hole(org.kframework.kil.Sort.of(sort.name()));
         } else {
@@ -573,7 +579,7 @@ public class KOREtoKIL implements Function<Definition, org.kframework.kil.Defini
                     .collect(Collectors.toList());
 
             if (kilProductionIdP) {
-                KLabelConstant kAppLabel = KLabelConstant.of(label.name());
+                KLabelConstant kAppLabel = KLabelConstant.of(label);
                 return new org.kframework.kil.KApp(kAppLabel, new org.kframework.kil.KList(
                         kilTerms));
             } else {
@@ -585,7 +591,7 @@ public class KOREtoKIL implements Function<Definition, org.kframework.kil.Defini
                             + " with id: " + kilProductionId);
                 }
 
-                return new org.kframework.kil.TermCons(org.kframework.kil.Sort.of(label.name()),
+                return new org.kframework.kil.TermCons(org.kframework.kil.Sort.of(label),
                         kilTerms, production);
             }
         }

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -23,7 +23,7 @@ case class DivergingAttributesForTheSameKLabel(ps: Set[Production])
 case class Definition(requires: Set[Require], modules: Set[Module], att: Att = Att())
   extends DefinitionToString with OuterKORE {
 
-  def getModule(name: String): Option[Module] = modules find { case Module(`name`, _, _, _) => true; case _ => false }
+  def getModule(name: String): Option[Module] = modules find {case Module(`name`, _, _, _) => true; case _ => false }
 }
 
 case class Require(file: java.io.File) extends OuterKORE
@@ -33,19 +33,21 @@ case class Module(name: String, imports: Set[Module], localSentences: Set[Senten
 
   val sentences: Set[Sentence] = localSentences | (imports flatMap { _.sentences })
 
-  val productions: Set[Production] = sentences collect { case p: Production => p }
+  val productions: Set[Production] = sentences collect {case p: Production => p }
 
   val productionsFor: Map[KLabel, Set[Production]] =
     productions
-      .collect({ case p if p.klabel != None => p })
+      .collect({case p if p.klabel != None => p })
       .groupBy(_.klabel.get)
-      .map { case (l, ps) => (l, ps) }
+      .map {case (l, ps) => (l, ps) }
 
   val sortFor: Map[KLabel, Sort] = productionsFor mapValues { _.head.sort }
 
+  println(sortFor)
+
   def isSort(klabel: KLabel, s: Sort) = subsorts.<(sortFor(klabel), s)
 
-  val rules: Set[Rule] = sentences collect { case r: Rule => r }
+  val rules: Set[Rule] = sentences collect {case r: Rule => r }
 
   // Check that productions with the same #klabel have identical attributes
   //  productionsFor.foreach {
@@ -61,12 +63,12 @@ case class Module(name: String, imports: Set[Module], localSentences: Set[Senten
       ps: Set[Production] =>
         ps.map {
           p: Production =>
-            val params: Seq[Sort] = p.items collect { case NonTerminal(sort) => sort }
+            val params: Seq[Sort] = p.items collect {case NonTerminal(sort) => sort }
             (params, p.sort)
         }
     }
 
-  val sortDeclarations: Set[SyntaxSort] = sentences.collect({ case s: SyntaxSort => s })
+  val sortDeclarations: Set[SyntaxSort] = sentences.collect({case s: SyntaxSort => s })
 
   val definedSorts: Set[Sort] = (productions map { _.sort }) ++ (sortDeclarations map { _.sort })
 
@@ -76,8 +78,8 @@ case class Module(name: String, imports: Set[Module], localSentences: Set[Senten
 
   private lazy val expressedPriorities: Set[(Tag, Tag)] =
     sentences
-      .collect({ case SyntaxPriority(ps, _) => ps })
-      .map { ps: Seq[Set[Tag]] =>
+      .collect({case SyntaxPriority(ps, _) => ps })
+      .map {ps: Seq[Set[Tag]] =>
       val pairSetAndPenultimateTagSet = ps.foldLeft((Set[(Tag, Tag)](), Set[Tag]())) {
         case ((all, prev), current) =>
           val newPairs = for (a <- prev; b <- current) yield (a, b)
@@ -92,8 +94,8 @@ case class Module(name: String, imports: Set[Module], localSentences: Set[Senten
 
   private def buildAssoc(side: Associativity.Value): Set[(Tag, Tag)] = {
     sentences
-      .collect({ case SyntaxAssociativity(`side` | Associativity.NonAssoc, ps, _) => ps })
-      .map { ps: Set[Tag] =>
+      .collect({case SyntaxAssociativity(`side` | Associativity.NonAssoc, ps, _) => ps })
+      .map {ps: Set[Tag] =>
       for (a <- ps; b <- ps) yield (a, b)
     }.flatten
   }
@@ -103,7 +105,7 @@ case class Module(name: String, imports: Set[Module], localSentences: Set[Senten
   // check that non-terminals have a defined sort
   private val nonTerminalsWithUndefinedSort = sentences flatMap {
     case Production(_, items, _) =>
-      items collect { case nt: NonTerminal if !definedSorts.contains(nt.sort) => nt }
+      items collect {case nt: NonTerminal if !definedSorts.contains(nt.sort) => nt }
     case _ => Set()
   }
   if (!nonTerminalsWithUndefinedSort.isEmpty)
@@ -121,7 +123,7 @@ trait Sentence {
 // deprecated
 case class Context(body: K, requires: K, att: Att = Att()) extends Sentence with OuterKORE with ContextToString
 
-case class Rule(body: K, requires: K, ensures: K, att: Att) extends Sentence with RuleToString with OuterKORE
+case class Rule(body: K, requires: K, ensures: K, att: Att = Att()) extends Sentence with RuleToString with OuterKORE
 
 case class ModuleComment(comment: String, att: Att = Att()) extends Sentence with OuterKORE
 

--- a/kore/src/main/scala/org/kframework/kore/Constructors.scala
+++ b/kore/src/main/scala/org/kframework/kore/Constructors.scala
@@ -18,7 +18,7 @@ trait Constructors[KK <: K] {
   val injectedKListLabel = "INJECTED-KLIST"
 
   // default methods:
-  @annotation.varargs def KList(items: KK*): KList = KList(items.asJava)
+  @annotation.varargs def KList[KKK <: KK](items: KKK*): KList = KList(items.asJava)
   @annotation.varargs def KApply(klabel: KLabel, items: KK*): KK = KApply(klabel, KList(items.asJava), Att())
   @annotation.varargs def KSequence(list: KK*): KK = KSequence(list.toList.asJava, Att())
   def KVariable(name: String): KVariable with KK = KVariable(name, Att())

--- a/kore/src/main/scala/org/kframework/kore/Constructors.scala
+++ b/kore/src/main/scala/org/kframework/kore/Constructors.scala
@@ -8,9 +8,9 @@ trait Constructors[KK <: K] {
   def KLabel(name: String): KLabel
   def Sort(name: String): Sort
   def KList[KKK <: KK](items: java.util.List[KKK]): KList
-  def KToken(sort: Sort, s: String, att: Att): KToken with KK
-  def KApply(klabel: KLabel, klist: KList, att: Att): KApply with KK
-  def KSequence[KKK <: KK](items: java.util.List[KKK], att: Att): KSequence with KK
+  def KToken(sort: Sort, s: String, att: Att): KK
+  def KApply(klabel: KLabel, klist: KList, att: Att): KK
+  def KSequence[KKK <: KK](items: java.util.List[KKK], att: Att): KK
   def KVariable(name: String, att: Att): KVariable with KK
   def KRewrite(left: K, right: K, att: Att): KRewrite with KK
   def InjectedKLabel(klabel: KLabel, att: Att): InjectedKLabel
@@ -18,9 +18,9 @@ trait Constructors[KK <: K] {
   val injectedKListLabel = "INJECTED-KLIST"
 
   // default methods:
-  @annotation.varargs def KList[KKK <: KK](items: KKK*): KList = KList(items.asJava)
-  @annotation.varargs def KApply(klabel: KLabel, items: KK*): KApply with KK = KApply(klabel, KList(items.asJava), Att())
-  @annotation.varargs def KSequence(list: KK*): KSequence with KK = KSequence(list.toList.asJava, Att())
+  @annotation.varargs def KList(items: KK*): KList = KList(items.asJava)
+  @annotation.varargs def KApply(klabel: KLabel, items: KK*): KK = KApply(klabel, KList(items.asJava), Att())
+  @annotation.varargs def KSequence(list: KK*): KK = KSequence(list.toList.asJava, Att())
   def KVariable(name: String): KVariable with KK = KVariable(name, Att())
 }
 

--- a/kore/src/main/scala/org/kframework/kore/ScalaSugar.scala
+++ b/kore/src/main/scala/org/kframework/kore/ScalaSugar.scala
@@ -31,5 +31,5 @@ trait ScalaSugar[K <: kore.K] {
   }
 
   def KList[KK <: K](ks: Seq[KK]): KList = KList(ks.asJava)
-  def KApply[KK <: K](klabel: KLabel, ks: Seq[KK], att: Att = Att()): KApply = KApply(klabel, KList(ks), att)
+  def KApply[KK <: K](klabel: KLabel, ks: Seq[KK], att: Att = Att()): K = KApply(klabel, KList(ks), att)
 }

--- a/kore/src/main/scala/org/kframework/kore/ScalaSugar.scala
+++ b/kore/src/main/scala/org/kframework/kore/ScalaSugar.scala
@@ -26,6 +26,11 @@ trait ScalaSugar[K <: kore.K] {
     def ~>(other: K) = KSequence(Seq(k, other).asJava, Att())
     def ==>(other: K) = KRewrite(k, other, Att())
     def +(other: K) = KLabel("+")(k, other)
+    def -(other: K) = KLabel("-")(k, other)
+    def *(other: K) = KLabel("*")(k, other)
+    def /(other: K) = KLabel("/")(k, other)
+    def &(other: K) = KLabel("&")(k, other)
+    def ~(other: K) = KLabel("~")(k, other)
     def &&(other: K) = KLabel(Labels.And)(k, other)
     def ||(other: K) = KLabel(Labels.Or)(k, other)
   }

--- a/tiny/pom.xml
+++ b/tiny/pom.xml
@@ -27,6 +27,11 @@
       <artifactId>guava</artifactId>
       <version>18.0</version>
     </dependency>
+    <dependency>
+      <groupId>io.github.nicolasstucki</groupId>
+      <artifactId>multisets_2.11</artifactId>
+      <version>0.2</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tiny/src/main/scala/org/kframework/tiny/Constructors.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/Constructors.scala
@@ -18,6 +18,8 @@ class Constructors(module: definition.Module) extends kore.Constructors[K] with 
     case "#K-EQUAL:_==K_" => Equals
     case "#BOOL:notBool_" => Not //NativeUnaryOpLabel("notBool_", Att(), (x: Boolean) => !x, Sorts.Bool)
     case "#INT:_+Int_" => NativeBinaryOpLabel("_+Int_", Att(), (x: Int, y: Int) => x + y, Sorts.Int)
+    case "#INT:_-Int_" => NativeBinaryOpLabel("_-Int_", Att(), (x: Int, y: Int) => x - y, Sorts.Int)
+    case "#INT:_*Int_" => NativeBinaryOpLabel("_*Int_", Att(), (x: Int, y: Int) => x * y, Sorts.Int)
     case "#INT:_/Int_" => NativeBinaryOpLabel("_/Int_", Att(), (x: Int, y: Int) => x / y, Sorts.Int)
     case "#INT:_<=Int_" => NativeBinaryOpLabel(labelString, Att(), (x: Int, y: Int) => x <= y, Sorts.Bool)
     case "Map:.Map" => KMapAppLabel("'_Map_")

--- a/tiny/src/main/scala/org/kframework/tiny/Constructors.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/Constructors.scala
@@ -67,11 +67,14 @@ class Constructors(module: definition.Module) extends kore.Constructors[K] with 
 
   override def Sort(name: String): kore.Sort = KORE.Sort(name)
 
-  override def KToken(sort: kore.Sort, s: String, att: Att): KTok = {
+  override def KToken(sort: kore.Sort, s: String, att: Att): K = {
     sort match {
       case Sorts.KString => TypedKTok(sort, s)
       case Sorts.Int => TypedKTok(sort, s.toInt)
-      case Sorts.Bool => val t = TypedKTok(sort, s.toBoolean); t.isNormal = false; t
+      case Sorts.Bool => s match {
+        case "true" => And()
+        case "false" => Or()
+      }
       case _ => RegularKTok(sort, s)
     }
   }

--- a/tiny/src/main/scala/org/kframework/tiny/Constructors.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/Constructors.scala
@@ -4,7 +4,7 @@ import org.kframework.attributes._
 import org.kframework.builtin.Sorts
 import org.kframework.kore.{Constructors => basic, _}
 import org.kframework.meta.{Down, Up}
-import org.kframework.tiny.builtin.{KMapAppLabel, MapKeys, Tuple2Label}
+import org.kframework.tiny.builtin.{BagLabel, KMapAppLabel, MapKeys, Tuple2Label}
 import org.kframework.{definition, kore, tiny}
 
 import scala.collection.JavaConverters._
@@ -25,7 +25,8 @@ class Constructors(module: definition.Module) extends kore.Constructors[K] with 
     case "Map:_|->_" => Tuple2Label
     case "Map:keys" => MapKeys
     case "Set:in" => RegularKAppLabel("???in???", Att())
-    case "#BOOL:_andBool_" =>  And //NativeBinaryOpLabel("_andBool_", Att(), (x: Boolean, y: Boolean) => x && y, Sorts.Bool)
+    case "#BOOL:_andBool_" => And //NativeBinaryOpLabel("_andBool_", Att(), (x: Boolean, y: Boolean) => x && y, Sorts
+    // .Bool)
     case "#BOOL:_orBool_" => Or //NativeBinaryOpLabel("_orBool_", Att(), (x: Boolean, y: Boolean) => x || y, Sorts.Int)
   }
 
@@ -40,7 +41,10 @@ class Constructors(module: definition.Module) extends kore.Constructors[K] with 
     } else {
       val att = module.attributesFor(KORE.KLabel(name))
       if (att.contains("assoc"))
-        RegularKAssocAppLabel(name, att)
+        if (att.contains("comm"))
+          BagLabel(name, att)
+        else
+          RegularKAssocAppLabel(name, att)
       else
         att.get[String]("hook").map(hookMappings(_, name)).getOrElse { RegularKAppLabel(name, att) }
     }

--- a/tiny/src/main/scala/org/kframework/tiny/Constructors.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/Constructors.scala
@@ -71,7 +71,7 @@ class Constructors(module: definition.Module) extends kore.Constructors[K] with 
     sort match {
       case Sorts.KString => TypedKTok(sort, s)
       case Sorts.Int => TypedKTok(sort, s.toInt)
-      case Sorts.Bool => TypedKTok(sort, s.toBoolean)
+      case Sorts.Bool => val t = TypedKTok(sort, s.toBoolean); t.isNormal = false; t
       case _ => RegularKTok(sort, s)
     }
   }

--- a/tiny/src/main/scala/org/kframework/tiny/Constructors.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/Constructors.scala
@@ -48,9 +48,9 @@ class Constructors(module: definition.Module) extends kore.Constructors[K] with 
     uniqueLabelCache.getOrElseUpdate(res.name, res)
   }
 
-  override def KApply(klabel: kore.KLabel, klist: kore.KList, att: Att): KApp = {
+  override def KApply(klabel: kore.KLabel, klist: kore.KList, att: Att): K = {
     val x: Label = convert(klabel)
-    x(klist.items.asScala.toSeq map convert, att).asInstanceOf[KApp]
+    x(klist.items.asScala.toSeq map convert, att)
   }
 
   def KApply(klabel: kore.KLabel, list: List[tiny.K], att: Att): KApp = {
@@ -60,8 +60,8 @@ class Constructors(module: definition.Module) extends kore.Constructors[K] with 
 
   def KApply(klabel: kore.KLabel, list: List[tiny.K]): KApp = KApply(klabel, list, Att())
 
-  override def KSequence[KK <: kore.K](items: java.util.List[KK], att: Att): KSeq =
-    KSeq(items.asScala.toSeq map convert, att).asInstanceOf[KSeq]
+  override def KSequence[KK <: kore.K](items: java.util.List[KK], att: Att): K =
+    KSeq(items.asScala.toSeq map convert, att)
 
   override def KVariable(name: String, att: Att): KVar = KVar(name, att)
 

--- a/tiny/src/main/scala/org/kframework/tiny/Constructors.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/Constructors.scala
@@ -16,7 +16,7 @@ class Constructors(module: definition.Module) extends kore.Constructors[K] with 
   // separate the hook mappings at some point
   def hookMappings(hook: String, labelString: String) = hook match {
     case "#K-EQUAL:_==K_" => Equals
-    case "#BOOL:notBool_" => Not
+    case "#BOOL:notBool_" => Not //NativeUnaryOpLabel("notBool_", Att(), (x: Boolean) => !x, Sorts.Bool)
     case "#INT:_+Int_" => NativeBinaryOpLabel("_+Int_", Att(), (x: Int, y: Int) => x + y, Sorts.Int)
     case "#INT:_/Int_" => NativeBinaryOpLabel("_/Int_", Att(), (x: Int, y: Int) => x / y, Sorts.Int)
     case "#INT:_<=Int_" => NativeBinaryOpLabel(labelString, Att(), (x: Int, y: Int) => x <= y, Sorts.Bool)
@@ -25,8 +25,8 @@ class Constructors(module: definition.Module) extends kore.Constructors[K] with 
     case "Map:_|->_" => Tuple2Label
     case "Map:keys" => MapKeys
     case "Set:in" => RegularKAppLabel("???in???", Att())
-    case "#BOOL:_andBool_" => And
-    case "#BOOL:_orBool_" => Or
+    case "#BOOL:_andBool_" =>  And //NativeBinaryOpLabel("_andBool_", Att(), (x: Boolean, y: Boolean) => x && y, Sorts.Bool)
+    case "#BOOL:_orBool_" => Or //NativeBinaryOpLabel("_orBool_", Att(), (x: Boolean, y: Boolean) => x || y, Sorts.Int)
   }
 
   val uniqueLabelCache = collection.mutable.Map[String, Label]()

--- a/tiny/src/main/scala/org/kframework/tiny/Constructors.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/Constructors.scala
@@ -17,13 +17,13 @@ class Constructors(module: definition.Module) extends kore.Constructors[K] with 
   def hookMappings(hook: String, labelString: String) = hook match {
     case "#K-EQUAL:_==K_" => Equals
     case "#BOOL:notBool_" => Not //NativeUnaryOpLabel("notBool_", Att(), (x: Boolean) => !x, Sorts.Bool)
-    case "#INT:_+Int_" => NativeBinaryOpLabel("_+Int_", Att(), (x: Int, y: Int) => x + y, Sorts.Int)
-    case "#INT:_-Int_" => NativeBinaryOpLabel("_-Int_", Att(), (x: Int, y: Int) => x - y, Sorts.Int)
-    case "#INT:_*Int_" => NativeBinaryOpLabel("_*Int_", Att(), (x: Int, y: Int) => x * y, Sorts.Int)
-    case "#INT:_/Int_" => NativeBinaryOpLabel("_/Int_", Att(), (x: Int, y: Int) => x / y, Sorts.Int)
+    case "#INT:_+Int_" => NativeBinaryOpLabel(labelString, Att(), (x: Int, y: Int) => x + y, Sorts.Int)
+    case "#INT:_-Int_" => NativeBinaryOpLabel(labelString, Att(), (x: Int, y: Int) => x - y, Sorts.Int)
+    case "#INT:_*Int_" => NativeBinaryOpLabel(labelString, Att(), (x: Int, y: Int) => x * y, Sorts.Int)
+    case "#INT:_/Int_" => NativeBinaryOpLabel(labelString, Att(), (x: Int, y: Int) => x / y, Sorts.Int)
     case "#INT:_<=Int_" => NativeBinaryOpLabel(labelString, Att(), (x: Int, y: Int) => x <= y, Sorts.Bool)
-    case "Map:.Map" => KMapAppLabel("'_Map_")
-    case "Map:__" => KMapAppLabel("'_Map_")
+    case "Map:.Map" => KMapAppLabel(labelString)
+    case "Map:__" => KMapAppLabel(labelString)
     case "Map:_|->_" => Tuple2Label
     case "Map:keys" => MapKeys
     case "Set:in" => RegularKAppLabel("???in???", Att())

--- a/tiny/src/main/scala/org/kframework/tiny/Rewriter.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/Rewriter.scala
@@ -6,10 +6,6 @@ import org.kframework.kore.Unapply.KLabel
 
 import scala.collection.parallel.ParIterable
 
-case class State(k: K) {
-  var from: Option[Seq[Rule]] = None
-}
-
 class Rewriter(module: definition.Module) {
   val cons = new Constructors(module)
 

--- a/tiny/src/main/scala/org/kframework/tiny/Rewriter.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/Rewriter.scala
@@ -8,7 +8,7 @@ import scala.collection.parallel.ParIterable
 
 object KIndex extends (K => Option[String]) {
   def apply(k: K): Option[String] = k match {
-    case KApp(KLabel("'<k>"), c, _) =>
+    case KApp(KLabel("<k>"), c, _) =>
       val top = c.head match {
         case s: KSeq => s.children.headOption.getOrElse(KSeq())
         case x => x

--- a/tiny/src/main/scala/org/kframework/tiny/Rewriter.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/Rewriter.scala
@@ -85,7 +85,7 @@ class Rewriter(module: definition.Module) {
     var prev: K = null
     do {
       steps += 1
-      if (steps % 100 == 0) {
+      if (steps % 1000 == 0) {
         println(steps +
           " runtime: " + (System.nanoTime() - time) / 1000000 +
           " cache size: " + NormalizationCaching.cache.size +

--- a/tiny/src/main/scala/org/kframework/tiny/Rule.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/Rule.scala
@@ -6,7 +6,7 @@ object Rule {
     val left = RewriteToTop.toLeft(termWithRewrite).normalize
     val right = RewriteToTop.toRight(termWithRewrite).normalize
 
-    def substitute(and: And, t: K): K = {
+    def substitute(and: K, t: K): K = {
       assert(and.isPureSubsitution,
         "Invalid substitution when applying " + left + " to " + t + ":\n" + and)
       Substitution(right).substitute(and.binding)
@@ -14,26 +14,24 @@ object Rule {
 
     (t: K) => {
 
-      def processAnd(and: And) = {
+      def processAnd(and: K) = {
         val res = substitute(and, t).normalize
         println(" applied " + left + " => " + right);
         println(" resulting in " + res)
         res
       }
 
-//      print(count);
+      //      print(count);
       count = count + 1;
       val pmSolutions = And(left.matcher(t), sideConditions).normalize
       pmSolutions match {
-        case Or(children, _, _) if children.size == 0 =>
-//          println(" tried and failed " + left + " => " + right)
+        case OrChildren(children) if children.size == 0 =>
+          //          println(" tried and failed " + left + " => " + right)
           Set()
-        case Or(children, _, _) => children map {
-          case and: And =>
+        case OrChildren(children) => children map {
+          case and =>
             processAnd(and)
         }
-        case and: And => Set(processAnd(and))
-        case b: Binding => Set(processAnd(And(b)))
       }
     }
   }
@@ -45,7 +43,7 @@ object ExecuteRule {
     val left = RewriteToTop.toLeft(termWithRewrite)
     val right = RewriteToTop.toRight(termWithRewrite)
 
-    def substitute(and: And, t: K): K = {
+    def substitute(and: K, t: K): K = {
       assert(and.isPureSubsitution,
         "Invalid substitution when applying " + left + " to " + t + ":\n" + and)
       Substitution(right).substitute(and.binding)
@@ -53,25 +51,18 @@ object ExecuteRule {
 
     (t: K) => {
 
-      def processAnd(and: And) = {
-        val res = substitute(and, t).normalize
-//        println(" applied " + left + " => " + right);
-//        println(" resulting in " + res)
-        res
-      }
 
-//      print(count);
+      //      print(count);
       count = count + 1;
       val pmSolutions = And(left.matcher(t), sideConditions).normalize
       pmSolutions match {
-        case Or(children, _, _) if children.size == 0 =>
-//          println(" tried and failed " + left + " => " + right)
+        case OrChildren(children) if children.size == 0 =>
+          //          println(" tried and failed " + left + " => " + right)
           None
-        case Or(children, _, _) => children.headOption map {
-          case and: And =>
-            processAnd(and)
+        case OrChildren(children) => children.headOption map {
+          case and: K => substitute(and, t).normalize
         }
-        case and: And => Some(processAnd(and))
+        case and: And => Some(substitute(and, t).normalize)
       }
     }
   }

--- a/tiny/src/main/scala/org/kframework/tiny/Rule.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/Rule.scala
@@ -24,15 +24,7 @@ object Rule {
       //      print(count);
       count = count + 1;
       val pmSolutions = And(left.matcher(t), sideConditions).normalize
-      pmSolutions match {
-        case OrChildren(children) if children.size == 0 =>
-          //          println(" tried and failed " + left + " => " + right)
-          Set()
-        case OrChildren(children) => children map {
-          case and =>
-            processAnd(and)
-        }
-      }
+      AsOr(pmSolutions).children map processAnd
     }
   }
 }
@@ -50,20 +42,10 @@ object ExecuteRule {
     }
 
     (t: K) => {
-
-
       //      print(count);
       count = count + 1;
       val pmSolutions = And(left.matcher(t), sideConditions).normalize
-      pmSolutions match {
-        case OrChildren(children) if children.size == 0 =>
-          //          println(" tried and failed " + left + " => " + right)
-          None
-        case OrChildren(children) => children.headOption map {
-          case and: K => substitute(and, t).normalize
-        }
-        case and: And => Some(substitute(and, t).normalize)
-      }
+      AsOr(pmSolutions).children.headOption map { substitute(_, t).normalize }
     }
   }
 }

--- a/tiny/src/main/scala/org/kframework/tiny/Rule.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/Rule.scala
@@ -1,6 +1,8 @@
 package org.kframework.tiny
 
-trait Rule extends (K => Set[K]) {
+trait Rule extends (K => Set[K])
+
+trait FromKDef {
   val termWithRewrite: K
   val sideConditions: K
   implicit val theory: Theory
@@ -17,18 +19,18 @@ trait Rule extends (K => Set[K]) {
   }
 
   def matchTerm(t: K) = And(left.matcher(t), sideConditions).normalize
-
 }
 
-case class RegularRule(termWithRewrite: K, sideConditions: K)(implicit val theory: Theory) extends Rule {
-
+case class RegularRule(termWithRewrite: K, sideConditions: K)(implicit val theory: Theory)
+  extends Rule with FromKDef {
   def apply(t: K) = {
     val pmSolutions = matchTerm(t)
     AsOr(pmSolutions).children map { count += 1; substitute(_, t).normalize }
   }
 }
 
-case class AnywhereRule(termWithRewrite: K, sideConditions: K)(implicit val theory: Theory) extends Rule {
+case class AnywhereRule(termWithRewrite: K, sideConditions: K)(implicit val theory: Theory)
+  extends Rule with FromKDef {
 
   val regularRule = RegularRule(termWithRewrite, sideConditions)
 
@@ -63,7 +65,8 @@ case class AnywhereRule(termWithRewrite: K, sideConditions: K)(implicit val theo
   }
 }
 
-case class ExecuteRule(termWithRewrite: K, sideConditions: K = True)(implicit val theory: Theory) extends Rule {
+case class ExecuteRule(termWithRewrite: K, sideConditions: K = True)(implicit val theory: Theory)
+  extends Rule with FromKDef {
   def apply(t: K) = {
     val pmSolutions = matchTerm(t)
     AsOr(pmSolutions).children.headOption map { count += 1; substitute(_, t).normalize } toSet

--- a/tiny/src/main/scala/org/kframework/tiny/Rule.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/Rule.scala
@@ -33,6 +33,7 @@ object Rule {
             processAnd(and)
         }
         case and: And => Set(processAnd(and))
+        case b: Binding => Set(processAnd(And(b)))
       }
     }
   }

--- a/tiny/src/main/scala/org/kframework/tiny/Substitution.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/Substitution.scala
@@ -12,7 +12,10 @@ class Substitution(self: K) {
   import org.kframework.tiny.Substitution._
 
   def substitute(substitution: Map[KVar, K]): K = {
-    doSubstitution(substitution)
+    if (self.isGround || substitution.isEmpty)
+      self
+    else
+      doSubstitution(substitution)
   }
 
   private def doSubstitution(substitution: Map[KVar, K]) =
@@ -30,7 +33,7 @@ class Substitution(self: K) {
 
         k.klabel(newChildren.toSeq: _*)
       case KApp(l, ks, att) =>
-        l(ks map { x: K => x.substitute(substitution) }, att)
+        l(ks map {x: K => x.substitute(substitution) }, att)
       case e => e
     }
 }

--- a/tiny/src/main/scala/org/kframework/tiny/Theory.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/Theory.scala
@@ -1,12 +1,11 @@
 package org.kframework.tiny
 
-import org.kframework.builtin.Sorts
 import org.kframework.definition._
 import org.kframework.meta.{Down, Up}
 
 
 trait Theory {
-  def normalize(k: K): K
+//  def normalize(k: K): K
 
 }
 
@@ -18,18 +17,6 @@ trait FreeTheory extends Theory {
 object FreeTheory extends FreeTheory
 
 class TheoryWithUpDown(up: Up[K], down: Down, val module: Module) extends FreeTheory {
-  override def normalize(k: K): K = {
-    k match {
-      case t: KTok => t.sort match {
-        case Sorts.Bool => t.s match {
-          case "true" => And()
-          case "false" => Or()
-        }
-        case _ => t
-      }
-      case t => super.normalize(k)
-    }
-  }
 }
 
 case class RewriteBasedTheory(rw: K => K) extends Theory {

--- a/tiny/src/main/scala/org/kframework/tiny/adt.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/adt.scala
@@ -181,6 +181,14 @@ case class NativeBinaryOp[T, R](val klabel: NativeBinaryOpLabel[T, R], val child
   }
 }
 
+case class NativeUnaryOp[T, R](val klabel: NativeUnaryOpLabel[T, R], val children: Seq[K], val att: Att = Att())
+  extends KRegularApp {
+  override def normalizeInner(implicit theory: Theory): K = children match {
+    case Seq(TypedKTok(s, v: T, _)) => TypedKTok(klabel.resSort, klabel.f(v))
+    case _ => this
+  }
+}
+
 final class RegularKApp(val klabel: RegularKAppLabel, val children: Seq[K], val att: Att = Att())
   extends KRegularApp with PlainNormalization
 
@@ -277,6 +285,10 @@ case class RegularKAppLabel(name: String, att: Att) extends KRegularAppLabel {
 
 case class NativeBinaryOpLabel[T, R](name: String, att: Att, f: (T, T) => R, resSort: Sort) extends KRegularAppLabel {
   override def construct(l: Iterable[K], att: Att): NativeBinaryOp[T, R] = new NativeBinaryOp(this, l.toSeq, att)
+}
+
+case class NativeUnaryOpLabel[T, R](name: String, att: Att, f: T => R, resSort: Sort) extends KRegularAppLabel {
+  override def construct(l: Iterable[K], att: Att): NativeUnaryOp[T, R] = new NativeUnaryOp(this, l.toSeq, att)
 }
 
 case class RegularKAssocAppLabel(name: String, att: Att) extends KAssocAppLabel {

--- a/tiny/src/main/scala/org/kframework/tiny/adt.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/adt.scala
@@ -169,13 +169,17 @@ case class NativeBinaryOp[T, R](val klabel: NativeBinaryOpLabel[T, R], val child
   extends KRegularApp {
   override def normalizeInner(implicit theory: Theory): K = children match {
     case Seq(TypedKTok(s1, v1: T, _), TypedKTok(s2, v2: T, _)) if s1 == s2 =>
-      // ugly hack
-      val res = klabel.f(v1, v2)
-      if (klabel.resSort != Sorts.Bool)
-        TypedKTok(klabel.resSort, res)
-      else res match {
-        case true => And()
-        case false => Or()
+      try {
+        val res = klabel.f(v1, v2)
+        if (klabel.resSort != Sorts.Bool)
+          TypedKTok(klabel.resSort, res)
+        else res match {
+          // ugly hack
+          case true => And()
+          case false => Or()
+        }
+      } catch {
+        case e: ArithmeticException => False
       }
     case _ => this
   }

--- a/tiny/src/main/scala/org/kframework/tiny/builtin/Bag.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/builtin/Bag.scala
@@ -1,0 +1,40 @@
+package org.kframework.tiny.builtin
+
+import org.kframework.attributes.Att
+import org.kframework.tiny._
+import org.kframework.tiny.matcher.{AssocMatchContents, KAppMatcher, Matcher, MatcherLabel}
+
+case class Bag(klabel: BagLabel, children: collection.Bag[K], att: Att = Att()) extends KAssocApp {
+  override def matcher(right: K): Matcher = BagMatcher(this, right)
+}
+
+case class BagLabel(name: String, att: Att = Att()) extends KAssocAppLabel {
+  implicit val bagConfig = collection.Bag.configuration.compact[K]
+
+  override def constructFromFlattened(l: Seq[K], att: Att): Bag = Bag(this, collection.Bag(l: _*), att)
+}
+
+case class BagMatcher(left: Bag, right: K) extends KAppMatcher with AssocMatchContents {
+  override def matchContents(ksL: Seq[K], ksR: Seq[K])(implicit theory: Theory): K = {
+    val groundLeft = ksL filter { _.isGround }
+    val groundRight = ksR filter { _.isGround }
+
+    if ((groundLeft diff groundRight).size > 0)
+      False
+    else {
+      val remainingRight = ksR.toList diff groundLeft
+      val symbolicLeft = ksL diff groundRight
+
+      Or((for (oneLeft <- symbolicLeft.permutations;
+               oneRight <- remainingRight.permutations) yield {
+        AsOr(super[AssocMatchContents].matchContents(oneLeft, oneRight)).children
+      }).flatten.toSeq: _*)
+    }
+  }
+  override val klabel: MatcherLabel = BagMatcher
+  override val leftKLabel: Label = left.klabel
+  override val rightAtt: Att = right.att
+}
+object BagMatcher extends MatcherLabel {
+  override def apply(k1: K, k2: K, att: Att): KProduct = BagMatcher(k1.asInstanceOf[Bag], k2)
+}

--- a/tiny/src/main/scala/org/kframework/tiny/logic.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/logic.scala
@@ -6,7 +6,7 @@ import org.kframework.tiny.matcher.{MatcherLabel, EqualsMatcher, Matcher}
 
 object Or extends KAssocAppLabel with EmptyAtt {
   override def constructFromFlattened(l: Seq[K], att: Att): KAssocApp = new Or(l.toSet, att)
-  override def name: String = "'_orBool_"
+  override def name: String = "_orBool_"
   override def apply(ks: K*): K = super.apply(ks: _*)
   def apply(ks: Set[K], att: Att = Att()): K =
     if (ks.size == 1)
@@ -66,7 +66,7 @@ object OrMatcher extends MatcherLabel {
 
 object And extends KAssocAppLabel with EmptyAtt {
   override def constructFromFlattened(l: Seq[K], att: Att): KAssocApp = new And(l.toSet, att)
-  override def name: String = "'_andBool_"
+  override def name: String = "_andBool_"
 }
 
 case class And(children: Set[K], att: Att, normalBy: Option[Theory] = None)
@@ -185,7 +185,7 @@ case class Equals(a: K, b: K, att: Att) extends KProduct {
   override val klabel = Equals
   override def toString = a + "=" + b
 
-  override def normalizeInner(implicit theory: Theory) = a.matcher(b)
+  override def normalizeInner(implicit theory: Theory) = a.matcher(b).normalize
 }
 
 object Equals extends KProduct2Label with EmptyAtt {

--- a/tiny/src/main/scala/org/kframework/tiny/matcher/Matcher.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/matcher/Matcher.scala
@@ -74,7 +74,7 @@ case class KAssocAppMatcher(left: KAssocApp, right: K) extends KAppMatcher {
           case (prefix, suffix) =>
             And(headL.matcher(left.klabel(prefix, right.att)), matchContents(tailL, suffix))
         }
-          .fold(False)({ (a, b) => Or(a, b) })
+          .fold(False: K)({ (a, b) => Or(a, b) })
 
       case other => False
     }

--- a/tiny/src/main/scala/org/kframework/tiny/package.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/package.scala
@@ -10,7 +10,7 @@ package object tiny {
   lazy val True = new And(Set(), Att())
   lazy val False = new Or(Set(), Att())
 
-  //  def ins[T](x: T) = { println(x); x }
+  def ins[T](x: T) = { println(x); x }
 
   implicit class WithIns[T](x: T) {
     def ins = { println(x); x }

--- a/tiny/src/main/scala/org/kframework/tiny/package.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/package.scala
@@ -5,8 +5,6 @@ import org.kframework.attributes.Att
 package object tiny {
   type Sort = kore.Sort
 
-  type Rule = K => Set[K]
-
   lazy val True = new And(Set(), Att())
   lazy val False = new Or(Set(), Att())
 

--- a/tiny/src/main/scala/org/kframework/tiny/package.scala
+++ b/tiny/src/main/scala/org/kframework/tiny/package.scala
@@ -10,10 +10,59 @@ package object tiny {
   lazy val True = new And(Set(), Att())
   lazy val False = new Or(Set(), Att())
 
-//  def ins[T](x: T) = { println(x); x }
+  //  def ins[T](x: T) = { println(x); x }
 
   implicit class WithIns[T](x: T) {
     def ins = { println(x); x }
+  }
+
+  implicit class ToDNF(t: K) {
+    def toDNF: K = t match {
+      case and: And => and.children.map(_.toDNF).fold(True)({
+        (or1: K, or2: K) =>
+          Or(for (c1 <- AsOr(or1).children;
+                  c2 <- AsOr(or2).children) yield {
+            And(c1, c2)
+          })
+      })
+      case or: Or => or.map(_.toDNF)
+      case k: K => k
+    }
+  }
+
+  implicit class AsAnd(thisAnd: K) {
+    def children: Set[K] = thisAnd match {
+      case AndChildren(thisC) => thisC
+    }
+
+    lazy val bindings = children collect {
+      case b: Binding => b
+    }
+
+    lazy val binding: Map[KVar, K] = bindings map {
+      case Binding(k, v, _) => (k, v)
+    } toMap
+
+    lazy val isPureSubsitution: Boolean = binding.size == children.size
+  }
+
+  implicit class AsOr(thisOr: K) {
+    def |(thatOr: K) = Or(children | AsOr(thatOr).children)
+
+    def children: Set[K] = thisOr match {
+      case OrChildren(thisC) => thisC
+    }
+
+    def eliminateGroundBooleans: K = if (children.contains(True)) True else thisOr
+
+    //      children.foldLeft(False: K) {
+    //      case (_, True) => Or(True)
+    //      //    case (sum, TypedKTok(Sorts.Bool, true, _)) => Or(True)
+    //      case (True, _) => Or(True)
+    //      case (sum: Or, False) => sum
+    //      //    case (sum, TypedKTok(Sorts.Bool, false, _)) => sum
+    //      case (sum: Or, p) => Or(sum.children + p)
+    //    }
   }
 
 }

--- a/tiny/src/test/scala/org/kframework/tiny/ADTTest.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/ADTTest.scala
@@ -43,7 +43,7 @@ class ADTTest extends AbstractTest {
   }
 
   @Test def AndMatcher {
-    assertEquals(And(), And().matcher(KToken(Sorts.Bool, "true", Att())).normalize)
+    assertEquals(True, And().matcher(KToken(Sorts.Bool, "true", Att())).normalize)
     assertEquals(And(), And().matcher(And()).normalize)
 
     assertEquals(Or(1: K, 2: K), (1: K) | 2)

--- a/tiny/src/test/scala/org/kframework/tiny/ADTTest.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/ADTTest.scala
@@ -33,8 +33,8 @@ class ADTTest extends AbstractTest {
     assertEquals(5: K, divide(10, 2).normalize)
     assertEquals(KSequence(5: K), KSequence(divide(10, 2)).normalize)
     assertEquals('foo(KSequence(5: K)), 'foo(KSequence(divide(10, 2))).normalize)
-    assertEquals(And('foo(KSequence(5: K))), And('foo(divide(10, 2))).normalize)
-    assertEquals(And('+(KSequence(5: K))), And('+(KSequence(divide(10, 2)))).normalize)
+    assertEquals('foo(KSequence(5: K)), And('foo(divide(10, 2))).normalize)
+    assertEquals('+(KSequence(5: K)), And('+(KSequence(divide(10, 2)))).normalize)
     assertEquals('+('+(KSequence(5: K)), '+(KMapAppLabel("Map")())), '+('+(KSequence(divide(10, 2))), '+(KMapAppLabel
       ("Map")())
     ).normalize)
@@ -43,7 +43,9 @@ class ADTTest extends AbstractTest {
   }
 
   @Test def AndMatcher {
-    assertEquals(Or(And()), And().matcher(KToken(Sorts.Bool, "true", Att())).normalize)
-    assertEquals(Or(And()), And().matcher(And()).normalize)
+    assertEquals(And(), And().matcher(KToken(Sorts.Bool, "true", Att())).normalize)
+    assertEquals(And(), And().matcher(And()).normalize)
+
+    assertEquals(Or(1: K, 2: K), (1: K) | 2)
   }
 }

--- a/tiny/src/test/scala/org/kframework/tiny/AbstractTest.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/AbstractTest.scala
@@ -20,7 +20,8 @@ trait AbstractTest {
     Production("~>", Sorts.KSeq, Seq(), Att() + "assoc"),
     Production("foo", String, Seq(), Att()),
     Production("bar", String, Seq(), Att()),
-    Production("+", Int, Seq(), Att() + "assoc")
+    Production("+", Int, Seq(), Att() + "assoc"),
+    Production("MyBag", Int, Seq(), Att() + "assoc" + "comm")
   ), Att()))
 
   val X = KVar("X")

--- a/tiny/src/test/scala/org/kframework/tiny/AbstractTest.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/AbstractTest.scala
@@ -1,6 +1,6 @@
 package org.kframework.tiny
 
-import org.junit.Assert
+import org.junit.{Before, Assert}
 import org.kframework.attributes.Att
 import org.kframework.builtin.Sorts
 import org.kframework.definition.{NonTerminal, Module, Production}
@@ -36,5 +36,9 @@ trait AbstractTest {
   def assertNotEquals(k1: kore.K, k2: kore.K): Unit = {
     if (k1 == k2)
       Assert.assertNotEquals(Unparse(k1), Unparse(k2))
+  }
+
+  @Before def clearCache: Unit = {
+    NormalizationCaching.cache.invalidateAll()
   }
 }

--- a/tiny/src/test/scala/org/kframework/tiny/AbstractTest.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/AbstractTest.scala
@@ -21,7 +21,7 @@ trait AbstractTest {
     Production("foo", String, Seq(), Att()),
     Production("bar", String, Seq(), Att()),
     Production("+", Int, Seq(), Att() + "assoc"),
-    Production("MyBag", Int, Seq(), Att() + "assoc" + "comm")
+    Production("MyBag", Sorts.K, Seq(), Att() + "assoc" + "comm")
   ), Att()))
 
   val X = KVar("X")

--- a/tiny/src/test/scala/org/kframework/tiny/GrigoreChallange.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/GrigoreChallange.scala
@@ -69,6 +69,11 @@ class GrigoreChallange {
     println(res.size + " states.")
   }
 
+  @Test
+  def shortTestWithSearch {
+    assertEquals(Right(24: K), rewriter.search((5: K) ~ 5 ~ 7 ~ 4, 24))
+  }
+
   val completeModuleWithAnywhere = Module("T-ANYWHERE", Set(syntaxModule, logicModule), Set(
     Rule(X ~ Y ==> (X + Y), argsAreInts, False, cons.Att() + "anywhere"),
     Rule(X ~ Y ==> (X - Y), argsAreInts, False, cons.Att() + "anywhere"),
@@ -83,11 +88,6 @@ class GrigoreChallange {
     val res = rewriterWithAnywhere.rewrite((5: K) ~ 5 ~ 7 ~ 4)
     println(res.mkString("\n"))
     println(res.size + " states.")
-  }
-
-  @Test
-  def shortTestWithSearch {
-    assertEquals(Right(24: K), rewriter.search((5: K) ~ 5 ~ 7 ~ 4, 24))
   }
 
   @Test

--- a/tiny/src/test/scala/org/kframework/tiny/GrigoreChallange.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/GrigoreChallange.scala
@@ -64,14 +64,14 @@ class GrigoreChallange {
 
   @Test
   def shortTest {
-    val res = rewriter.rewrite((5: K) ~ 5 ~ 7 ~ 4)
+    val res = rewriter.rewrite((5: K) ~ 5 ~ 7)
     println(res.mkString("\n"))
     println(res.size + " states.")
   }
 
   @Test
   def shortTestWithSearch {
-    assertEquals(Right(24: K), rewriter.search((5: K) ~ 5 ~ 7 ~ 4, 24))
+    assertEquals(Right(0: K), rewriter.search((5: K) ~ 5 ~ 7, 0))
   }
 
   val completeModuleWithAnywhere = Module("T-ANYWHERE", Set(syntaxModule, logicModule), Set(
@@ -85,13 +85,13 @@ class GrigoreChallange {
 
   @Test
   def shortTestWithAnywhere {
-    val res = rewriterWithAnywhere.rewrite((5: K) ~ 5 ~ 7 ~ 4)
+    val res = rewriterWithAnywhere.rewrite((5: K) ~ 5 ~ 7)
     println(res.mkString("\n"))
     println(res.size + " states.")
   }
 
   @Test
   def shortTestWithSearchAnywhere {
-    assertEquals(Right(24: K), rewriterWithAnywhere.search((5: K) ~ 5 ~ 7 ~ 4, 24))
+    assertEquals(Right(0: K), rewriterWithAnywhere.search((5: K) ~ 5 ~ 7, 0))
   }
 }

--- a/tiny/src/test/scala/org/kframework/tiny/GrigoreChallange.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/GrigoreChallange.scala
@@ -1,0 +1,97 @@
+package org.kframework.tiny
+
+import org.junit.Test
+import org.junit.Assert._
+import org.kframework.attributes.Att
+import org.kframework.builtin.Sorts
+import org.kframework.definition._
+
+
+class GrigoreChallange {
+
+  //  mod T is
+  //  including RAT .
+  //  sort MSet .
+  //  subsort Rat < MSet .
+  //  op _,_ : MSet MSet -> MSet [assoc comm] .
+  //  vars A B : Rat .
+  //  rl A,B => A * B .
+  //    rl A,B => A - B .
+  //    rl A,B => A + B .
+  //    rl A,B => A / B .
+  //    endm
+  //
+  //  search 5,5,7,4 =>* 24 .
+  //  show path 634 .
+
+  import org.kframework.builtin.Sorts._
+
+  val X = KVar("X")
+  val Y = KVar("Y")
+
+  val boolPair = Seq(NonTerminal(Bool), NonTerminal(Bool))
+
+  val logicModule = Module("BOOLEAN-LOGIC", Set(), Set(
+    Production("_andBool_", Bool, boolPair, Att() + ("hook" -> "#BOOL:_andBool_")),
+    Production("_orBool_", Sorts.Bool, boolPair, Att() + ("hook" -> "#BOOL:_orBool_"))))
+
+  val intPair = Seq(NonTerminal(Int), NonTerminal(Int))
+
+  val syntaxModule = Module("T-SYNTAX", Set(), Set(
+    Production("+", Int, intPair, Att() + ("hook" -> "#INT:_+Int_")),
+    Production("-", Int, intPair, Att() + ("hook" -> "#INT:_-Int_")),
+    Production("/", Int, intPair, Att() + ("hook" -> "#INT:_/Int_")),
+    Production("*", Int, intPair, Att() + ("hook" -> "#INT:_*Int_")),
+    Production("~", K, intPair, Att() + "assoc" + "comm")
+  ), Att())
+
+  val cons = new Constructors(syntaxModule)
+
+  import cons._
+
+  val R = KVar("R")
+
+  val argsAreInts = And('isInt(X), 'isInt(Y))
+
+  val completeModule = Module("T", Set(syntaxModule, logicModule), Set(
+    Rule(X ~ Y ~ R ==> (X + Y) ~ R, argsAreInts, False),
+    Rule(X ~ Y ~ R ==> (X - Y) ~ R, argsAreInts, False),
+    Rule(X ~ Y ~ R ==> (X / Y) ~ R, argsAreInts, False),
+    Rule(X ~ Y ~ R ==> (X * Y) ~ R, argsAreInts, False)
+  ))
+
+  val rewriter = new Rewriter(completeModule)
+
+  @Test
+  def shortTest {
+    val res = rewriter.rewrite((5: K) ~ 5 ~ 7 ~ 4)
+    println(res.mkString("\n"))
+    println(res.size + " states.")
+  }
+
+  val completeModuleWithAnywhere = Module("T-ANYWHERE", Set(syntaxModule, logicModule), Set(
+    Rule(X ~ Y ==> (X + Y), argsAreInts, False, cons.Att() + "anywhere"),
+    Rule(X ~ Y ==> (X - Y), argsAreInts, False, cons.Att() + "anywhere"),
+    Rule(X ~ Y ==> (X / Y), argsAreInts, False, cons.Att() + "anywhere"),
+    Rule(X ~ Y ==> (X * Y), argsAreInts, False, cons.Att() + "anywhere")
+  ))
+
+  val rewriterWithAnywhere = new Rewriter(completeModuleWithAnywhere)
+
+  @Test
+  def shortTestWithAnywhere {
+    val res = rewriterWithAnywhere.rewrite((5: K) ~ 5 ~ 7 ~ 4)
+    println(res.mkString("\n"))
+    println(res.size + " states.")
+  }
+
+  @Test
+  def shortTestWithSearch {
+    assertEquals(Right(24: K), rewriter.search((5: K) ~ 5 ~ 7 ~ 4, 24))
+  }
+
+  @Test
+  def shortTestWithSearchAnywhere {
+    assertEquals(Right(24: K), rewriterWithAnywhere.search((5: K) ~ 5 ~ 7 ~ 4, 24))
+  }
+}

--- a/tiny/src/test/scala/org/kframework/tiny/GrigoreChallange.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/GrigoreChallange.scala
@@ -60,7 +60,7 @@ class GrigoreChallange {
     Rule(X ~ Y ~ R ==> (X * Y) ~ R, argsAreInts, False)
   ))
 
-  val rewriter = new Rewriter(completeModule)
+  val rewriter = new Rewriter(completeModule, SimpleIndex)
 
   @Test
   def shortTest {
@@ -81,7 +81,7 @@ class GrigoreChallange {
     Rule(X ~ Y ==> (X * Y), argsAreInts, False, cons.Att() + "anywhere")
   ))
 
-  val rewriterWithAnywhere = new Rewriter(completeModuleWithAnywhere)
+  val rewriterWithAnywhere = new Rewriter(completeModuleWithAnywhere, SimpleIndex)
 
   @Test
   def shortTestWithAnywhere {

--- a/tiny/src/test/scala/org/kframework/tiny/LogicTest.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/LogicTest.scala
@@ -8,7 +8,7 @@ class LogicTest extends AbstractTest {
 
   @Test def nestingOfAndOr {
     implicit val theory = FreeTheory
-    assertEquals(Or(And(X)), And(Or(And(Or(And(X))))).normalize)
+    assertEquals(X, And(Or(And(Or(And(X))))).normalize)
     assertEquals(Or(And(Binding(X, 'foo()))), And(Or(And(Or(Binding(X, 'foo()))))).normalize)
   }
 

--- a/tiny/src/test/scala/org/kframework/tiny/TestRewriting.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/TestRewriting.scala
@@ -172,5 +172,4 @@ class TestRewriting extends AbstractTest {
       Assert.assertEquals(expected.toString(), actual.toString())
     }
   }
-
 }

--- a/tiny/src/test/scala/org/kframework/tiny/TestRewriting.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/TestRewriting.scala
@@ -1,7 +1,6 @@
 package org.kframework.tiny
 
 import org.junit.{Assert, Ignore, Test}
-import org.kframework.attributes._
 import org.kframework.tiny.matcher.Anywhere
 
 class TestRewriting extends AbstractTest {
@@ -61,12 +60,12 @@ class TestRewriting extends AbstractTest {
 
   @Test
   def testVarSubstitutionWithTrueSideCondition() {
-    assertEquals(Set('foo(5, 4)), 'foo(4).searchFor('foo(X) ==> 'foo(5: K, X), Equals(X, 4)))
+    assertEquals(Set('foo(5, 4)), 'foo(4).searchFor('foo(X) ==> 'foo(5: K, X), X -> 4))
   }
 
   @Test
   def testVarSubstitutionWithFalseSideCondition() {
-    assertEquals(Set(), 'foo(4).searchFor('foo(X) ==> 'foo(5, X), Equals(X, 7)))
+    assertEquals(Set(), 'foo(4).searchFor('foo(X) ==> 'foo(5, X), X -> 7))
   }
 
   @Test

--- a/tiny/src/test/scala/org/kframework/tiny/TestRewriting.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/TestRewriting.scala
@@ -9,7 +9,7 @@ class TestRewriting extends AbstractTest {
 
   implicit class KToRewriting(self: K) {
     def searchFor(rewrite: K, sideConditions: K = True)(implicit theory: Theory): Set[K] = {
-      Rule(rewrite, sideConditions)(theory)(self)
+      RegularRule(rewrite, sideConditions)(theory)(self)
     }
   }
 
@@ -89,7 +89,8 @@ class TestRewriting extends AbstractTest {
     assertEquals(Set(), '+(4, 4, 4, 4, 4).searchFor('+(X, X) ==> '+(X)))
   }
 
-  @Test @Ignore
+  @Test
+  @Ignore
   def testKLabelMatch() {
     assertEquals(Set('foo(4)), 'foo(4, 4).searchFor(KApply(X, List(4: K, 4: K)) ==> KApply(X, List(4: K), Att
       ())))
@@ -132,6 +133,20 @@ class TestRewriting extends AbstractTest {
   @Test def testAnywhere {
     assertEquals(Set('bar('foo(0)), 'foo('bar(0))),
       'foo('bar('foo(0))).searchFor(Anywhere("ONE", 'foo(X) ==> X)))
+  }
+
+  @Test def testAnywhereRule {
+    val r = AnywhereRule('foo(X) ==> X, True)
+
+    assertEquals(Set('bar('foo(0)), 'foo('bar(0))),
+      r('foo('bar('foo(0)))))
+  }
+
+  @Test def testAnywhereRuleAssoc {
+    val r = AnywhereRule(X + X ==> X, True)
+
+    assertEquals(Set('+(0, 0, 0), '+(0, 0)),
+      r((0: K) + 0 + 0))
   }
 
   @Test

--- a/tiny/src/test/scala/org/kframework/tiny/matcher/MatcherTest.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/matcher/MatcherTest.scala
@@ -1,6 +1,6 @@
 package org.kframework.tiny.matcher
 
-import org.junit.{Assert, Ignore, Test}
+import org.junit.{Before, Assert, Ignore, Test}
 import org.kframework.builtin.Sorts
 import org.kframework.tiny._
 

--- a/tiny/src/test/scala/org/kframework/tiny/matcher/MatcherTest.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/matcher/MatcherTest.scala
@@ -285,5 +285,16 @@ class MatcherTest extends AbstractTest {
       And(X -> 'MyBag(1, 2), Y -> 'MyBag())
     ), 'MyBag(X, Y).matchAll('MyBag(1, 2)))
 
+    assertEquals(Or(
+      And(X -> 1, Y -> 2, Z -> 3),
+      And(X -> 1, Y -> 3, Z -> 2),
+      And(X -> 2, Y -> 1, Z -> 3),
+      And(X -> 2, Y -> 3, Z -> 1),
+      And(X -> 3, Y -> 1, Z -> 2),
+      And(X -> 3, Y -> 2, Z -> 1)
+    ), 'MyBag(X, 'MyBag(Y, Z)).matchAll('MyBag(1, 2, 3), And('isInt(X), 'isInt(Y), 'isInt(Z))))
+
+    assertEquals(Or(), 'MyBag(X, Y).matchAll('MyBag(1)))
+
   }
 }

--- a/tiny/src/test/scala/org/kframework/tiny/matcher/MatcherTest.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/matcher/MatcherTest.scala
@@ -225,7 +225,8 @@ class MatcherTest extends AbstractTest {
   }
 
 
-  @Test @Ignore def testTwoAnywheres() {
+  @Test
+  @Ignore def testTwoAnywheres() {
     val o = 'foo('foo('foo('bar())))
     val inner = Anywhere("inner", 'foo(X))
     val outer = Anywhere("outer", 'foo(inner))
@@ -269,5 +270,20 @@ class MatcherTest extends AbstractTest {
 
   @Test def testSmallOr: Unit = {
     assertEquals(X -> 1, And(X -> Or(1, 2), X -> 1).normalize)
+  }
+
+  @Test def testBag {
+    NormalizationCaching.cache.cleanUp()
+    val o = 'MyBag(1, 2, 3)
+    val p = 'MyBag(X, 2)
+    assertEquals(False, 'MyBag(X, 7).matchAll(o))
+    assertEquals(X -> 'MyBag(1, 3), p.matchAll(o))
+    assertEquals(Or(
+      And(X -> 'MyBag(), Y -> 'MyBag(1, 2)),
+      And(X -> 'MyBag(1), Y -> 'MyBag(2)),
+      And(X -> 'MyBag(2), Y -> 'MyBag(1)),
+      And(X -> 'MyBag(1, 2), Y -> 'MyBag())
+    ), 'MyBag(X, Y).matchAll('MyBag(1, 2)))
+
   }
 }

--- a/tiny/src/test/scala/org/kframework/tiny/matcher/MatcherTest.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/matcher/MatcherTest.scala
@@ -50,13 +50,13 @@ class MatcherTest extends AbstractTest {
   @Test def testKApplyWithCondition() {
     val foo = 'foo(5: K)
     val pattern = 'foo(X)
-    assertEquals(X -> ((5: K): K), pattern.matchOne(foo, Equals(X, 5: K)))
+    assertEquals(X -> 5, pattern.matchOne(foo, X -> 5))
   }
 
   @Test def testKApplyWithFailingCondition() {
     val foo = 'foo(5: K)
     val pattern = 'foo(X)
-    assertEquals(False, pattern.matchAll(foo, Equals(X, 4: K)))
+    assertEquals(False, pattern.matchAll(foo, X -> 4))
   }
 
   @Test
@@ -225,7 +225,7 @@ class MatcherTest extends AbstractTest {
   }
 
 
-  @Test def testTwoAnywheres() {
+  @Test @Ignore def testTwoAnywheres() {
     val o = 'foo('foo('foo('bar())))
     val inner = Anywhere("inner", 'foo(X))
     val outer = Anywhere("outer", 'foo(inner))
@@ -242,4 +242,32 @@ class MatcherTest extends AbstractTest {
     assertEquals(True, o.matchAll(o))
   }
 
+  @Test def testOrInMatchWithVariable {
+    NormalizationCaching.cache.cleanUp()
+    val o = Or(1: K, 2: K)
+    val p = Or(1: K, X)
+    assertEquals(X -> Or(1, 2), p.matchAll(o))
+  }
+  @Test def testOrInMatchWithVariable1 {
+    NormalizationCaching.cache.cleanUp()
+    val o = Or(1: K, 2: K)
+    val p = X
+    assertEquals(X -> Or(1, 2), p.matchAll(o))
+  }
+  @Test def testOrInMatchWithVariable2 {
+    NormalizationCaching.cache.cleanUp()
+    val o = 'foo(Or(1: K, 2: K))
+    val p = 'foo(X)
+    assertEquals(X -> Or(1, 2), p.matchAll(o))
+  }
+  @Test def testOrInMatchWithVariable3 {
+    NormalizationCaching.cache.cleanUp()
+    val o = 'foo(Or(1: K, 2: K))
+    val p = 'foo(X)
+    assertEquals(X -> 2, p.matchAll(o, X -> 2))
+  }
+
+  @Test def testSmallOr: Unit = {
+    assertEquals(X -> 1, And(X -> Or(1, 2), X -> 1).normalize)
+  }
 }

--- a/tiny/src/test/scala/org/kframework/tiny/matcher/MatcherTest.scala
+++ b/tiny/src/test/scala/org/kframework/tiny/matcher/MatcherTest.scala
@@ -32,7 +32,7 @@ class MatcherTest extends AbstractTest {
 
   @Test def testSimpleWithTrueSideCondition() {
     val foo = 'foo()
-    Assert.assertEquals(And(X -> 'foo()), X.matchAll(foo, True))
+    Assert.assertEquals(X -> 'foo(), X.matchAll(foo, True))
   }
 
   @Test def testEmptyMatch() {
@@ -43,14 +43,14 @@ class MatcherTest extends AbstractTest {
   @Test def testKApply() {
     val foo = 'foo(5: K)
     val pattern = 'foo(X)
-    Assert.assertEquals(And(X -> ((5: K): K)),
+    Assert.assertEquals(X -> ((5: K): K),
       pattern.matchOne(foo, True))
   }
 
   @Test def testKApplyWithCondition() {
     val foo = 'foo(5: K)
     val pattern = 'foo(X)
-    assertEquals(And(X -> ((5: K): K)), pattern.matchOne(foo, Equals(X, 5: K)))
+    assertEquals(X -> ((5: K): K), pattern.matchOne(foo, Equals(X, 5: K)))
   }
 
   @Test def testKApplyWithFailingCondition() {
@@ -80,31 +80,31 @@ class MatcherTest extends AbstractTest {
   }
 
   @Test def testNested() {
-    assertEquals(And(X -> ((5: K): K)), 'foo('bar(X)).matchAll('foo('bar(5: K))))
+    assertEquals(X -> ((5: K): K), 'foo('bar(X)).matchAll('foo('bar(5: K))))
   }
 
   @Test def testAssocEntire() {
     val foo = (5: K) + 6
     val pattern = X
-    assertEquals(And(X -> foo), pattern.matchAll(foo))
+    assertEquals(X -> foo, pattern.matchAll(foo))
   }
 
   @Test def testAssocPrefix() {
     val foo = (5: K) + 6 + 7
     val pattern = X + 7
-    assertEquals(Or(And(X -> ((5: K) + 6))), pattern.matchAll(foo))
+    assertEquals(X -> ((5: K) + 6), pattern.matchAll(foo))
   }
 
   @Test def testAssocPostfix() {
     val foo = (5: K) + 6 + 7
     val pattern = (5: K) + X
-    assertEquals(Or(And(X -> ((6: K) + 7))), pattern.matchAll(foo))
+    assertEquals(X -> ((6: K) + 7), pattern.matchAll(foo))
   }
 
   @Test def testAssocMiddle() {
     val foo = (5: K) + 6 + 7 + 8
     val pattern = (5: K) + X + 8
-    assertEquals(Or(And(X -> ((6: K) + 7))), pattern.matchAll(foo))
+    assertEquals(X -> ((6: K) + 7), pattern.matchAll(foo))
   }
 
   @Test def testAssocMultivar() {
@@ -126,7 +126,7 @@ class MatcherTest extends AbstractTest {
   @Test def testAssocMultivar2() {
     val foo = (5: K) + 6 + 7
     val pattern = X + 6 + Y
-    assertEquals(Or(And(Y -> 7, X -> 5)), pattern.matchAll(foo))
+    assertEquals(And(Y -> 7, X -> 5), pattern.matchAll(foo))
   }
 
   @Test def testAssocMultivar3() {
@@ -142,15 +142,15 @@ class MatcherTest extends AbstractTest {
   @Test def testAssocMultivar3WithCond() {
     val foo = (5: K) + 5 + 5
     val pattern = X + 5 + Y
-    assertEquals(Or(
+    assertEquals(
       And(X -> 5, Y -> 5)
-    ), pattern.matchAll(foo, Equals(X, 5: K)))
+      , pattern.matchAll(foo, Equals(X, 5: K)))
   }
 
   @Test def testAssocMultipleVar() {
     val foo = '+(5: K, 5: K)
     val pattern = '+(X, X)
-    assertEquals(Or(And(X -> (5: K))),
+    assertEquals(X -> (5: K),
       pattern.matchAll(foo))
   }
 
@@ -163,7 +163,7 @@ class MatcherTest extends AbstractTest {
   @Test def testKApplyWithEmptySeq() {
     val foo = '+()
     val pattern = '+(X)
-    assertEquals(And(X -> '+()), pattern.matchOne(foo))
+    assertEquals(X -> '+(), pattern.matchOne(foo))
   }
 
   //  @Test def testKVariableMatchingKLabel() {
@@ -234,6 +234,12 @@ class MatcherTest extends AbstractTest {
         (X -> 'bar() && inner.TOPVariable -> 'foo(inner.HOLEVariable) && outer.TOPVariable -> outer.HOLEVariable) ||
         (X -> 'bar() && inner.TOPVariable -> inner.HOLEVariable && outer.TOPVariable -> 'foo(outer.HOLEVariable))),
       outer.matchAll(o))
+  }
+
+  @Test def testOrInMatch {
+    NormalizationCaching.cache.cleanUp()
+    val o = Or(1: K)
+    assertEquals(True, o.matchAll(o))
   }
 
 }


### PR DESCRIPTION
- aside from tiny stuff, the main change is that the KIL-to-KORE convertors removes the quote, i.e., `'` from all productions and labels. As we now have a different escaping mechanism, there is no point in leaving it there.
