### PR TITLE
Tidy Transformer stuff

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/ParseInModule.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/ParseInModule.java
@@ -127,7 +127,7 @@ public class ParseInModule implements Serializable {
         getGrammar();
 
         Grammar.NonTerminal startSymbolNT = grammar.get(startSymbol.name());
-        Set<ParseFailedException> warn = new AmbFilter().warningUnit();
+        Set<ParseFailedException> warn = Sets.newHashSet();
         if (startSymbolNT == null) {
             String msg = "Could not find start symbol: " + startSymbol;
             KException kex = new KException(KException.ExceptionType.ERROR, KException.KExceptionGroup.CRITICAL, msg);
@@ -167,9 +167,9 @@ public class ParseInModule implements Serializable {
 
         Term rez3 = new PreferAvoidVisitor().apply(rez2._1().right().get());
         rez2 = new AmbFilter().apply(rez3);
-        warn = new AmbFilter().mergeWarnings(rez2._2(), warn);
+        warn = Sets.union(rez2._2(), warn);
         rez2 = new AddEmptyLists(disambModule).apply(rez2._1().right().get());
-        warn = new AmbFilter().mergeWarnings(rez2._2(), warn);
+        warn = Sets.union(rez2._2(), warn);
         rez3 = new RemoveBracketVisitor().apply(rez2._1().right().get());
 
         return new Tuple2<>(Right.apply(rez3), warn);

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/AddEmptyLists.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/AddEmptyLists.java
@@ -2,6 +2,7 @@
 package org.kframework.parser.concrete2kore.disambiguation;
 
 
+import com.google.common.collect.Sets;
 import org.kframework.POSet;
 import org.kframework.builtin.Sorts;
 import org.kframework.definition.Module;
@@ -96,7 +97,7 @@ public class AddEmptyLists extends SetsGeneralTransformer<ParseFailedException, 
             Collections.reverse(newItems); // TermCons with PStack requires the elements to be in the reverse order
             tc = TermCons.apply(ConsPStack.from(newItems), tc.production(), tc.location(), tc.source());
             Tuple2<Either<Set<ParseFailedException>, Term>, Set<ParseFailedException>> rez = super.apply(tc);
-            return new Tuple2<>(Right.apply(rez._1().right().get()), this.mergeWarnings(warnings, rez._2()));
+            return new Tuple2<>(Right.apply(rez._1().right().get()), Sets.union(warnings, rez._2()));
         } else {
             return super.apply(tc);
         }

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/AmbFilter.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/AmbFilter.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2015 K Team. All Rights Reserved.
 package org.kframework.parser.concrete2kore.disambiguation;
 
+import com.google.common.collect.Sets;
 import org.kframework.kore.K;
 import org.kframework.parser.Ambiguity;
 import org.kframework.parser.ProductionReference;
@@ -62,6 +63,6 @@ public class AmbFilter extends SetsGeneralTransformer<ParseFailedException, Pars
                 new KException(ExceptionType.WARNING, KExceptionGroup.INNER_PARSER, msg, amb.items().iterator().next().source().get(), amb.items().iterator().next().location().get()));
 
         Tuple2<Either<Set<ParseFailedException>, Term>, Set<ParseFailedException>> rez = this.apply(amb.items().iterator().next());
-        return new Tuple2<>(Right.apply(rez._1().right().get()), this.mergeWarnings(this.makeWarningSet(w), rez._2()));
+        return new Tuple2<>(Right.apply(rez._1().right().get()), Sets.union(Sets.newHashSet(w), rez._2()));
     }
 }

--- a/kore/src/main/scala/org/kframework/parser/Transformer.scala
+++ b/kore/src/main/scala/org/kframework/parser/Transformer.scala
@@ -14,9 +14,12 @@ class Ignore
 
 object Ignore extends Ignore
 
-trait ChildrenMapping[E, W] {
+abstract class ChildrenMapping[E, W] {
 
   def applyTerm(t: Term): (Either[E, Term], W)
+
+  protected def simpleError(err:E) : (Either[E, Term], W) = (Left(err),warningUnit)
+  protected def simpleResult(result:Term): (Either[E, Term], W) = (Right(result),warningUnit)
 
   /**
    * Transforms all children of the current item. If any of them is problematic,
@@ -118,7 +121,7 @@ abstract class GeneralTransformer[E, W] extends ChildrenMapping[E, W] {
   def apply(a: Ambiguity): (Either[E, Term], W) = mapChildren(a)
   def apply(tc: TermCons): (Either[E, Term], W) = mapChildrenStrict(tc)
   def apply(kl: KList): (Either[E, Term], W) = mapChildrenStrict(kl)
-  def apply(c: Constant): (Either[E, Term], W) = { (Right(c), warningUnit) }
+  def apply(c: Constant): (Either[E, Term], W) = simpleResult(c)
 }
 
 trait EAsSet[E] {
@@ -127,19 +130,15 @@ trait EAsSet[E] {
    */
   def mergeErrors(a: java.util.Set[E], b: java.util.Set[E]): java.util.Set[E] = Sets.union(a, b)
 
-  val errorUnit: java.util.Set[E] = makeErrorSet()
-
-  @annotation.varargs def makeErrorSet(l:E*) = l.toSet.asJava
+  val errorUnit: java.util.Set[E] = Sets.newHashSet()
 }
 
 trait WAsSet[W] {
-  val warningUnit: java.util.Set[W] = makeWarningSet()
+  val warningUnit: java.util.Set[W] = Sets.newHashSet();
   /**
    * Merges the set of problematic (i.e., Left) results.
    */
   def mergeWarnings(a: java.util.Set[W], b: java.util.Set[W]): java.util.Set[W] = Sets.union(a, b)
-
-  @annotation.varargs def makeWarningSet(l:W*) = l.toSet.asJava
 }
 
 abstract class SetsGeneralTransformer[E, W]


### PR DESCRIPTION
Directly call Sets.union instead of going through the silly little
wrappers used as internals in the Transformers system.

Extract helper methods for returning a warning-less result or error.

@cos, @dwightguth please review.

@cos, I changed `ChildrenMapping` from a trait to an abstract class only because if I didn't then the `simpleResult` and `simpleError` methods would end up as unimplemented abstract methods in the abstract classes that extended the trait, instead of picking up the trait's implementation.
