### PR TITLE
fix race in KompileOptions.files

### DIFF
--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -26,11 +26,17 @@ public class KompileOptions implements Serializable {
     @Parameter(description="<file>")
     private List<String> parameters;
 
+    private File mainDefinitionFile;
+
     public File mainDefinitionFile() {
-        if (parameters == null || parameters.size() == 0) {
-            throw KEMException.criticalError("You have to provide exactly one main file in order to compile.");
+        File m = mainDefinitionFile;
+        if (m == null) {
+            if (parameters == null || parameters.size() == 0) {
+                throw KEMException.criticalError("You have to provide exactly one main file in order to compile.");
+            }
+            m = mainDefinitionFile = files.get().resolveWorkingDirectory(parameters.get(0));
         }
-        return files.get().resolveWorkingDirectory(parameters.get(0));
+        return m;
     }
 
     private transient Provider<FileUtil> files;

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -28,15 +28,14 @@ public class KompileOptions implements Serializable {
 
     private File mainDefinitionFile;
 
-    public File mainDefinitionFile() {
-        File m = mainDefinitionFile;
-        if (m == null) {
+    public synchronized File mainDefinitionFile() {
+        if (mainDefinitionFile == null) {
             if (parameters == null || parameters.size() == 0) {
                 throw KEMException.criticalError("You have to provide exactly one main file in order to compile.");
             }
-            m = mainDefinitionFile = files.get().resolveWorkingDirectory(parameters.get(0));
+            mainDefinitionFile = files.get().resolveWorkingDirectory(parameters.get(0));
         }
-        return m;
+        return mainDefinitionFile;
     }
 
     private transient Provider<FileUtil> files;

--- a/kernel/src/main/java/org/kframework/utils/inject/DefinitionLoadingModule.java
+++ b/kernel/src/main/java/org/kframework/utils/inject/DefinitionLoadingModule.java
@@ -72,7 +72,6 @@ public class DefinitionLoadingModule extends AbstractModule {
         // a hack, but it's good enough for what we need from it, which is a temporary solution
         if (files.get().resolveKompiled("compiled.bin").exists()) {
             KompileOptions res = compiledDef.get().kompileOptions;
-            res.setFiles(files);
             return res;
         } else {
             Context res = context.get();


### PR DESCRIPTION
@yilongli please review. The net effect of this is that mainDefinitionFile is always accessed in kompile and therefore we don't need the FileUtil in this class in krun.

fixes https://github.com/kframework/k/issues/1543
