### PR TITLE
rename the subsort instead of the supersort

### DIFF
--- a/k-distribution/tests/regression/smt-sort-flattening/test.k
+++ b/k-distribution/tests/regression/smt-sort-flattening/test.k
@@ -1,8 +1,12 @@
 // Copyright (c) 2015 K Team. All Rights Reserved.
 module TEST
+  syntax S ::= S1           [smt-sort-flatten]
+             | S2           [smt-sort-flatten]
   syntax S1 ::= foo1(Int)   [function, smtlib(foo1)]
-              | S2          [smt-sort-flatten]
+              | S3
   syntax S2 ::= foo2(Int)   [function, smtlib(foo2)]
+              | S3
+  syntax S3 ::= "s"
   syntax KItem ::= bar1(Int)
                  | bar2(Int)
 

--- a/kernel/src/main/java/org/kframework/kil/loader/Context.java
+++ b/kernel/src/main/java/org/kframework/kil/loader/Context.java
@@ -494,7 +494,7 @@ public class Context implements Serializable {
                         production);
             }
 
-            smtSortFlattening.put(production.getSort(), production.getSubsort());
+            smtSortFlattening.put(production.getSubsort(), production.getSort());
         }
     }
 


### PR DESCRIPTION
@daejunpark this fixes a bug in the previous commit; please review
