### PR TITLE
Inheritance breaks fragments

### DIFF
--- a/k-distribution/src/test/java/org/kframework/kore/compile/ConfigurationInheritanceTest.java
+++ b/k-distribution/src/test/java/org/kframework/kore/compile/ConfigurationInheritanceTest.java
@@ -30,6 +30,6 @@ public class ConfigurationInheritanceTest {
 
         String actual = KOREToTreeNodes.toString(new AddBrackets(unparsingModule).addBrackets((ProductionReference) KOREToTreeNodes.apply(KOREToTreeNodes.up(unparsingModule, kResult), unparsingModule)));
 
-        assertEquals("Execution failed", "<t> <k> foo ~> .::K </k> <b> x </b> </t>", actual);
+        assertEquals("Execution failed", "<t> <k> foo ~> .::K </k> <b> x </b> <c> .::K </c> </t>", actual);
     }
 }

--- a/k-distribution/src/test/resources/compiler-tests/configuration-inheritance.k
+++ b/k-distribution/src/test/resources/compiler-tests/configuration-inheritance.k
@@ -19,8 +19,8 @@ module C
     imports A
     imports B
 
-    configuration <t> initKCell(Init) initBCell </t>
+    configuration <t> initKCell(Init) initBCell  <c> .K </c> </t>
 
     rule <k> y => foo ...</k> <b> bar => x </b>
-    rule <k> <t>-fragment _ _ </t>-fragment => .K ...</k>
+    rule <k> <t>-fragment _ _ _ </t>-fragment => .K ...</k>
 endmodule

--- a/k-distribution/src/test/resources/compiler-tests/configuration-inheritance.k
+++ b/k-distribution/src/test/resources/compiler-tests/configuration-inheritance.k
@@ -22,4 +22,5 @@ module C
     configuration <t> initKCell(Init) initBCell </t>
 
     rule <k> y => foo ...</k> <b> bar => x </b>
+    rule <k> <t>-fragment _ _ </t>-fragment => .K ...</k>
 endmodule


### PR DESCRIPTION
These first two commits demonstrate that a parent cell whose children all have inherited definitions does not get a cell fragment, and that then adding another explicit child is enough to cause the expected fragment productions to be generated and the rules to pass.

@cos, @dwightguth this was introduced in #1873.
