### PR TITLE
fix #1351 : add error message for duplicate cell

### DIFF
--- a/kernel/src/main/java/org/kframework/compile/transformers/ResolveContextAbstraction.java
+++ b/kernel/src/main/java/org/kframework/compile/transformers/ResolveContextAbstraction.java
@@ -134,6 +134,9 @@ public class ResolveContextAbstraction extends CopyOnWriteTransformer {
         bringToLevel(visitor, min);
         LinkedList<Term> cells = visitor.levels.get(min);
         Cell parentCell = createParentCell(confCell, cells);
+        if (!cells.isEmpty()) {
+            throw KExceptionManager.criticalError("Found term remaining in cell collection after populating parent cell. Did you duplicate a cell accidentally?", cells.iterator().next());
+        }
         assert(cells.isEmpty());
         if (change) cell = parentCell;
         return cell;


### PR DESCRIPTION
@bmmoore please review. Note that I wouldn't bother with this were it not so extremely quick to fix. The new KORE implementation already catches this error, after all. But it's an easy way to close out the issue, so I took it.
