### PR TITLE
Fix JDK link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ This is a readme file for the developers.
 # Prerequisites
 
 ## Java Development Kit (required JDK8 version 8u45 or higher)
-You can follow the instructions http://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html depending on
-the type of your machine.
+You can download the JDK at http://www.oracle.com/technetwork/java/javase/downloads/index.html
 
 To make sure that everything works you should be able to call `java -version` and
 `javac -version` from a Terminal.


### PR DESCRIPTION
Goes to a more useful page (which has a convenient link
to the instruction page too).

Fixes #1627

@grosu, please review.
