### PR TITLE
add build instructions for reference manual

### DIFF
--- a/k-distribution/documentation/README.md
+++ b/k-distribution/documentation/README.md
@@ -1,0 +1,5 @@
+To build the reference manual, run:
+```
+kompile ref-manual.k --main-module AUTO-INCLUDED-MODULE
+kdoc
+```

--- a/k-distribution/documentation/README.md
+++ b/k-distribution/documentation/README.md
@@ -1,3 +1,4 @@
+<!-- Copyright (c) 2015 K Team. All Rights Reserved. -->
 To build the reference manual, run:
 ```
 kompile ref-manual.k --main-module AUTO-INCLUDED-MODULE


### PR DESCRIPTION
@grosu please review.

Note that once we include documentation for the prelude in the reference manual, the build instructions will look much nicer. But that's not a huge priority since we haven't created a manual yet, and likely will not until K 4.0.
