### PR TITLE
Parse pre-completion cells in proper sorts.

### DIFF
--- a/k-distribution/tests/regression/config.xml
+++ b/k-distribution/tests/regression/config.xml
@@ -73,8 +73,8 @@
            programs="ocamlbackend/tests"
            results="ocamlbackend/tests" />
 
-  <include file="kore-cell-fragments/imp_fragments/config.xml"
-           directory="kore-cell-fragments/imp_fragments/" />
+  <include file="kore-cell-fragments/config.xml"
+           directory="kore-cell-fragments/" />
 
   <include file="issue1724/config.xml"
            directory="issue1724"

--- a/k-distribution/tests/regression/kore-cell-fragments/cell_arguments/config.xml
+++ b/k-distribution/tests/regression/kore-cell-fragments/cell_arguments/config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) 2015 K Team. All Rights Reserved. -->
+  <tests>
+    <test definition="test.k">
+      <kompile-option name="--kore"/>
+    </test>
+  </tests>

--- a/k-distribution/tests/regression/kore-cell-fragments/cell_arguments/test.k
+++ b/k-distribution/tests/regression/kore-cell-fragments/cell_arguments/test.k
@@ -1,0 +1,20 @@
+// Copyright (c) 2015 K Team. All Rights Reserved.
+require "domains.k"
+module TEST-SYNTAX
+imports TEST
+endmodule
+module TEST
+imports MAP
+configuration <T>
+  <k> $PGM:K </k>
+  <x>
+    <a> .K </a>
+    <b> .K </b>
+    <c> .K </c>
+  </x>
+</T>
+
+syntax KItem ::= frag(XCellFragment)
+
+rule frag(<x>-fragment <a> A </a> noBCell noCCell </x>-fragment) => .K
+endmodule

--- a/k-distribution/tests/regression/kore-cell-fragments/config.xml
+++ b/k-distribution/tests/regression/kore-cell-fragments/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) 2015 K Team. All Rights Reserved. -->
+
+<tests>
+  <include file="imp_fragments/config.xml"
+           directory="imp_fragments/" />
+
+  <include file="cell_arguments/config.xml"
+           directory="cell_arguments/" />
+</tests>
+

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
@@ -190,7 +190,7 @@ public class RuleGrammarGenerator {
                     if (cfgInfo.isLeafCell(p.sort())) {
                         body = p.items().tail().head();
                     } else {
-                        body = NonTerminal(Sort("K"));
+                        body = NonTerminal(Sort("Bag"));
                     }
                     final ProductionItem optDots = NonTerminal(Sort("#OptionalDots"));
                     Seq<ProductionItem> pi = Seq(p.items().head(), optDots, body, optDots, p.items().last());

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
@@ -194,7 +194,7 @@ public class RuleGrammarGenerator {
                     }
                     final ProductionItem optDots = NonTerminal(Sort("#OptionalDots"));
                     Seq<ProductionItem> pi = Seq(p.items().head(), optDots, body, optDots, p.items().last());
-                    Production p1 = Production(p.klabel().get().name(), Sort("Cell"), pi, p.att());
+                    Production p1 = Production(p.klabel().get().name(), p.sort(), pi, p.att());
                     Production p2 = Production(Sort("Cell"), Seq(NonTerminal(p.sort())));
                     return Stream.of(p1, p2);
                 }


### PR DESCRIPTION
When generating the modified productions that allow incomplete cells
with features such as dots and omitting parent cells,
the modified productions for indvidual cells were places into the
generic Cell sort (used for flexibility such as allowing parent cells),
this instead keeps the original more specific FooCell sorts,
for which subsorts into Cell were already generated.

@daejunpark  this should fix ~~#1748~~ #1747

I need to add tests, but you can check if this commit helps.
