### PR TITLE
several optimizations to startup time for OCAML backend

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/AbstractUnifier.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/AbstractUnifier.java
@@ -1,36 +1,15 @@
 // Copyright (c) 2013-2015 K Team. All Rights Reserved.
 package org.kframework.backend.java.symbolic;
 
-import org.kframework.backend.java.kil.Bottom;
-import org.kframework.backend.java.kil.BuiltinList;
-import org.kframework.backend.java.kil.BuiltinMap;
-import org.kframework.backend.java.kil.BuiltinSet;
-import org.kframework.backend.java.kil.CellCollection;
-import org.kframework.backend.java.kil.Hole;
-import org.kframework.backend.java.kil.InjectedKLabel;
-import org.kframework.backend.java.kil.KCollection;
-import org.kframework.backend.java.kil.KItem;
-import org.kframework.backend.java.kil.KLabelConstant;
-import org.kframework.backend.java.kil.KLabelInjection;
-import org.kframework.backend.java.kil.KList;
-import org.kframework.backend.java.kil.KSequence;
-import org.kframework.backend.java.kil.Kind;
-import org.kframework.backend.java.kil.Term;
-import org.kframework.backend.java.kil.TermContext;
-import org.kframework.backend.java.kil.Token;
-import org.kframework.backend.java.kil.Variable;
-import org.kframework.backend.java.util.Profiler;
-import org.kframework.utils.errorsystem.KEMException;
+import com.google.common.collect.Multimap;
+import org.apache.commons.lang3.tuple.Pair;
+import org.kframework.backend.java.kil.*;
+import org.kframework.backend.java.util.DoubleLinkedList;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.apache.commons.lang3.tuple.Pair;
-import com.google.common.collect.Multimap;
 
 
 /**
@@ -68,8 +47,8 @@ public abstract class AbstractUnifier implements Unifier {
         }
     }
 
-    private final Deque<Pair<Term, Term>> tasks = new ArrayDeque<>();
-    private final Deque<Pair<Term, Term>> taskBuffer = new ArrayDeque<>();
+    private final DoubleLinkedList<Pair<Term, Term>> tasks = new DoubleLinkedList<>();
+    private final DoubleLinkedList<Pair<Term, Term>> taskBuffer = new DoubleLinkedList<>();
 
     protected boolean failed = false;
 
@@ -78,7 +57,7 @@ public abstract class AbstractUnifier implements Unifier {
     protected TermContext termContext;
 
     void addUnificationTask(Term term, Term otherTerm) {
-        taskBuffer.push(Pair.of(term, otherTerm));
+        taskBuffer.add(Pair.of(term, otherTerm));
     }
 
     /**
@@ -213,9 +192,7 @@ public abstract class AbstractUnifier implements Unifier {
     }
 
     private void flushTaskBuffer() {
-        while (!taskBuffer.isEmpty()) {
-            tasks.push(taskBuffer.pop());
-        }
+        tasks.pushAll(taskBuffer);
     }
 
     abstract void add(Term left, Term right);

--- a/java-backend/src/main/java/org/kframework/backend/java/util/DoubleLinkedList.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/DoubleLinkedList.java
@@ -1,0 +1,87 @@
+// Copyright (c) 2015 K Team. All Rights Reserved.
+package org.kframework.backend.java.util;
+
+import java.util.NoSuchElementException;
+
+/**
+ * A primitive doubly-linked list which was created in order to allow certain operations
+ * to occur in constant time which java.util.LinkedList did not.
+ * Currently only enough functionality is supported
+ * to be able to handle the behavior of AbstractUnifier.
+ * @param <E>
+ */
+public class DoubleLinkedList<E> {
+
+    private static class Entry<E> {
+        private E value;
+        private Entry<E> next;
+        private Entry<E> prev;
+
+        Entry(E value, Entry<E> next, Entry<E> prev) {
+            this.value = value;
+            this.next = next;
+            this.prev = prev;
+        }
+    }
+
+    private Entry<E> head;
+    private Entry<E> tail;
+
+    public void clear() {
+        head = tail = null;
+    }
+
+    public boolean isEmpty() {
+        return head == null;
+    }
+
+    public void add(E e) {
+        Entry<E> entry = new Entry<>(e, null, tail);
+        if (tail == null) {
+            head = tail = entry;
+        } else {
+            tail.next = entry;
+            tail = entry;
+        }
+    }
+
+    public E pop() {
+        if (head == null) {
+            throw new NoSuchElementException();
+        } else {
+            Entry<E> entry = head;
+            head = entry.next;
+            entry.next = null;
+            if (head == null)
+                tail = null;
+            else
+                head.prev = null;
+            return entry.value;
+        }
+    }
+
+    /**
+     * Appends the specified list to the front of this list in constant time.
+     * Because references to elements in {@code list} are no longer safe after becoming
+     * part of another list reference, the specified {@code list} is cleared
+     * and becomes empty.
+     *
+     * @param list
+     */
+    public void pushAll(DoubleLinkedList<E> list) {
+        Entry<E> listLast = list.tail;
+        if (listLast == null)
+            return;
+        Entry<E> thisFirst = this.head;
+        if (thisFirst == null) {
+            this.head = list.head;
+            this.tail = list.tail;
+            list.clear();
+            return;
+        }
+        listLast.next = thisFirst;
+        thisFirst.prev = listLast;
+        this.head = list.head;
+        list.clear();
+    }
+}

