### PR TITLE
Nice error for configuration needing Map module

### DIFF
--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -293,7 +293,13 @@ public class Kompile {
                         configDecl -> stream(GenerateSentencesFromConfigDecl.gen(configDecl.body(), configDecl.ensures(), configDecl.att(), parser.getExtensionModule())))
                 .collect(Collections.toSet());
 
-        return Module(module.name(), (Set<Module>) module.imports().$bar(Set(def.getModule("MAP").get())), (Set<Sentence>) module.localSentences().$bar(configDeclProductions), module.att());
+        Module mapModule;
+        if (def.getModule("MAP").isDefined()) {
+            mapModule = def.getModule("MAP").get();
+        } else {
+            throw KEMException.compilerError("Module Map must be visible at the configuration declaration, in module "+module.name());
+        }
+        return Module(module.name(), (Set<Module>) module.imports().$bar(Set(mapModule)), (Set<Sentence>) module.localSentences().$bar(configDeclProductions), module.att());
     }
 
     private Module resolveBubbles(Module module) {


### PR DESCRIPTION
Replace a bare .get with a better check that a Map
module is available, when processing the configuration
in Kompile (which assumes it can use the standard Maps if desired).
