### PR TITLE
more specific exclude pattern

### DIFF
--- a/k-distribution/tutorial/1_k/4_imp++/lesson_7/exercises/abort/tests/config.xml
+++ b/k-distribution/tutorial/1_k/4_imp++/lesson_7/exercises/abort/tests/config.xml
@@ -5,7 +5,7 @@
   <include file="../../../tests/config.xml"
            more-programs="."
            more-results="."
-           exclude="io" >  <!-- Because of bug #159-->
+           exclude="io.imp" >  <!-- Because of bug #159-->
            <all-programs>
              <krun-option name="--search" />
              <krun-option name="--pattern" value="&lt;out&gt; ListItem(#buffer(S:String)) &lt;/out&gt;" />


### PR DESCRIPTION
Since `exclude` matches the given string on FULL file paths, the exclude pattern `io` is too general, which may lead to exclude unexpected ones. For example, `k-distribution` matches the exclude pattern `io`, so that it excludes all files under the path `k-distribution/tutorial/`.

Well, the suggested fix `io.imp` may be still problematic. So, `ktest` would be better to report explicitly which files are excluded.
