### PR TITLE
FIxing issue #1705. 

### DIFF
--- a/k-distribution/include/builtin/kast.k
+++ b/k-distribution/include/builtin/kast.k
@@ -172,6 +172,13 @@ module RULE-LISTS
   // adds the subsort production to the parsing module only:
   // Es ::= E        [userList("*")]
 
+  // automatically add subsorts between related lists
+  // Exp ::= Int
+  // Exps ::= List{Exp,","}
+  // Ints ::= List{Int,","}
+  // because the elements of the two lists are subsorted,
+  // the lists will automatically be subsorted also by adding the production:
+  // Exps ::= Ints
 endmodule
 
 module DEFAULT-CONFIGURATION

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
@@ -312,7 +312,7 @@ public class RuleGrammarGenerator {
              */
             for (UserList ul1 : userLists) {
                 for (UserList ul2 : userLists) {
-                    if (ul1 != ul2 && ul1.separator.equals(ul2.separator)
+                    if (ul1 != ul2 && ul1.klabel.equals(ul2.klabel)
                             && mod.subsorts().$greater(Sort(ul1.childSort), Sort(ul2.childSort))) {
                         res.add(Production(Sort(ul1.sort), Seq(NonTerminal(Sort(ul2.sort)))));
                     }

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
@@ -297,11 +297,26 @@ public class RuleGrammarGenerator {
 
         if (baseK.getModule(RULE_LISTS).isDefined() && mod.importedModules().contains(baseK.getModule(RULE_LISTS).get())) {
             java.util.Set<Sentence> res = new HashSet<>();
-            for (UserList ul : UserList.getLists(parseProds)) {
+            java.util.List<UserList> userLists = UserList.getLists(parseProds);
+            for (UserList ul : userLists) {
                 org.kframework.definition.Production prod1;
                 // Es ::= E
                 prod1 = Production(Sort(ul.sort), Seq(NonTerminal(Sort(ul.childSort))));
                 res.add(prod1);
+            }
+
+            /*
+             * Add list of Sort2 for a separator if there is some syntactic list of Sort1 with the
+             * same separator such that Sort2 is a subsort of Sort1
+             * (i.e. List{Sort2, separator} if List{Sort1, separator} and Sort2 < Sort1)
+             */
+            for (UserList ul1 : userLists) {
+                for (UserList ul2 : userLists) {
+                    if (ul1 != ul2 && ul1.separator.equals(ul2.separator)
+                            && mod.subsorts().$greater(Sort(ul1.childSort), Sort(ul2.childSort))) {
+                        res.add(Production(Sort(ul1.sort), Seq(NonTerminal(Sort(ul2.sort)))));
+                    }
+                }
             }
 
             parseProds.addAll(res);

--- a/kernel/src/test/java/org/kframework/parser/concrete2kore/RuleGrammarTest.java
+++ b/kernel/src/test/java/org/kframework/parser/concrete2kore/RuleGrammarTest.java
@@ -393,4 +393,21 @@ public class RuleGrammarTest {
                 "endmodule";
         parseRule("a .Stmts", def, 0, false);
     }
+
+    // automatic subsort overloaded lists
+    // regression test for issue #1705
+    @Test
+    public void test24() {
+        String def = "" +
+                "module TEST " +
+                "syntax Id " +
+                "syntax Int " +
+                "syntax Exp ::= Int | Id " +
+                "" +
+                "syntax Ids  ::= List{Id, \",\"} " +
+                "syntax Ints ::= List{Int,\",\"} " +
+                "syntax Exps ::= List{Exp,\",\"} " +
+                "endmodule";
+        parseRule("A, B", def, 2, false);
+    }
 }


### PR DESCRIPTION
Calculating automatic subsorts for overloaded lists.
This works only at parsing, disambiguation and type inference level.

@bmmoore, @andreistefanescu  please review, but do not merge yet.
It works, but I'm not sure why. I used to have a place where I would take into consideration overloaded operators, but it works without that step, so I think we need more tests for this.

Please test it in the meantime..
