### PR TITLE
Excercise regression test by reintroducing bug

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
@@ -271,8 +271,8 @@ public class RuleGrammarGenerator {
 
                 Att newAtts = ul.attrs.remove("userList");
                 // Es#Terminator ::= "" [klabel('.Es)]
-                prod1 = Production(ul.terminatorKLabel, Sort(ul.sort + "#Terminator"), Seq(Terminal("")),
-                        newAtts.add("klabel", ul.terminatorKLabel).add(Constants.ORIGINAL_PRD, ul.pTerminator));
+                prod1 = Production(ul.klabel, Sort(ul.sort + "#Terminator"), Seq(Terminal("")),
+                        newAtts.add("klabel", ul.klabel).add(Constants.ORIGINAL_PRD, ul.pTerminator));
                 // Ne#Es ::= E "," Ne#Es [klabel('_,_)]
                 prod2 = Production(ul.klabel, Sort("Ne#" + ul.sort),
                         Seq(NonTerminal(Sort(ul.childSort)), Terminal(ul.separator), NonTerminal(Sort("Ne#" + ul.sort))),


### PR DESCRIPTION
This intentionally reintroduces the bug which was fixed in
8a85beccaae21702cec078db5da40bb94e713c10,
so we can develop a unit test that will actually catch it.

@radumereuta, please continue with this branch. Why don't all those tests you added actually catch this bug? Maybe the klabel attributes of these productions are never actually used?