--- a/k-distribution/include/ocaml/lexer.mll
+++ b/k-distribution/include/ocaml/lexer.mll
@@ -1,0 +1,23 @@
+{ open Parser }
+
+rule token = parse
+  | [' ' '\t' '\n' '\r'] { token lexbuf }
+  | "~>" { KSEQ }
+  | ".::K" { DOTK }
+  | ".K" { DOTK }
+  | "(" { LPAREN }
+  | ")" { RPAREN }
+  | "," { COMMA }
+  | ".::KList" { DOTKLIST }
+  | ".KList" { DOTKLIST }
+  | "#token" { TOKENLABEL }
+  | "#klabel" { KLABELLABEL }
+  | (['#' 'a'-'z'](['a'-'z' 'A'-'Z' '0'-'9'])*) as label { KLABEL label }
+  | ('"' ([^'"' '\\']|('\\' _))* '"') as s { STRING (Prelude.unescape_k_string s) }
+  | "`" (([^'`' '\\']|('\\' _))* as l) '`' { KLABEL (Str.global_replace (Str.regexp "\\\\(.)") "\\1" l) }
+  | eof { EOF }
+
+{ 
+let parse_k (str: string) =
+  let lexbuf = Lexing.from_string str in Parser.top token lexbuf
+}

--- a/k-distribution/include/ocaml/parser.mly
+++ b/k-distribution/include/ocaml/parser.mly
@@ -1,0 +1,35 @@
+%{
+open Constants.K
+%}
+
+%token <string> STRING KLABEL
+%token KSEQ DOTK LPAREN RPAREN COMMA DOTKLIST TOKENLABEL KLABELLABEL EOF
+
+%start top
+%type <Constants.k> top
+
+%left COMMA KSEQ
+
+%%
+
+top: k EOF { $1 }
+
+k:
+  kitem { $1 }
+| k KSEQ k { $1 @ $3 }
+| DOTK { [] }
+
+kitem: 
+  klabel LPAREN klist RPAREN { Def.eval (Constants.KApply($1, $3)) [] }
+| KLABELLABEL LPAREN klabel RPAREN { [InjectedKLabel $3] }
+| TOKENLABEL LPAREN STRING COMMA sort RPAREN { [Prelude.ktoken $5 $3] }
+
+klist:
+  k { [$1] }
+| klist COMMA klist { $1 @ $3 }
+| klist COMMA COMMA klist { $1 @ $4 }
+| DOTKLIST { [] }
+
+klabel: KLABEL { Constants.parse_klabel $1 }
+
+sort: STRING { Constants.parse_sort $1 }

--- a/kernel/src/main/java/org/kframework/kore/compile/DeconstructIntegerAndFloatLiterals.java
+++ b/kernel/src/main/java/org/kframework/kore/compile/DeconstructIntegerAndFloatLiterals.java
@@ -6,6 +6,7 @@ import org.kframework.builtin.Sorts;
 import org.kframework.definition.Context;
 import org.kframework.definition.Rule;
 import org.kframework.definition.Sentence;
