### PR TITLE
fix context hole bug

### DIFF
--- a/kernel/src/main/java/org/kframework/kore/compile/ResolveContexts.java
+++ b/kernel/src/main/java/org/kframework/kore/compile/ResolveContexts.java
@@ -114,10 +114,13 @@ public class ResolveContexts {
                 if (k.klabel().name().startsWith("#SemanticCastTo")) {
                     K child = k.klist().items().get(0);
                     if (child instanceof KVariable && ((KVariable) child).name().equals("HOLE")) {
-                        if (holeWithSemanticCast != null) {
-                            throw KEMException.compilerError("Cannot compile a context with multiple holes.", context);
+                        if (!ResolveSemanticCasts.getSortNameOfCast(k).equals("KItem")) {
+                            if (holeWithSemanticCast != null && !holeWithSemanticCast.equals(k)) {
+                                throw KEMException.compilerError("Cannot compile a context with multiple holes" +
+                                        " having different sort casting.", context);
+                            }
+                            holeWithSemanticCast = k;
                         }
-                        holeWithSemanticCast = k;
                     }
                 }
                 return super.apply(k);


### PR DESCRIPTION
now the error occurs only when a context has multiple holes with different sort casting except KItem.

this will fix the issue on translating SIMPLE and KOOL.

@msaxena2 please try if it fix the issue.

@andreistefanescu please review
