### PR TITLE
Documentation fix for krun -p option

### DIFF
--- a/kernel/src/main/java/org/kframework/krun/KRunOptions.java
+++ b/kernel/src/main/java/org/kframework/krun/KRunOptions.java
@@ -85,7 +85,7 @@ public final class KRunOptions {
 
         @DynamicParameter(names={"--config-parser", "-p"}, description="Command used to parse " +
                 "configuration variables. Default is \"kast --parser ground -e\". See description of " +
-                "--parser. For example, -cpPGM=\"kast\" specifies that the configuration variable $PGM " +
+                "--parser. For example, -pPGM=\"kast\" specifies that the configuration variable $PGM " +
                 "should be parsed with the command \"kast\".")
         private Map<String, String> configVarParsers = new HashMap<>();
 


### PR DESCRIPTION
The short form is just `-p`, not `-cp` like in the example in the `--help` text.
