### PR TITLE
fix #1437 : align latex cells by cell label instead of cell content

### DIFF
--- a/k-distribution/include/latex/k.sty
+++ b/k-distribution/include/latex/k.sty
@@ -1,4 +1,4 @@
-% Copyright (c) 2012-2014 K Team. All Rights Reserved.
+% Copyright (c) 2012-2015 K Team. All Rights Reserved.
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{k}[2012/02/14 Package for typesetting K Framework definitions http://k-framework.org]
 

--- a/k-distribution/include/latex/k.sty
+++ b/k-distribution/include/latex/k.sty
@@ -732,7 +732,7 @@ $\mid\;{#2}$ \ifthenelse{\equal{#3}{}}{}{[#3]\;}%
   % Parameters #4 and #5 determine whether the west and east arc are curved
   % or straight ("whole" or "ruptured").
 
-  \begin{tikzpicture}[baseline=(cell content.base)]
+  \begin{tikzpicture}[baseline=(cell label.base)]
     \begin{scope}[inner sep=0pt,outer sep=0pt,anchor=base west]
       % Beside the cell content, also draw an empty node a bit wider than
       % the cell label.  That way, the cell body will always be wide enough


### PR DESCRIPTION
@grosu please review. If you could compare what the code looks like before vs after, and let me know if you think it's an improvement, that would be great. Basically, this code makes all the cells align based on their cell label instead of based on the baseline of their content.
