### PR TITLE
Type inference fix

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/VariableTypeInferenceFilter.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/VariableTypeInferenceFilter.java
@@ -61,20 +61,6 @@ public class VariableTypeInferenceFilter extends SetsGeneralTransformer<ParseFai
         this.inferSortChecks = inferSortChecks;
     }
 
-    /** return the subset of maximal elements of {@code sorts} */
-    private Set<Sort> maximal(Collection<Sort> sorts) {
-        Set<Sort> maxSorts = new HashSet<>();
-
-        nextsort:
-        for (Sort vv1 : sorts) {
-            for (Sort vv2 : sorts)
-                if (subsorts.lessThan(vv1, vv2))
-                    continue nextsort;
-            maxSorts.add(vv1);
-        }
-        return maxSorts;
-    }
-
     /** Return the set of all known sorts which are a lower bound on
      * all sorts in {@code bounds}, leaving out internal sorts below "KBott".
      */
@@ -216,7 +202,7 @@ public class VariableTypeInferenceFilter extends SetsGeneralTransformer<ParseFai
                         solution.clear();
                         break;
                     } else {
-                        solution.putAll(key, maximal(mins));
+                        solution.putAll(key, subsorts.maximal(mins));
                     }
                 }
                 // I found a solution that fits everywhere, then store it for disambiguation
@@ -268,7 +254,7 @@ public class VariableTypeInferenceFilter extends SetsGeneralTransformer<ParseFai
                 }
                 Multimap<VarKey,Sort> solution = HashMultimap.create();
                 for (VarKey k : varBounds.keySet()) {
-                    Set<Sort> sorts = maximal(varBounds.get(k));
+                    Set<Sort> sorts = subsorts.maximal(varBounds.get(k));
                     if (sorts.size() > 1) {
                         String msg = "Could not infer a unique sort for variable " + k + ".";
                         msg += " Possible sorts: ";

--- a/kernel/src/test/java/org/kframework/parser/concrete2kore/RuleGrammarTest.java
+++ b/kernel/src/test/java/org/kframework/parser/concrete2kore/RuleGrammarTest.java
@@ -360,7 +360,7 @@ public class RuleGrammarTest {
                 "syntax TB ::= t(B) [klabel(t)] " +
                 "endmodule";
         parseRule("t(Y) => .K", def, 0, true); // incorrect result, should infer a type
-        parseRule("t(_) => .K", def, 1, false); // incorrect result, this is reporting an ambiguity.
+        parseRule("t(_) => .K", def, 0, true); // incorrect result, should infer a type
     }
 
     // test inference with complicated ambiguity

--- a/kernel/src/test/java/org/kframework/parser/concrete2kore/RuleGrammarTest.java
+++ b/kernel/src/test/java/org/kframework/parser/concrete2kore/RuleGrammarTest.java
@@ -347,4 +347,36 @@ public class RuleGrammarTest {
         parseProgram("0()", def, "Exp", 0, false);
         parseProgram("0[]", def, "Exp", 0, true);
     }
+
+    // test inference with overloading.
+    // regression test for issue #1586
+    @Test
+    public void test21() {
+        String def = "" +
+                "module TEST " +
+                "syntax A ::= B | \"a\" " +
+                "syntax B ::= \"b\" " +
+                "syntax TA ::= TB | t(A) [klabel(t)] " +
+                "syntax TB ::= t(B) [klabel(t)] " +
+                "endmodule";
+        parseRule("t(Y) => .K", def, 0, true); // incorrect result, should infer a type
+        parseRule("t(_) => .K", def, 1, false); // incorrect result, this is reporting an ambiguity.
+    }
+
+    // test inference with complicated ambiguity
+    // regression test for issue #1603
+    @Test
+    public void test22() {
+        String def = "" +
+                "module TEST\n" +
+                "syntax T ::= \"wrap\" M [klabel(wrapM)] | \"wrap\" X [klabel(wrapX)]\n" +
+                "syntax A\n" +
+                "syntax B\n" +
+                "syntax M ::= A | B\n" +
+                "syntax N ::= A | B | X // make A and B both maximal in the intersection of N and M\n" +
+                "syntax X\n" +
+                "syntax KItem ::= label(N,T)\n" +
+                "endmodule";
+        parseRule("X => label(X,wrap X)", def, 1, false); // incorect result, this should be an error.
+    }
 }

--- a/kernel/src/test/java/org/kframework/parser/concrete2kore/RuleGrammarTest.java
+++ b/kernel/src/test/java/org/kframework/parser/concrete2kore/RuleGrammarTest.java
@@ -359,8 +359,8 @@ public class RuleGrammarTest {
                 "syntax TA ::= TB | t(A) [klabel(t)] " +
                 "syntax TB ::= t(B) [klabel(t)] " +
                 "endmodule";
-        parseRule("t(Y) => .K", def, 0, true); // incorrect result, should infer a type
-        parseRule("t(_) => .K", def, 0, true); // incorrect result, should infer a type
+        parseRule("t(Y) => .K", def, 1, false);
+        parseRule("t(_) => .K", def, 0, false);
     }
 
     // test inference with complicated ambiguity
@@ -377,6 +377,6 @@ public class RuleGrammarTest {
                 "syntax X\n" +
                 "syntax KItem ::= label(N,T)\n" +
                 "endmodule";
-        parseRule("X => label(X,wrap X)", def, 1, false); // incorect result, this should be an error.
+        parseRule("X => label(X,wrap X)", def, 0, true);
     }
 }

--- a/kore/src/main/scala/org/kframework/POSet.scala
+++ b/kore/src/main/scala/org/kframework/POSet.scala
@@ -1,6 +1,7 @@
 // Copyright (c) 2015 K Team. All Rights Reserved.
 package org.kframework
 
+import java.util
 import java.util.Optional
 
 case class CircularityException[T](cycle: Seq[T]) extends Exception(cycle.mkString(" < "))
@@ -99,6 +100,18 @@ class POSet[T](directRelations: Set[(T, T)]) extends Serializable {
             def compare(x: T, y: T) = if (x < y) -1 else if (x > y) 1 else 0
           }))
     }
+  }
+
+  /** Return the subset of items from the argument which are not
+    * less then any other item.
+    */
+  def maximal(sorts : Iterable[T]) : Set[T] =
+    sorts.filter(s1 => !sorts.exists(s2 => lessThan(s1,s2))).toSet
+
+  def maximal(sorts : util.Collection[T]) : util.Set[T] = {
+    import scala.collection.JavaConversions._
+    val sorts2 : Iterable[T] = sorts;
+    maximal(sorts2)
   }
 
   override def toString() = {


### PR DESCRIPTION
This updates the type inference code to calculate sorts also for _ variables, and to more carefully combine sort constraints from multiple possible parses.

Now a variable is assigned an inferred sort only if that sort is a (nonstrict) supersort of the sort the variable has in every possible way of assigning legal variable sorts in any of the possible ambiguous parses. An error will be reported if any variable doesn't have a unique maximal sort, or if it's not possible to simultaneously assign all those sorts. Also, an ambiguity error will be reported a bit after this code if assigning these inferred types isn't enough to reduce the possible parses down to a single KORE term (debugging VariableTypeInferenceFilter may show some ambiguity nodes, because this code is still working in terms of productions where e.g. overloaded labels may lead to mutliple syntax trees that still eventually flatten to the same AST).

@radumereuta please review.

Fixes #1586 and #1603.
