### PR TITLE
fix module import in DOMAINS module

### DIFF
--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -15,7 +15,7 @@ module DOMAINS
   imports INT
   imports BOOL
   imports STRING
-  imports K
+  imports BASIC-K
   imports K-IO
   imports LIST
   imports MAP


### PR DESCRIPTION
We probably don't want to import the entire syntax of K into the definition since the up'd syntax doesn't really exist at runtime.
