### PR TITLE
Simplify follow regex construction

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
@@ -214,8 +214,7 @@ public class RuleGrammarGenerator {
                                     });
                             // add follow restrictions for the characters that might produce ambiguities
                             if (!follow.isEmpty()) {
-                                String restriction = follow.stream().map(StringUtil::escapeAutomatonRegex).reduce((s1, s2) -> "(" + s1 + ")|(" + s2 + ")").get();
-                                return Terminal.apply(t.value(), restriction);
+                                return Terminal.apply(t.value(), follow.stream().collect(toList()));
                             }
                         }
                         return pi;

--- a/kernel/src/main/java/org/kframework/utils/StringUtil.java
+++ b/kernel/src/main/java/org/kframework/utils/StringUtil.java
@@ -669,8 +669,4 @@ public class StringUtil {
         result.append(delimiter);
         return result.toString();
     }
-
-    public static String escapeAutomatonRegex(String str) {
-        return "\"" + str.replace("\"", "\"\\\"\"") + "\"";
-    }
 }

--- a/kore/src/main/scala/org/kframework/definition/Constructors.scala
+++ b/kore/src/main/scala/org/kframework/definition/Constructors.scala
@@ -28,8 +28,7 @@ object Constructors {
   def Production(klabel: String, sort: Sort, items: Seq[ProductionItem]) = definition.Production(klabel, sort, items)
   def Production(klabel: String, sort: Sort, items: Seq[ProductionItem], att: attributes.Att) = definition.Production(klabel, sort, items, att)
 
-  def Terminal(s: String) = definition.Terminal(s, "#")
-  def Terminal(s: String, followRegexString: String) = definition.Terminal(s, followRegexString)
+  def Terminal(s: String) = definition.Terminal(s, Seq())
   def NonTerminal(sort: Sort) = definition.NonTerminal(sort)
   def RegexTerminal(regexString: String) = definition.RegexTerminal("#", regexString, "#")
   def RegexTerminal(precedeRegexString: String, regexString: String, followRegexString: String) = definition.RegexTerminal(precedeRegexString, regexString, followRegexString)

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -299,11 +299,12 @@ RegexTerminalToString {
   }
 }
 
-case class Terminal(value: String, followRegex: String) extends TerminalLike // hooked
+case class Terminal(value: String, followRegex: Seq[String]) extends TerminalLike // hooked
 with TerminalToString {
+  def this(value: String) = this(value, Seq())
   lazy val pattern = new RunAutomaton(BasicAutomata.makeString(value), false)
   lazy val followPattern =
-    new RunAutomaton(new RegExp(followRegex).toAutomaton, false)
+    new RunAutomaton(BasicAutomata.makeStringUnion(followRegex.toArray : _*), false)
   lazy val precedePattern = new RunAutomaton(BasicAutomata.makeEmpty(), false)
 }
 

--- a/kore/src/test/scala/org/kframework/meta/TestMeta.scala
+++ b/kore/src/test/scala/org/kframework/meta/TestMeta.scala
@@ -31,11 +31,11 @@ class TestMeta {
     if (x != y) Assert.assertEquals(x.toString, y.toString)
   }
 
-  val m = Module("TEST", Set(), Set(Production("Foo", Sort("Foo"), Seq(Terminal("Bar", "#")))))
+  val m = Module("TEST", Set(), Set(Production("Foo", Sort("Foo"), Seq(Terminal("Bar", Seq())))))
   val d = Definition(m, m, Set(m))
 
   val metamodule = 'Module("TEST", 'Set(),
-    'Set('Production("Foo", 'Sort("Foo"), 'List('Terminal("Bar", "#")))))
+    'Set('Production("Foo", 'Sort("Foo"), 'List('Terminal("Bar")))))
 
   val metad = 'Definition(metamodule, metamodule,
     'Set(metamodule),
@@ -104,7 +104,7 @@ class TestMeta {
       assertEquals(prod, actual)
     }
     {
-      val prod = Production(Sort("Exp"), Seq(NonTerminal(Sort("Int")), Terminal("+", "#"), RegexTerminal("#", "[a-z]", "#")), Att())
+      val prod = Production(Sort("Exp"), Seq(NonTerminal(Sort("Int")), Terminal("+", Seq()), RegexTerminal("#", "[a-z]", "#")), Att())
       val prod2 = Production(Sort("Exp"), Seq(), Att().add("originalProd", prod))
       assertEquals(prod, prod2.att.get("originalProd").get)
     }


### PR DESCRIPTION
This changes Terminal to take the follow pattern as a list of strings
rather than a single regular expression, and to use the specialized
method `BasicAutomaton.makeStringUnion` to build the matcher,
rather than escaping the patterns to make regexps which match
only that string, appending them together in quadratic time, and
passing it through the RegExp parser which needs linear space
(which was leading to stack overflows trying to build the C semantics
under default JVM options).

@radumereuta, @cos please review (@cos especially for how Down/Up handles that Seq - it seems to work but I don't know if the Product case handles it well).