+import org.kframework.kil.Attribute;
 import org.kframework.kore.K;
 import org.kframework.kore.KApply;
 import org.kframework.kore.KRewrite;
@@ -53,6 +54,9 @@ public class DeconstructIntegerAndFloatLiterals {
     }
 
     public Sentence convert(Sentence s) {
+        if (s.att().contains(Attribute.MACRO_KEY)) {
+            return s;
+        }
         if (s instanceof Rule) {
             return convert((Rule) s);
         } else if (s instanceof Context) {

--- a/kernel/src/main/java/org/kframework/krun/KRun.java
+++ b/kernel/src/main/java/org/kframework/krun/KRun.java
@@ -10,7 +10,6 @@ import org.kframework.definition.Module;
 import org.kframework.definition.Rule;
 import org.kframework.kil.Attributes;
 import org.kframework.kompile.CompiledDefinition;
-import org.kframework.kompile.Kompile;
 import org.kframework.kore.K;
 import org.kframework.kore.KApply;
 import org.kframework.kore.KToken;
@@ -129,7 +128,7 @@ public class KRun implements Transformation<Void, Void> {
         if (pattern != null && (options.experimental.prove != null || options.experimental.ltlmc())) {
             throw KEMException.criticalError("Pattern matching is not supported by model checking or proving");
         }
-        return new Kompile(compiledDef.kompileOptions, files, kem).compileRule(compiledDef, pattern, source);
+        return compiledDef.compilePatternIfAbsent(files, kem, pattern, source);
     }
 
     public static void prettyPrint(CompiledDefinition compiledDef, OutputModes output, Consumer<String> print, K result) {

--- a/kernel/src/main/java/org/kframework/krun/KRunOptions.java
+++ b/kernel/src/main/java/org/kframework/krun/KRunOptions.java
@@ -243,7 +243,7 @@ public final class KRunOptions {
     @Parameter(names="--pattern", description="Specify a term and/or side condition that the result of execution or search must match in order to succeed. Return the resulting matches as a list of substitutions. In conjunction with it you can specify other 2 options that are optional: bound (the number of desired solutions) and depth (the maximum depth of the search).")
     public String pattern;
 
-    @Parameter(names="--exit-code", description="Specify a term containing a named integer variable which will be used as the exit status of krun.")
+    @Parameter(names="--exit-code", description="Specify a matching pattern containing an integer variable which will be used as the exit status of krun.")
     public String exitCodePattern;
 
     public static final String DEFAULT_PATTERN = "<generatedTop> B:Bag </generatedTop> [anywhere]";

--- a/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlRewriter.java
+++ b/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlRewriter.java
@@ -121,6 +121,7 @@ public class OcamlRewriter implements Function<Module, Rewriter> {
                     args.add(files.resolveKompiled("prelude.cmx").getAbsolutePath());
                 }
                 args.addAll(Arrays.asList(files.resolveKompiled("def.cmx").getAbsolutePath(), "-I", files.resolveKompiled(".").getAbsolutePath(),
+                        files.resolveKompiled("parser.cmx").getAbsolutePath(), files.resolveKompiled("lexer.cmx").getAbsolutePath(),
                         name));
                 args.add("-inline");
                 args.add("20");
@@ -135,6 +136,7 @@ public class OcamlRewriter implements Function<Module, Rewriter> {
                     args.add(files.resolveKompiled("prelude.cmo").getAbsolutePath());
                 }
                 args.addAll(Arrays.asList(files.resolveKompiled("def.cmo").getAbsolutePath(), "-I", files.resolveKompiled(".").getAbsolutePath(),
+                        files.resolveKompiled("parser.cmo").getAbsolutePath(), files.resolveKompiled("lexer.cmo").getAbsolutePath(),
                         name));
                 pb = pb.command(args);
                 pb.environment().put("OCAMLFIND_COMMANDS", "ocamlc=ocamlc.opt");


### PR DESCRIPTION
@bmmoore @andreistefanescu please review.

Basically, I fixed the inefficiency in AbstractUnifier.flushTaskBuffer, added a definition-scoped cache for parses of patterns, and wrote code to parse K terms inside OCAML in order to decrease time spent compiling programs.
