### PR TITLE
Use leaf cell sorts in inference, parsing

### DIFF
--- a/k-distribution/tutorial/1_k/4_imp++/lesson_8/imp.k
+++ b/k-distribution/tutorial/1_k/4_imp++/lesson_8/imp.k
@@ -507,7 +507,7 @@ recovery.  Its role is to discard the current environment in the
 This rule is structural: we do not want them to count as computational
 steps in the transition system of a program. */
 
-  rule <k> Rho:Map => .K ...</k> <env> _ => Rho </env>    [structural]
+  rule <k> Rho => .K ...</k> <env> _ => Rho </env>    [structural]
 
 /*@ If you want to avoid useless environment recovery steps and keep the size
 of the computation structure smaller, then you can also add the rule

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
@@ -170,15 +170,15 @@ public class RuleGrammarGenerator {
         }
         extensionProds.addAll(prods);
 
-        boolean add_rule_cells;
+        boolean addRuleCells;
         if (baseK.getModule(RULE_CELLS).isDefined() && mod.importedModules().contains(baseK.getModule(RULE_CELLS).get())) { // prepare cell productions for rule parsing
             // make sure a configuration actually exists, otherwise ConfigurationInfoFromModule explodes.
-            add_rule_cells = mod.sentences().exists(func(p -> p instanceof Production && ((Production) p).att().contains("cell")));
+            addRuleCells = mod.sentences().exists(func(p -> p instanceof Production && ((Production) p).att().contains("cell")));
         } else {
-            add_rule_cells = false;
+            addRuleCells = false;
         }
         Set<Sentence> parseProds;
-        if (add_rule_cells) {
+        if (addRuleCells) {
             ConfigurationInfo cfgInfo = new ConfigurationInfoFromModule(mod);
             parseProds = Stream.concat(prods.stream(), stream(mod.sentences())).flatMap(s -> {
                 if (s instanceof Production && (s.att().contains("cell"))) {

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
@@ -186,13 +186,14 @@ public class RuleGrammarGenerator {
                     // assuming that productions tagged with 'cell' start and end with terminals, and only have non-terminals in the middle
                     assert p.items().head() instanceof Terminal || p.items().head() instanceof RegexTerminal;
                     assert p.items().last() instanceof Terminal || p.items().last() instanceof RegexTerminal;
-                    Seq<ProductionItem> pi;
+                    final ProductionItem body;
                     if (cfgInfo.isLeafCell(p.sort())) {
-                        ProductionItem body = p.items().tail().head();
-                        pi = Seq(p.items().head(), NonTerminal(Sort("#OptionalDots")), body, NonTerminal(Sort("#OptionalDots")), p.items().last());
+                        body = p.items().tail().head();
                     } else {
-                        pi = Seq(p.items().head(), NonTerminal(Sort("#OptionalDots")), NonTerminal(Sort("K")), NonTerminal(Sort("#OptionalDots")), p.items().last());
+                        body = NonTerminal(Sort("K"));
                     }
+                    final ProductionItem optDots = NonTerminal(Sort("#OptionalDots"));
+                    Seq<ProductionItem> pi = Seq(p.items().head(), optDots, body, optDots, p.items().last());
                     Production p1 = Production(p.klabel().get().name(), Sort("Cell"), pi, p.att());
                     Production p2 = Production(Sort("Cell"), Seq(NonTerminal(p.sort())));
                     return Stream.of(p1, p2);

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
@@ -5,6 +5,8 @@ import org.apache.commons.collections4.trie.PatriciaTrie;
 import org.kframework.Collections;
 import org.kframework.attributes.Att;
 import org.kframework.builtin.Sorts;
+import org.kframework.compile.ConfigurationInfo;
+import org.kframework.compile.ConfigurationInfoFromModule;
 import org.kframework.definition.Definition;
 import org.kframework.definition.Module;
 import org.kframework.definition.NonTerminal;
@@ -30,6 +32,7 @@ import static org.kframework.Collections.*;
 import static org.kframework.definition.Constructors.Att;
 import static org.kframework.definition.Constructors.*;
 import static org.kframework.kore.KORE.*;
+import static scala.compat.java8.JFunction.func;
 
 /**
  * Generator for rule and ground parsers.
@@ -166,23 +169,38 @@ public class RuleGrammarGenerator {
             }
         }
         extensionProds.addAll(prods);
-        Set<Sentence> parseProds;
+
+        boolean add_rule_cells;
         if (baseK.getModule(RULE_CELLS).isDefined() && mod.importedModules().contains(baseK.getModule(RULE_CELLS).get())) { // prepare cell productions for rule parsing
+            // make sure a configuration actually exists, otherwise ConfigurationInfoFromModule explodes.
+            add_rule_cells = mod.sentences().exists(func(p -> p instanceof Production && ((Production) p).att().contains("cell")));
+        } else {
+            add_rule_cells = false;
+        }
+        Set<Sentence> parseProds;
+        if (add_rule_cells) {
+            ConfigurationInfo cfgInfo = new ConfigurationInfoFromModule(mod);
             parseProds = Stream.concat(prods.stream(), stream(mod.sentences())).flatMap(s -> {
                 if (s instanceof Production && (s.att().contains("cell"))) {
                     Production p = (Production) s;
                     // assuming that productions tagged with 'cell' start and end with terminals, and only have non-terminals in the middle
                     assert p.items().head() instanceof Terminal || p.items().head() instanceof RegexTerminal;
                     assert p.items().last() instanceof Terminal || p.items().last() instanceof RegexTerminal;
-                    Seq<ProductionItem> pi = Seq(p.items().head(), NonTerminal(Sort("#OptionalDots")), NonTerminal(Sort("K")), NonTerminal(Sort("#OptionalDots")), p.items().last());
+                    Seq<ProductionItem> pi;
+                    if (cfgInfo.isLeafCell(p.sort())) {
+                        ProductionItem body = p.items().tail().head();
+                        pi = Seq(p.items().head(), NonTerminal(Sort("#OptionalDots")), body, NonTerminal(Sort("#OptionalDots")), p.items().last());
+                    } else {
+                        pi = Seq(p.items().head(), NonTerminal(Sort("#OptionalDots")), NonTerminal(Sort("K")), NonTerminal(Sort("#OptionalDots")), p.items().last());
+                    }
                     Production p1 = Production(p.klabel().get().name(), Sort("Cell"), pi, p.att());
                     Production p2 = Production(Sort("Cell"), Seq(NonTerminal(p.sort())));
                     return Stream.of(p1, p2);
                 }
-                if(s instanceof Production && (s.att().contains("cellFragment"))) {
-                    Production p = (Production)s;
+                if (s instanceof Production && (s.att().contains("cellFragment"))) {
+                    Production p = (Production) s;
                     Production p1 = Production(Sort("Cell"), Seq(NonTerminal(p.sort())));
-                    return Stream.of(p,p1);
+                    return Stream.of(p, p1);
                 }
                 return Stream.of(s);
             }).collect(Collectors.toSet());

--- a/kernel/src/test/java/org/kframework/parser/concrete2kore/RuleGrammarTest.java
+++ b/kernel/src/test/java/org/kframework/parser/concrete2kore/RuleGrammarTest.java
@@ -92,11 +92,11 @@ public class RuleGrammarTest {
             }
             kem.print();
         }
-        Assert.assertEquals("Expected " + warnings + " warnings: ", warnings, rule._2().size());
         if (expectedError)
             Assert.assertTrue("Expected error here: ", rule._1().isLeft());
         else
             Assert.assertTrue("Expected no errors here: ", rule._1().isRight());
+        Assert.assertEquals("Expected " + warnings + " warnings: ", warnings, rule._2().size());
     }
 
     // test proper associativity for rewrite, ~> and cast

--- a/kore/src/main/scala/org/kframework/compile/ConfigurationInfoFromModule.scala
+++ b/kore/src/main/scala/org/kframework/compile/ConfigurationInfoFromModule.scala
@@ -67,7 +67,7 @@ class ConfigurationInfoFromModule(val m: Module) extends ConfigurationInfo {
       m + (to -> (m(from) + 1))
   }
 
-  private val mainCell = {
+  private lazy val mainCell = {
     val mainCells = cellProductions.filter(x => x._2.att.contains("maincell")).map(_._1)
     if (mainCells.size > 1)
       throw new AssertionError("Too many main cells:" + mainCells)


### PR DESCRIPTION
@radumereuta, @andreistefanescu  please review.

The productions generated for parsing cells in rule bodies
always parsed the contents as K, even for leaf cells which
have a specific sort from the configuration.
This commit generates more specific productions for leaf cells,
using the actual expected sort of the contents.

This allows removing a type annotation that was added to IMP++
only to work around this issue.

The test in RuleGrammarTest needed an extra attribute in
handwritten cell productions to avoid an assertion error,
because ConfigurationInfoFromModule is pretty fragile.

In passing, I also changed the unit test to complain first about
an unexpected (lack of) parse error before checking the
precise warning count.
