### PR TITLE
Automatic follow restriction should not be calculated for empty strings.

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
@@ -206,6 +206,8 @@ public class RuleGrammarGenerator {
                     List<ProductionItem> items = stream(p.items()).map(pi -> {
                         if (pi instanceof Terminal) {
                             Terminal t = (Terminal) pi;
+                            if (t.value().trim().equals(""))
+                                return pi;
                             Set<String> follow = new HashSet<>();
                             terminals.prefixMap(t.value()).keySet().stream().filter(biggerString -> !t.value().equals(biggerString))
                                     .forEach(biggerString -> {

--- a/kernel/src/test/java/org/kframework/parser/concrete2kore/RuleGrammarTest.java
+++ b/kernel/src/test/java/org/kframework/parser/concrete2kore/RuleGrammarTest.java
@@ -380,4 +380,17 @@ public class RuleGrammarTest {
                 "endmodule";
         parseRule("X => label(X,wrap X)", def, 0, true);
     }
+
+    // automatic follow restriction should not be added for empty terminals
+    // regression test for issue #1575
+    @Test
+    public void test23() {
+        String def = "" +
+                "module TEST " +
+                "syntax Stmts ::= Stmt \"\" Stmts\n" +
+                "                 | \".Stmts\"\n" +
+                "  syntax Stmt  ::= \"a\"" +
+                "endmodule";
+        parseRule("a .Stmts", def, 0, false);
+    }
 }


### PR DESCRIPTION
Fixing #1575. 
@andreistefanescu or @daejunpark please review.
@bmmoore was right. It was related to automatic follow restriction.
What delayed me from seeing this, is that there is no representation in KORE for certain parts of the grammar. I think we got carried away again with some over optimization.
