### PR TITLE
Fix configuration generation for optional cells.

### DIFF
--- a/kernel/src/main/java/org/kframework/kore/compile/GenerateSentencesFromConfigDecl.java
+++ b/kernel/src/main/java/org/kframework/kore/compile/GenerateSentencesFromConfigDecl.java
@@ -372,9 +372,10 @@ public class GenerateSentencesFromConfigDecl {
         } else if (multiplicity == Multiplicity.OPTIONAL) {
             // syntax Cell ::= ".Cell"
             Production cellUnit = Production("." + sortName, sort, Seq(Terminal("." + sortName)));
-            // add UNIT_KEY attribute to cell production.
-            cellProduction = Production(cellProduction.sort(), cellProduction.items(), cellProduction.att().add(Attribute.UNIT_KEY, cellUnit.klabel().get().name()));
             sentences.add(cellUnit);
+            // add UNIT_KEY attribute to cell production.
+            sentences.remove(cellProduction);
+            cellProduction = Production(cellProduction.sort(), cellProduction.items(), cellProduction.att().add(Attribute.UNIT_KEY, cellUnit.klabel().get().name()));
             sentences.add(cellProduction);
             // rule initCell => .CellBag
             // -or-

--- a/kernel/src/test/java/org/kframework/kore/compile/GenerateSentencesFromConfigDeclTest.java
+++ b/kernel/src/test/java/org/kframework/kore/compile/GenerateSentencesFromConfigDeclTest.java
@@ -4,6 +4,7 @@ package org.kframework.kore.compile;
 import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
+import org.kframework.attributes.Att;
 import org.kframework.attributes.Source;
 import org.kframework.builtin.BooleanUtils;
 import org.kframework.builtin.Sorts;
@@ -65,33 +66,47 @@ public class GenerateSentencesFromConfigDeclTest {
         RuleGrammarGenerator parserGen = new RuleGrammarGenerator(def, true);
         Module m = parserGen.getCombinedGrammar(parserGen.getConfigGrammar(m1)).getExtensionModule();
         Set<Sentence> gen = GenerateSentencesFromConfigDecl.gen(configuration, BooleanUtils.FALSE, Att(), m);
-        Set reference = Set(Production("<threads>", Sort("ThreadsCell"),
-                        Seq(Terminal("<threads>"), NonTerminal(Sort("ThreadCellBag")), Terminal("</threads>"))),
+        Att initializerAtts = Att().add("function").add("initializer");
+        Set<Sentence> reference = Set(Production("<threads>", Sort("ThreadsCell"),
+                        Seq(Terminal("<threads>"), NonTerminal(Sort("ThreadCellBag")), Terminal("</threads>")),
+                        Att().add("cell").add("topcell")),
                 SyntaxSort(Sort("ThreadCellBag"), Att().add("hook", "BAG.Bag")),
                 Production("_ThreadCellBag_", Sort("ThreadCellBag"),
-                        Seq(NonTerminal(Sort("ThreadCellBag")), NonTerminal(Sort("ThreadCellBag")))),
+                        Seq(NonTerminal(Sort("ThreadCellBag")), NonTerminal(Sort("ThreadCellBag"))),
+                        Att().add("assoc","").add("comm","").add("unit",".ThreadCellBag")
+                                .add("element","ThreadCellBagItem").add("wrapElement","<thread>")
+                                .add("function").add("hook","BAG.concat")),
                 Production(".ThreadCellBag", Sort("ThreadCellBag"),
-                        Seq(Terminal(".ThreadCellBag"))),
+                        Seq(Terminal(".ThreadCellBag")),
+                        Att().add("function").add("hook","BAG.unit")),
                 Production(Sort("ThreadCellBag"),
                         Seq(NonTerminal(Sort("ThreadCell")))),
                 Production("ThreadCellBagItem", Sort("ThreadCellBag"),
-                        Seq(Terminal("ThreadCellBagItem"), Terminal("("), NonTerminal(Sort("ThreadCell")), Terminal(")"))),
+                        Seq(Terminal("ThreadCellBagItem"), Terminal("("), NonTerminal(Sort("ThreadCell")), Terminal(")")),
+                        Att().add("function").add("hook","BAG.element")),
                 Production("<thread>", Sort("ThreadCell"),
-                        Seq(Terminal("<thread>"), NonTerminal(Sort("KCell")), NonTerminal(Sort("OptCell")), Terminal("</thread>"))),
+                        Seq(Terminal("<thread>"), NonTerminal(Sort("KCell")), NonTerminal(Sort("OptCell")), Terminal("</thread>")),
+                        Att().add("cell").add("multiplicity","*")),
                 Production("<k>", Sort("KCell"),
-                        Seq(Terminal("<k>"), NonTerminal(Sort("K")), Terminal("</k>"))),
+                        Seq(Terminal("<k>"), NonTerminal(Sort("K")), Terminal("</k>")),
+                        Att().add("cell").add("maincell")),
                 Production("<opt>", Sort("OptCell"),
-                        Seq(Terminal("<opt>"), NonTerminal(Sort("OptCellContent")), Terminal("</opt>"))),
+                        Seq(Terminal("<opt>"), NonTerminal(Sort("OptCellContent")), Terminal("</opt>")),
+                        Att().add("cell").add("multiplicity","?").add("unit",".OptCell")),
                 Production(".OptCell", Sort("OptCell"),
                         Seq(Terminal(".OptCell"))),
                 Production("initThreadsCell", Sort("ThreadsCell"),
-                        Seq(Terminal("initThreadsCell"), Terminal("("), NonTerminal(Sort("Map")), Terminal(")"))),
+                        Seq(Terminal("initThreadsCell"), Terminal("("), NonTerminal(Sort("Map")), Terminal(")")),
+                        initializerAtts),
                 Production("initThreadCell", Sort("ThreadCell"),
-                        Seq(Terminal("initThreadCell"), Terminal("("), NonTerminal(Sort("Map")), Terminal(")"))),
+                        Seq(Terminal("initThreadCell"), Terminal("("), NonTerminal(Sort("Map")), Terminal(")")),
+                        initializerAtts),
                 Production("initKCell", Sort("KCell"),
-                        Seq(Terminal("initKCell"), Terminal("("), NonTerminal(Sort("Map")), Terminal(")"))),
+                        Seq(Terminal("initKCell"), Terminal("("), NonTerminal(Sort("Map")), Terminal(")")),
+                        initializerAtts),
                 Production("initOptCell", Sort("OptCell"),
-                        Seq(Terminal("initOptCell"))),
+                        Seq(Terminal("initOptCell")),
+                        initializerAtts),
                 Rule(KRewrite(KApply(KLabel("initThreadsCell"), KVariable("Init")),
                                 IncompleteCellUtils.make(KLabel("<threads>"), false,
                                         KApply(KLabel("initThreadCell"), KVariable("Init")), false)),
@@ -120,9 +135,20 @@ public class GenerateSentencesFromConfigDeclTest {
                 Production(Sort("KCellOpt"), Seq(NonTerminal(Sort("KCell")))),
                 Production("noKCell", Sort("KCellOpt"), Seq(Terminal("noKCell")),Att().add(Attribute.CELL_OPT_ABSENT_KEY, "KCell"))
             );
-        assertEquals(Set(),reference.$amp$tilde(gen));
-        assertEquals(Set(), gen.$amp$tilde(reference));
-        assertEquals(reference, gen);
+
+        assertEquals("Missing expected productions", Set(), reference.$amp$tilde(gen));
+        assertEquals("Produced unexpected productions", Set(), gen.$amp$tilde(reference));
+        // Production.equals ignores attributes, but they are important here
+        nextgen:
+        for (Sentence g : iterable(gen)) {
+            for (Sentence r : iterable(reference)) {
+                if (g.equals(r)) {
+                    assertEquals("Production "+r+" generated with incorrect attributes", r.att(), g.att());
+                    continue nextgen;
+                }
+            }
+            assert false; // We checked set equality above
+        }
     }
 
     private KApply cells(K cell1, K cell2) {


### PR DESCRIPTION
This fixes an error introduced in #1588, where the cell production
for optional cells lost the `unit` attribute which later passes use to
recodngize optional cells.
In particular this is critical for configuration abstraction, and leads to
a compilation error on definitions which have an optional cell and
any rule where a closed instance of the parent cell is missing the optional cell.
For a cell without the `inital` attribute, the generated initializer rule will contain
such a pattern, but the initial optional cells may not be noticed.

None of the end-to-end kore tests used optional cells enough to recognize this, and
the unit test which tries to cover this case missed it because
GenerateSentencesFromConfigDeclTest was relying on Production.equals
which intentionally ignores attributes other than klabel.
This pull request also improves the unit test to compare with expected attributes.

@dwightguth please review
Fixes #1612
