### PR TITLE
Make K_OPTS extend defaults

### DIFF
--- a/k-distribution/src/main/scripts/lib/k
+++ b/k-distribution/src/main/scripts/lib/k
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 source "$(dirname "$0")/setenv"
 ulimit -s `ulimit -H -s`
-if [ -z "$K_OPTS" ];
-  then export K_OPTS="-Xms64m -Xmx1024m -Xss32m -XX:+TieredCompilation"
-fi
+export K_OPTS="-Xms64m -Xmx1024m -Xss32m -XX:+TieredCompilation $K_OPTS"
 if "$(dirname "$0")/checkJava"; then
   if [[ `uname` == *MINGW* || `uname` == *CYGWIN* ]]; then
     NG=ng.exe


### PR DESCRIPTION
Changes the master k script so setting the K_OPT environment
variable does not completely remove K's default JVM options,
but instead lets settings in K_OPT override individual defaults.

This was noticed while working on the C semantics, where the makefile setting K_OPTS to increase heap size lost the default 32m stack size, leading to stack overflow errors.

@dwightguth please review.
