### PR TITLE
Add minimum Java release number to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is a readme file for the developers.
 
 # Prerequisites
 
-## Java Development Kit (required JDK8 or higher)
+## Java Development Kit (required JDK8 version 8u45 or higher)
 You can follow the instructions http://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html depending on
 the type of your machine.
 


### PR DESCRIPTION
Some code no longer compiles with older Java 8 JDK releases.
This commit adds a precise version number to the README.md,
specifically 8u45 which is known to work because that's
what Jenkins is currently using.
