### PR TITLE
Fix label processing in AddEmptyLists

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/AddEmptyLists.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/AddEmptyLists.java
@@ -231,7 +231,11 @@ public class AddEmptyLists extends SetsGeneralTransformer<ParseFailedException, 
             Constant labelCon = (Constant) labelTerm;
             if (labelCon.production().sort().name().equals("KLabel")) {
                 String labelVal = labelCon.value();
-                return Optional.of(KLabel(labelVal.substring(1, labelVal.length() - 1)));
+                if (labelVal.charAt(0) == '`') {
+                    return Optional.of(KLabel(labelVal.substring(1, labelVal.length() - 1)));
+                } else {
+                    return Optional.of(KLabel(labelVal));
+                }
             }
         }
         return Optional.empty();


### PR DESCRIPTION
It assumed labeled form is was always written with "`"
around the label name, but kast.k allows some simple
labels to be written directly, which is execised in
RuleGrammarTest.test24.

@dwightguth please review. I have no idea how #1810 passed jenkins.
