### PR TITLE
fix #45 : better error message on JavaCC ParseException

### DIFF
--- a/kernel/src/main/javacc/Outer.jj
+++ b/kernel/src/main/javacc/Outer.jj
@@ -229,6 +229,7 @@ public class Outer {
       // TODO: report location
       throw KExceptionManager.outerParserError("Encountered " + StringUtil.enquoteCString(e.currentToken.next.image)
             + ".\nWas expecting one of: " + Stream.of(e.expectedTokenSequences)
+            // using an anonymous class because JavaCC doesn't support Java 8 syntax.
               .map(new Function<int[], String>() {
                 public String apply(int[] is) {
                   StringBuilder sb = new StringBuilder();

--- a/kernel/src/main/javacc/Outer.jj
+++ b/kernel/src/main/javacc/Outer.jj
@@ -190,8 +190,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 // Comments get processed in an odd order that may cause them to be
 // out of order.  Thus we sort module items by their *end* position so
@@ -224,8 +227,20 @@ public class Outer {
       return parser.Start();
     } catch (ParseException e) {
       // TODO: report location
-      throw KExceptionManager.outerParserError(e.getMessage(), e, source,
-      	new Location(e.currentToken.beginLine, e.currentToken.beginColumn, e.currentToken.endLine, e.currentToken.endColumn));
+      throw KExceptionManager.outerParserError("Encountered " + StringUtil.enquoteCString(e.currentToken.next.image)
+            + ".\nWas expecting one of: " + Stream.of(e.expectedTokenSequences)
+              .map(new Function<int[], String>() {
+                public String apply(int[] is) {
+                  StringBuilder sb = new StringBuilder();
+                  for (int i : is) {
+                    sb.append(e.tokenImage[i]);
+                    sb.append(" ");
+                  }
+                  sb.deleteCharAt(sb.length() - 1);
+                  return sb.toString();
+                }
+              }).collect(Collectors.toList()).toString(), e, source,
+            new Location(e.currentToken.next.beginLine, e.currentToken.next.beginColumn, e.currentToken.next.endLine, e.currentToken.next.endColumn));
     } catch (TokenMgrError e) {
       throw KExceptionManager.outerParserError(e.getMessage(), e, source, null);
     }

--- a/kernel/src/main/javacc/Outer.jj
+++ b/kernel/src/main/javacc/Outer.jj
@@ -226,7 +226,6 @@ public class Outer {
     try {
       return parser.Start();
     } catch (ParseException e) {
-      // TODO: report location
       throw KExceptionManager.outerParserError("Encountered " + e.tokenImage[e.currentToken.next.kind]
             + ".\nWas expecting one of: " + Stream.of(e.expectedTokenSequences)
             // using an anonymous class because JavaCC doesn't support Java 8 syntax.
@@ -243,6 +242,7 @@ public class Outer {
               }).collect(Collectors.toList()).toString(), e, source,
             new Location(e.currentToken.next.beginLine, e.currentToken.next.beginColumn, e.currentToken.next.endLine, e.currentToken.next.endColumn));
     } catch (TokenMgrError e) {
+      // TODO: report location
       throw KExceptionManager.outerParserError(e.getMessage(), e, source, null);
     }
   }

--- a/kernel/src/main/javacc/Outer.jj
+++ b/kernel/src/main/javacc/Outer.jj
@@ -227,7 +227,7 @@ public class Outer {
       return parser.Start();
     } catch (ParseException e) {
       // TODO: report location
-      throw KExceptionManager.outerParserError("Encountered " + StringUtil.enquoteCString(e.currentToken.next.image)
+      throw KExceptionManager.outerParserError("Encountered " + e.tokenImage[e.currentToken.next.kind]
             + ".\nWas expecting one of: " + Stream.of(e.expectedTokenSequences)
             // using an anonymous class because JavaCC doesn't support Java 8 syntax.
               .map(new Function<int[], String>() {


### PR DESCRIPTION
@radumereuta please review

Sample error message:

```
[Error] Inner Parser: Encountered "|".
Was expecting one of: [<STRING>, <STRING_CASE_INSENSITIVE>, <STRING_REGEX>,
"(", "List", "NeList", "Lexer", "Token", <UPPER_ID>, <UPPER_ID>, "List",
"NeList", "Lexer", "Token"]
    Source(./test.k)
    Location(2,22,2,22)
```
