### PR TITLE
Allow cell bag union labels in SortCells

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/compile/KOREtoBackendKIL.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/compile/KOREtoBackendKIL.java
@@ -161,9 +161,9 @@ public class KOREtoBackendKIL extends org.kframework.kore.AbstractConstructors<o
             org.kframework.kore.KList klist = ((KApply) k).klist();
             if (useCellCollections && definition.configurationInfo().getCellForConcat(klabel).isDefined())
                 return KLabelInjection.injectionOf(CellCollection(klabel, klist), context);
-            if (useCellCollections && definition.configurationInfo().getCellForUnit((KApply) k).isDefined())
+            if (useCellCollections && definition.configurationInfo().getCellForUnit(klabel).isDefined() && klist.size() == 0)
                 return KLabelInjection.injectionOf(
-                        CellCollection.empty(definition.configurationInfo().getCellForUnit((KApply) k).get(), definition),
+                        CellCollection.empty(definition.configurationInfo().getCellForUnit(klabel).get(), definition),
                         context);
             else if (useCellCollections && definition.cellMultiplicity(CellLabel.of(klabel.name())) == ConfigurationInfo.Multiplicity.STAR)
                 return KLabelInjection.injectionOf(

--- a/kernel/src/main/java/org/kframework/kore/compile/ConcretizationInfo.java
+++ b/kernel/src/main/java/org/kframework/kore/compile/ConcretizationInfo.java
@@ -9,6 +9,7 @@ import org.kframework.kore.KApply;
 import org.kframework.kore.KLabel;
 import org.kframework.kore.KVariable;
 import org.kframework.kore.Sort;
+import scala.Option;
 
 import java.util.List;
 
@@ -60,6 +61,17 @@ public class ConcretizationInfo {
         Sort s = labels.getCodomain(cellLabel);
         return cfg.isCell(s) ? s : null;
     }
+
+    /** If {@code label} is a label making a cell collection, return the
+     * Sort of the cells in that collection.
+     */
+    public Sort getCellCollectionCell(KLabel label) {
+        Option<Sort> result = cfg.getCellForConcat(label);
+        if (result.isEmpty()) {
+            result = cfg.getCellForUnit(label);
+        }
+        return result.isDefined() ? result.get() : null;
+    }
     public KLabel getCellFragmentLabel(KLabel cellLabel) {
         Sort s = labels.getCodomain(cellLabel);
         return cfg.getCellFragmentLabel(s);
@@ -68,6 +80,11 @@ public class ConcretizationInfo {
     public K getCellAbsentTerm(Sort cellSort) {
         KLabel l = cfg.getCellAbsentLabel(cellSort);
         return l == null ? null : KApply(l);
+    }
+
+    public boolean isCellCollection(KLabel klabel) {
+        Sort s = labels.getCodomain(klabel);
+        return cfg.isCellCollection(s);
     }
 
     public boolean isCell(KLabel klabel) {

--- a/kernel/src/main/java/org/kframework/kore/compile/SortCells.java
+++ b/kernel/src/main/java/org/kframework/kore/compile/SortCells.java
@@ -367,9 +367,13 @@ public class SortCells {
                 } else if (item instanceof KApply) {
                     List<K> children = IncompleteCellUtils.flattenCells(item);
                     if(children.size() == 1 && children.get(0) == item) {
-                        Sort s = cfg.getCellSort(((KApply) item).klabel());
+                        final KLabel label = ((KApply) item).klabel();
+                        Sort s = cfg.getCellSort(label);
                         if (s == null) {
-                            throw new IllegalArgumentException("Attempting to split non-cell term "+item);
+                            s = cfg.getCellCollectionCell(label);
+                            if (s == null) {
+                                throw new IllegalArgumentException("Attempting to split non-cell term " + item);
+                            }
                         }
                         return Collections.singletonMap(s, apply(item));
                     }

--- a/kore/src/main/java/org/kframework/compile/ConfigurationInfo.java
+++ b/kore/src/main/java/org/kframework/compile/ConfigurationInfo.java
@@ -33,6 +33,9 @@ public interface ConfigurationInfo {
     /** True if sort k is actually a cell sort */
     boolean isCell(Sort k);
 
+    /** True if sort s is the collection sort for a multiplicity star cell. */
+    boolean isCellCollection(Sort s);
+
     /** True if kLabel is the KLabel of a cell */
     boolean isCellLabel(KLabel kLabel);
 
@@ -91,7 +94,7 @@ public interface ConfigurationInfo {
     Option<Sort> getCellForConcat(KLabel concat);
 
     /** Returns the cell associated with this unit */
-    Option<Sort> getCellForUnit(KApply unit);
+    Option<Sort> getCellForUnit(KLabel unit);
 
     /** Declared mulitplicitly of a cell */
     enum Multiplicity {

--- a/kore/src/main/scala/org/kframework/compile/ConfigurationInfoFromModule.scala
+++ b/kore/src/main/scala/org/kframework/compile/ConfigurationInfoFromModule.scala
@@ -89,6 +89,7 @@ class ConfigurationInfoFromModule(val m: Module) extends ConfigurationInfo {
 
   override def getParent(k: Sort): Sort = edges collectFirst { case (p, `k`) => p } get
   override def isCell(k: Sort): Boolean = cellSorts.contains(k)
+  override def isCellCollection(s: Sort): Boolean = cellBagSorts.contains(s)
   override def isCellLabel(kLabel: KLabel): Boolean = cellLabelsToSorts.contains(kLabel)
   override def isLeafCell(k: Sort): Boolean = !isParentCell(k)
 
@@ -140,10 +141,13 @@ class ConfigurationInfoFromModule(val m: Module) extends ConfigurationInfo {
     .map(_._1)
     .headOption
 
-  override def getCellForUnit(unit: KApply): Option[Sort] = cellSorts
-    .map(s => (s, getCellBagSortsOfCell(s)))
-    .filter(_._2.size == 1)
-    .filter(p => KApply(KLabel(cellBagProductions(p._2.head).att.get[String]("unit").get)).equals(unit))
-    .map(_._1)
-    .headOption
+  override def getCellForUnit(unitLabel: KLabel): Option[Sort] = {
+    val unit = KApply(unitLabel)
+    cellSorts
+      .map(s => (s, getCellBagSortsOfCell(s)))
+      .filter(_._2.size == 1)
+      .filter(p => KApply(KLabel(cellBagProductions(p._2.head).att.get[String]("unit").get)).equals(unit))
+      .map(_._1)
+      .headOption
+  }
 }


### PR DESCRIPTION
SortCells would previously fail some inputs using the
labels from a cell bag sort. This commit changes the pass to
recognize those labels as acceptable items under a parent cell,
and to handle them correctly when re-assembling the sorted contents.

@dwightguth please review.
This also allows the C semantics to build under #1754 -
the sort changes there added ambigous parses using the cell bag labels,
and when one of those parses was chosen the build would fail because
of this problem.
