### PR TITLE
Avoid keywords in label unparsing.

### DIFF
--- a/kore/src/main/scala/org/kframework/kore/Unparse.scala
+++ b/kore/src/main/scala/org/kframework/kore/Unparse.scala
@@ -39,7 +39,8 @@ object ToKast {
   def escape(s: String): String = StringEscapeUtils.escapeJava(s)
 
   def unparse(inParen: Boolean, l: KLabel) : String = {
-    if (l.name.matches("[#a-z][a-zA-Z0-9]*")) {
+    if (l.name.matches("[#a-z][a-zA-Z0-9]*")
+        && l.name != "#token" && l.name != "#klabel") {
       l.name
     } else if (inParen) {
       " `"+l.name+'`'

--- a/kore/src/test/scala/org/kframework/kore/UnparseTest.scala
+++ b/kore/src/test/scala/org/kframework/kore/UnparseTest.scala
@@ -59,4 +59,11 @@ class UnparseTest {
   @Test def TickSpace() {
     Assert.assertEquals("`` `_+_`(.KList)=>b(.KList)``~>c(.KList)",ToKast(KRewrite(KLabel("_+_")(),'b())~>'c()))
   }
+
+  @Test def testKeywords(): Unit = {
+    Assert.assertEquals("#a(.KList)~>`#klabel`(.KList)~>#klabel(test)~>`#token`(.KList)~>#token(\"Int\",\"1\")",
+      ToKast(KSequence(KLabel("#a")(),
+        KLabel("#klabel")(), InjectedKLabel(KLabel("test"),Att()),
+        KLabel("#token")(),  KToken(Sort("Int"),"1"))))
+  }
 }


### PR DESCRIPTION
The lexical syntax of labels based on kore.k allows
some labels to be printed without backquotes, including alphabetical
names with an optional leading `#`, but we need to make sure
labels named `#klabel` or `#token` are printed with quotes to
avoid confusion with tokens and injected labels.
