### PR TITLE
implement #1422

### DIFF
--- a/kernel/src/main/java/org/kframework/ktest/Test/TestCase.java
+++ b/kernel/src/main/java/org/kframework/ktest/Test/TestCase.java
@@ -459,8 +459,13 @@ public class TestCase {
                     // skip excluded files
                     boolean exclude = false;
                     for (String excludedPattern : excludes)
-                            if (pgmFilePath.contains(excludedPattern))
-                                exclude = true;
+                        if (pgmFilePath.contains(excludedPattern)) {
+                            if (options.isVerbose()) {
+                                System.out.format("Excluding file %s (matching pattern: \"%s\")%n",
+                                        pgmFilePath, excludedPattern);
+                            }
+                            exclude = true;
+                        }
                     if (exclude)
                         continue;
 


### PR DESCRIPTION
Example output:

```
➜  lesson_2 git:(impl1422) ✗ ktest tests/config.xml --skip pdf --verbose
Parse command line options                                   =    12
Running ['/home/omer/kframework/k/k-distribution/target/release/k/bin/kompile' '/home/omer/kframework/k/k-distribution/tutorial/1_k/3_lambda++/lesson_2/lambda.k' '--superheat' 'strict' '--backend' 'java']
Done with ['/home/omer/kframework/k/k-distribution/target/release/k/bin/kompile' '/home/omer/kframework/k/k-distribution/tutorial/1_k/3_lambda++/lesson_2/lambda.k' '--superheat' 'strict' '--backend' 'java'] (time 2717 ms)
Excluding file /home/omer/kframework/k/k-distribution/tutorial/1_k/1_lambda/lesson_1/tests/omega.lambda (matching pattern: "omega")
... snip ...
```

See the line starting with `Excluding file ...`. It's only printed in verbose mode.
