### PR TITLE
Eliminate unnecessary variable in POSet

### DIFF
--- a/kore/src/main/scala/org/kframework/POSet.scala
+++ b/kore/src/main/scala/org/kframework/POSet.scala
@@ -110,8 +110,7 @@ class POSet[T](directRelations: Set[(T, T)]) extends Serializable {
 
   def maximal(sorts : util.Collection[T]) : util.Set[T] = {
     import scala.collection.JavaConversions._
-    val sorts2 : Iterable[T] = sorts;
-    maximal(sorts2)
+    maximal(sorts : Iterable[T])
   }
 
   override def toString() = {


### PR DESCRIPTION
Use an actual type annotation rather than introducing a val just to set the type.
Thanks to @cos for the right syntax. 
