### PR TITLE
rename -COMMON modules + "main syntax module" refactoring

### DIFF
--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -1,6 +1,6 @@
 // Copyright (c) 2015 K Team. All Rights Reserved.
 module DOMAINS-SYNTAX
-  imports EMPTY-ID
+  imports ID
   imports INT-SYNTAX
   imports BOOL-SYNTAX
   imports STRING-SYNTAX
@@ -478,7 +478,7 @@ module ID
   syntax Id ::= r"(?<![A-Za-z0-9\\_])[A-Za-z\\_][A-Za-z0-9\\_]*"     [notInRules, token, autoReject]
 endmodule
 
-module EMPTY-ID
+module ID-PROGRAM-PARSING
   imports STRING
 
   syntax Id

--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -1,14 +1,9 @@
 // Copyright (c) 2015 K Team. All Rights Reserved.
-module DOMAINS-COMMON
+module DOMAINS-SYNTAX
   imports EMPTY-ID
   imports INT-SYNTAX
   imports BOOL-SYNTAX
   imports STRING-SYNTAX
-endmodule
-
-module DOMAINS-SYNTAX
-  imports DOMAINS-COMMON
-  imports ID
 endmodule
 
 module DOMAINS

--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -474,11 +474,11 @@ module STRING
 
 endmodule
 
-module ID
+module ID-PROGRAM-PARSING
   syntax Id ::= r"(?<![A-Za-z0-9\\_])[A-Za-z\\_][A-Za-z0-9\\_]*"     [notInRules, token, autoReject]
 endmodule
 
-module ID-PROGRAM-PARSING
+module ID
   imports STRING
 
   syntax Id

--- a/k-distribution/include/builtin/misc.k
+++ b/k-distribution/include/builtin/misc.k
@@ -4,7 +4,7 @@ module ID
   syntax Id ::= r"(?<![A-Za-z0-9\\_])[A-Za-z\\_][A-Za-z0-9\\_]*"     [token, autoReject]
 endmodule
 
-module EMPTY-ID
+module ID
   imports K
   imports LOGIC
 

--- a/k-distribution/samples-kore/kernelc/kernelc-semantics.k
+++ b/k-distribution/samples-kore/kernelc/kernelc-semantics.k
@@ -1,7 +1,7 @@
 // Copyright (c) 2014-2015 K Team. All Rights Reserved.
 
 module KERNELC-CONFIGURATION
-  imports KERNELC-COMMON-SYNTAX
+  imports KERNELC-SYNTAX-SYNTAX
   imports BOOL
   imports INT
   imports FLOAT

--- a/k-distribution/samples-kore/kernelc/kernelc-semantics.k
+++ b/k-distribution/samples-kore/kernelc/kernelc-semantics.k
@@ -1,7 +1,7 @@
 // Copyright (c) 2014-2015 K Team. All Rights Reserved.
 
 module KERNELC-CONFIGURATION
-  imports KERNELC-SYNTAX-SYNTAX
+  imports KERNELC-SYNTAX
   imports BOOL
   imports INT
   imports FLOAT

--- a/k-distribution/samples-kore/kernelc/kernelc-syntax.k
+++ b/k-distribution/samples-kore/kernelc/kernelc-syntax.k
@@ -1,6 +1,6 @@
 // Copyright (c) 2014-2015 K Team. All Rights Reserved.
 
-module KERNELC-COMMON-SYNTAX
+module KERNELC-SYNTAX-SYNTAX
   imports BOOL-SYNTAX
   imports INT-SYNTAX
   imports FLOAT-SYNTAX
@@ -131,9 +131,3 @@ module KERNELC-COMMON-SYNTAX
               | "p" [token] | "n" [token] | "s" [token] | "l" [token] | "ln" [token] | "tn" [token] | "sn" [token] | "temp" [token]
               | "min" [token] | "iterx" [token] | "itery" [token] | "change" [token]
 endmodule
-
-module KERNELC-SYNTAX
-  imports KERNELC-COMMON-SYNTAX
-  imports ID
-endmodule
-

--- a/k-distribution/samples-kore/kernelc/kernelc-syntax.k
+++ b/k-distribution/samples-kore/kernelc/kernelc-syntax.k
@@ -1,6 +1,6 @@
 // Copyright (c) 2014-2015 K Team. All Rights Reserved.
 
-module KERNELC-SYNTAX-SYNTAX
+module KERNELC-SYNTAX
   imports BOOL-SYNTAX
   imports INT-SYNTAX
   imports FLOAT-SYNTAX

--- a/k-distribution/samples-kore/kernelc/kernelc-syntax.k
+++ b/k-distribution/samples-kore/kernelc/kernelc-syntax.k
@@ -5,7 +5,7 @@ module KERNELC-SYNTAX
   imports INT-SYNTAX
   imports FLOAT-SYNTAX
   imports STRING-SYNTAX
-  imports EMPTY-ID
+  imports ID
 
   syntax File ::= Globals
 

--- a/k-distribution/src/test/java/org/kframework/kore/convertors/TstBackendOnKORE_IT.java
+++ b/k-distribution/src/test/java/org/kframework/kore/convertors/TstBackendOnKORE_IT.java
@@ -61,5 +61,4 @@ public class TstBackendOnKORE_IT {
         assertEquals("Execution failed", "<T> <k> finish ~> . </k> </T>", actual);
 
     }
-
 }

--- a/k-distribution/src/test/java/org/kframework/utils/KoreUtils.java
+++ b/k-distribution/src/test/java/org/kframework/utils/KoreUtils.java
@@ -115,7 +115,7 @@ public class KoreUtils {
         map.put(KToken("$PGM", Sorts.KConfigVar()), parsed);
 
         BiFunction<String, Source, K> strategyParser = compiledDef.getParser(
-                compiledDef.generatedProgramParsingModuleFor(compiledDef.mainSyntaxModuleName()).get(), KORE.Sort("Strategy"), kem);
+                compiledDef.programParsingModuleFor(compiledDef.mainSyntaxModuleName()).get(), KORE.Sort("Strategy"), kem);
 
         if (strategy != null)
             map.put(KToken("$STRATEGY", Sorts.KConfigVar()), strategyParser.apply(strategy, Source.apply("given strategy")));

--- a/k-distribution/src/test/java/org/kframework/utils/KoreUtils.java
+++ b/k-distribution/src/test/java/org/kframework/utils/KoreUtils.java
@@ -115,7 +115,7 @@ public class KoreUtils {
         map.put(KToken("$PGM", Sorts.KConfigVar()), parsed);
 
         BiFunction<String, Source, K> strategyParser = compiledDef.getParser(
-                compiledDef.programParsingModuleFor(compiledDef.mainSyntaxModuleName()).get(), KORE.Sort("Strategy"), kem);
+                compiledDef.programParsingModuleFor(compiledDef.mainSyntaxModuleName(), kem).get(), KORE.Sort("Strategy"), kem);
 
         if (strategy != null)
             map.put(KToken("$STRATEGY", Sorts.KConfigVar()), strategyParser.apply(strategy, Source.apply("given strategy")));

--- a/k-distribution/src/test/java/org/kframework/utils/KoreUtils.java
+++ b/k-distribution/src/test/java/org/kframework/utils/KoreUtils.java
@@ -116,7 +116,7 @@ public class KoreUtils {
         Map<KToken, K> map = new HashMap<>();
         map.put(KToken("$PGM", Sorts.KConfigVar()), parsed);
 
-        BiFunction<String, Source, K> strategyParser = compiledDef.getParser(compiledDef.programsModule(), KORE.Sort("Strategy"), kem);
+        BiFunction<String, Source, K> strategyParser = compiledDef.getParser(compiledDef.syntaxModule(), KORE.Sort("Strategy"), kem);
 
         if (strategy != null)
             map.put(KToken("$STRATEGY", Sorts.KConfigVar()), strategyParser.apply(strategy, Source.apply("given strategy")));

--- a/k-distribution/src/test/java/org/kframework/utils/KoreUtils.java
+++ b/k-distribution/src/test/java/org/kframework/utils/KoreUtils.java
@@ -115,7 +115,7 @@ public class KoreUtils {
         map.put(KToken("$PGM", Sorts.KConfigVar()), parsed);
 
         BiFunction<String, Source, K> strategyParser = compiledDef.getParser(
-                compiledDef.programParsingModuleForModule(compiledDef.mainSyntaxModuleName()).get(), KORE.Sort("Strategy"), kem);
+                compiledDef.generatedProgramParsingModuleFor(compiledDef.mainSyntaxModuleName()).get(), KORE.Sort("Strategy"), kem);
 
         if (strategy != null)
             map.put(KToken("$STRATEGY", Sorts.KConfigVar()), strategyParser.apply(strategy, Source.apply("given strategy")));

--- a/k-distribution/src/test/java/org/kframework/utils/KoreUtils.java
+++ b/k-distribution/src/test/java/org/kframework/utils/KoreUtils.java
@@ -4,7 +4,6 @@ package org.kframework.utils;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.kframework.backend.java.symbolic.JavaBackend;
-import org.kframework.kore.ADT;
 import org.kframework.kore.KORE;
 import org.kframework.kore.KToken;
 import org.kframework.kore.Sort;
@@ -34,7 +33,6 @@ import org.kframework.utils.options.SMTOptions;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -116,7 +114,8 @@ public class KoreUtils {
         Map<KToken, K> map = new HashMap<>();
         map.put(KToken("$PGM", Sorts.KConfigVar()), parsed);
 
-        BiFunction<String, Source, K> strategyParser = compiledDef.getParser(compiledDef.syntaxModule(), KORE.Sort("Strategy"), kem);
+        BiFunction<String, Source, K> strategyParser = compiledDef.getParser(
+                compiledDef.programParsingModuleForModule(compiledDef.mainSyntaxModuleName()).get(), KORE.Sort("Strategy"), kem);
 
         if (strategy != null)
             map.put(KToken("$STRATEGY", Sorts.KConfigVar()), strategyParser.apply(strategy, Source.apply("given strategy")));

--- a/k-distribution/src/test/java/org/kframework/utils/KoreUtils.java
+++ b/k-distribution/src/test/java/org/kframework/utils/KoreUtils.java
@@ -116,7 +116,7 @@ public class KoreUtils {
         Map<KToken, K> map = new HashMap<>();
         map.put(KToken("$PGM", Sorts.KConfigVar()), parsed);
 
-        BiFunction<String, Source, K> strategyParser = compiledDef.getParser(compiledDef.syntaxModule(), KORE.Sort("Strategy"), kem);
+        BiFunction<String, Source, K> strategyParser = compiledDef.getParser(compiledDef.programsModule(), KORE.Sort("Strategy"), kem);
 
         if (strategy != null)
             map.put(KToken("$STRATEGY", Sorts.KConfigVar()), strategyParser.apply(strategy, Source.apply("given strategy")));

--- a/k-distribution/src/test/resources/compiler-tests/strategies_imp.k
+++ b/k-distribution/src/test/resources/compiler-tests/strategies_imp.k
@@ -1,7 +1,7 @@
 // Copyright (c) 2014-2015 K Team. All Rights Reserved.
 requires "domains.k"
 
-module IMP-CORE-SYNTAX
+module IMP-SYNTAX
   imports ID
   imports INT-SYNTAX
   imports BOOL-SYNTAX
@@ -31,7 +31,7 @@ module IMP-CORE-SYNTAX
 endmodule
 
 module IMP
-  imports IMP-CORE-SYNTAX
+  imports IMP-SYNTAX
   imports MAP
   imports INT
 

--- a/k-distribution/src/test/resources/compiler-tests/strategies_imp.k
+++ b/k-distribution/src/test/resources/compiler-tests/strategies_imp.k
@@ -2,7 +2,7 @@
 requires "domains.k"
 
 module IMP-CORE-SYNTAX
-  imports EMPTY-ID
+  imports ID
   imports INT-SYNTAX
   imports BOOL-SYNTAX
   imports BASIC-STRATEGY
@@ -28,11 +28,6 @@ module IMP-CORE-SYNTAX
   syntax Ids ::= List{Id,","}
 
   syntax Exp ::= Pgm
-endmodule
-
-module IMP-SYNTAX
-  imports ID
-  imports IMP-CORE-SYNTAX
 endmodule
 
 module IMP

--- a/k-distribution/src/test/resources/convertor-tests/kore_imp.k
+++ b/k-distribution/src/test/resources/convertor-tests/kore_imp.k
@@ -1,7 +1,7 @@
 // Copyright (c) 2014-2015 K Team. All Rights Reserved.
 requires "domains.k"
 
-module IMP-CORE-SYNTAX
+module IMP-SYNTAX
   imports ID
   imports INT-SYNTAX
   imports BOOL-SYNTAX
@@ -28,7 +28,7 @@ module IMP-CORE-SYNTAX
 endmodule
 
 module IMP
-  imports IMP-CORE-SYNTAX
+  imports IMP-SYNTAX
   imports MAP
   imports INT
   syntax KResult ::= Int | Bool

--- a/k-distribution/src/test/resources/convertor-tests/kore_imp.k
+++ b/k-distribution/src/test/resources/convertor-tests/kore_imp.k
@@ -2,7 +2,7 @@
 requires "domains.k"
 
 module IMP-CORE-SYNTAX
-  imports EMPTY-ID
+  imports ID
   imports INT-SYNTAX
   imports BOOL-SYNTAX
 
@@ -25,11 +25,6 @@ module IMP-CORE-SYNTAX
                  > Stmt Stmt                  [left]
   syntax Pgm ::= "int" Ids ";" Stmt
   syntax Ids ::= List{Id,","}
-endmodule
-
-module IMP-SYNTAX
-  imports ID
-  imports IMP-CORE-SYNTAX
 endmodule
 
 module IMP

--- a/k-distribution/src/test/resources/convertor-tests/kore_imp_tiny.k
+++ b/k-distribution/src/test/resources/convertor-tests/kore_imp_tiny.k
@@ -13,7 +13,7 @@ module TEST
   import BOOL
   import LOGIC
   import INT
-  import EMPTY-ID
+  import ID
   import MAP
   import K-RESULT
 

--- a/k-distribution/src/test/resources/convertor-tests/kore_varlabel.k
+++ b/k-distribution/src/test/resources/convertor-tests/kore_varlabel.k
@@ -2,12 +2,7 @@
 require "domains.k"
 
 module VARLABEL-SYNTAX
-  imports VARLABEL-COMMON
   imports DOMAINS-SYNTAX
-endmodule
-
-module VARLABEL-COMMON
-  imports DOMAINS-COMMON
 
   syntax Exp ::= Int "+" Int
                  | Int "-" Int
@@ -20,7 +15,7 @@ endmodule
 
 module VARLABEL
   imports DOMAINS
-  imports VARLABEL-COMMON
+  imports VARLABEL-SYNTAX
 
 
   configuration <T color="yellow">

--- a/k-distribution/tests/regression/kore-cell-fragments/imp++/kore_imp++.k
+++ b/k-distribution/tests/regression/kore-cell-fragments/imp++/kore_imp++.k
@@ -2,11 +2,6 @@
 require "domains.k"
 
 module IMP-SYNTAX
-imports IMP-COMMON
-imports ID
-endmodule
-
-module IMP-COMMON
 imports INT-SYNTAX
 imports BOOL-SYNTAX
 imports EMPTY-ID
@@ -48,7 +43,7 @@ module IMP
   imports INT
   imports BOOL
   imports STRING
-  imports IMP-COMMON
+  imports IMP-SYNTAX
 /*@ \section{Semantics}
 We next give the semantics of IMP++\@.  We start by first defining its
 configuration. */

--- a/k-distribution/tests/regression/kore-cell-fragments/imp++/kore_imp++.k
+++ b/k-distribution/tests/regression/kore-cell-fragments/imp++/kore_imp++.k
@@ -4,7 +4,7 @@ require "domains.k"
 module IMP-SYNTAX
 imports INT-SYNTAX
 imports BOOL-SYNTAX
-imports EMPTY-ID
+imports ID
 imports STRING-SYNTAX
 
   syntax AExp  ::= Int | String | Id

--- a/k-distribution/tests/regression/kore-cell-fragments/imp_fragments/kore_imp_stack.k
+++ b/k-distribution/tests/regression/kore-cell-fragments/imp_fragments/kore_imp_stack.k
@@ -2,7 +2,7 @@
 requires "domains.k"
 
 module IMP-CORE-SYNTAX
-  imports EMPTY-ID
+  imports ID
   imports INT-SYNTAX
   imports BOOL-SYNTAX
 
@@ -28,11 +28,6 @@ module IMP-CORE-SYNTAX
                  > Stmt Stmt                  [left]
   syntax Pgm ::= "int" Ids ";" Stmt
   syntax Ids ::= List{Id,","}
-endmodule
-
-module IMP-SYNTAX
-  imports ID
-  imports IMP-CORE-SYNTAX
 endmodule
 
 module IMP

--- a/k-distribution/tests/regression/kore-cell-fragments/imp_fragments/kore_imp_stack.k
+++ b/k-distribution/tests/regression/kore-cell-fragments/imp_fragments/kore_imp_stack.k
@@ -1,7 +1,7 @@
 // Copyright (c) 2014-2015 K Team. All Rights Reserved.
 requires "domains.k"
 
-module IMP-CORE-SYNTAX
+module IMP-SYNTAX
   imports ID
   imports INT-SYNTAX
   imports BOOL-SYNTAX
@@ -31,7 +31,7 @@ module IMP-CORE-SYNTAX
 endmodule
 
 module IMP
-  imports IMP-CORE-SYNTAX
+  imports IMP-SYNTAX
   imports MAP
   imports INT
 

--- a/k-distribution/tests/regression/kore-io/imp.k
+++ b/k-distribution/tests/regression/kore-io/imp.k
@@ -1,7 +1,7 @@
 // Copyright (c) 2014-2015 K Team. All Rights Reserved.
 require "domains.k"
 
-module IMP-COMMON
+module IMP-SYNTAX
   imports EMPTY-ID
   imports INT-SYNTAX
   imports BOOL-SYNTAX
@@ -32,11 +32,6 @@ module IMP-COMMON
   syntax Ids ::= List{Id,","}
 endmodule
 
-module IMP-SYNTAX
-  imports ID
-  imports IMP-COMMON
-endmodule
-
 module IMP
   imports INT
   imports BOOL
@@ -46,7 +41,7 @@ module IMP
   imports MAP
   imports SET
   imports K-IO
-  imports IMP-COMMON
+  imports IMP-SYNTAX
 
   syntax KResult ::= Int | Bool
 

--- a/k-distribution/tests/regression/kore-io/imp.k
+++ b/k-distribution/tests/regression/kore-io/imp.k
@@ -2,7 +2,7 @@
 require "domains.k"
 
 module IMP-SYNTAX
-  imports EMPTY-ID
+  imports ID
   imports INT-SYNTAX
   imports BOOL-SYNTAX
   imports STRING-SYNTAX

--- a/k-distribution/tests/regression/ocamlbackend/imp.k
+++ b/k-distribution/tests/regression/ocamlbackend/imp.k
@@ -1,7 +1,7 @@
 // Copyright (c) 2014-2015 K Team. All Rights Reserved.
 require "domains.k"
 
-module IMP-COMMON
+module IMP-SYNTAX
   imports EMPTY-ID
   imports INT-SYNTAX
   imports BOOL-SYNTAX
@@ -35,11 +35,6 @@ module IMP-COMMON
   rule if (Cond) Block => if (Cond) Block else {} [macro]
 endmodule
 
-module IMP-SYNTAX
-  imports ID
-  imports IMP-COMMON
-endmodule
-
 module IMP
   imports INT
   imports BOOL
@@ -48,7 +43,7 @@ module IMP
   imports LIST
   imports MAP
   imports SET
-  imports IMP-COMMON
+  imports IMP-SYNTAX
 
   syntax KResult ::= Int | Bool
 

--- a/k-distribution/tests/regression/ocamlbackend/imp.k
+++ b/k-distribution/tests/regression/ocamlbackend/imp.k
@@ -2,7 +2,7 @@
 require "domains.k"
 
 module IMP-SYNTAX
-  imports EMPTY-ID
+  imports ID
   imports INT-SYNTAX
   imports BOOL-SYNTAX
   imports STRING-SYNTAX

--- a/k-distribution/tutorial/1_k/1_lambda/lesson_8/lambda.k
+++ b/k-distribution/tutorial/1_k/1_lambda/lesson_8/lambda.k
@@ -3,12 +3,7 @@ require "domains.k"
 require "substitution.k"
 
 module LAMBDA-SYNTAX
-  imports LAMBDA-COMMON
-  imports ID
-endmodule
-
-module LAMBDA-COMMON
-  imports DOMAINS-COMMON
+  imports DOMAINS-SYNTAX
   syntax Val ::= Id
                | "lambda" Id "." Exp  [binder, latex(\lambda{#1}.{#2})]
   syntax Exp ::= Val
@@ -27,7 +22,7 @@ module LAMBDA-COMMON
 endmodule
 
 module LAMBDA
-  imports LAMBDA-COMMON
+  imports LAMBDA-SYNTAX
   imports DOMAINS
   imports SUBSTITUTION
 

--- a/k-distribution/tutorial/1_k/1_lambda/lesson_9/lambda.k
+++ b/k-distribution/tutorial/1_k/1_lambda/lesson_9/lambda.k
@@ -62,12 +62,7 @@ require "domains.k"
 require "substitution.k"
 
 module LAMBDA-SYNTAX
-  imports LAMBDA-COMMON
-  imports ID
-endmodule
-
-module LAMBDA-COMMON
-  imports DOMAINS-COMMON
+  imports DOMAINS-SYNTAX
 
 /*@ \section{Basic Call-by-value $\lambda$-Calculus}
 
@@ -117,7 +112,7 @@ interleaved) orders.
 endmodule
 
 module LAMBDA
-  imports LAMBDA-COMMON
+  imports LAMBDA-SYNTAX
   imports DOMAINS
   imports SUBSTITUTION
 

--- a/k-distribution/tutorial/1_k/2_imp/lesson_5/imp.k
+++ b/k-distribution/tutorial/1_k/2_imp/lesson_5/imp.k
@@ -19,12 +19,7 @@ conditional, while loop and sequential composition constructs for statements.
 */
 
 module IMP-SYNTAX
-  imports IMP-COMMON
   imports DOMAINS-SYNTAX
-endmodule
-
-module IMP-COMMON
-  imports DOMAINS-COMMON
 /*@ \section{Syntax}
 This module defines the syntax of IMP\@.
 Note that \texttt{<=} is sequentially strict and has a \LaTeX\ attribute
@@ -65,7 +60,7 @@ semantics.  */
 
 module IMP
   imports DOMAINS
-  imports IMP-COMMON
+  imports IMP-SYNTAX
 /*@ \section{Semantics}
 This module defines the semantics of IMP\@.
 Before you start adding semantic rules to a \K definition, you need to

--- a/k-distribution/tutorial/1_k/3_lambda++/lesson_2/lambda.k
+++ b/k-distribution/tutorial/1_k/3_lambda++/lesson_2/lambda.k
@@ -3,12 +3,7 @@
 require "domains.k"
 
 module LAMBDA-SYNTAX
-  imports LAMBDA-COMMON
-  imports ID
-endmodule
-
-module LAMBDA-COMMON
-  imports DOMAINS-COMMON
+  imports DOMAINS-SYNTAX
 
   syntax Exp ::= Id
                | "lambda" Id "." Exp  [latex(\lambda{#1}.{#2})]
@@ -17,7 +12,7 @@ module LAMBDA-COMMON
 endmodule
 
 module LAMBDA
-  imports LAMBDA-COMMON
+  imports LAMBDA-SYNTAX
   imports DOMAINS
 
   configuration <T>

--- a/k-distribution/tutorial/1_k/3_lambda++/lesson_3/lambda.k
+++ b/k-distribution/tutorial/1_k/3_lambda++/lesson_3/lambda.k
@@ -3,12 +3,7 @@
 require "domains.k"
 
 module LAMBDA-SYNTAX
-  imports LAMBDA-COMMON
-  imports ID
-endmodule
-
-module LAMBDA-COMMON
-  imports DOMAINS-COMMON
+  imports DOMAINS-SYNTAX
 
   syntax Exp ::= Id
                | "lambda" Id "." Exp  [latex(\lambda{#1}.{#2})]
@@ -30,7 +25,7 @@ module LAMBDA-COMMON
 endmodule
 
 module LAMBDA
-  imports LAMBDA-COMMON
+  imports LAMBDA-SYNTAX
   imports DOMAINS
 
   configuration <T>

--- a/k-distribution/tutorial/1_k/3_lambda++/lesson_4/lambda.k
+++ b/k-distribution/tutorial/1_k/3_lambda++/lesson_4/lambda.k
@@ -3,12 +3,7 @@
 require "domains.k"
 
 module LAMBDA-SYNTAX
-  imports LAMBDA-COMMON
-  imports ID
-endmodule
-
-module LAMBDA-COMMON
-  imports DOMAINS-COMMON
+  imports DOMAINS-SYNTAX
 
   syntax Exp ::= Id
                | "lambda" Id "." Exp  [latex(\lambda{#1}.{#2})]
@@ -32,7 +27,7 @@ module LAMBDA-COMMON
 endmodule
 
 module LAMBDA
-  imports LAMBDA-COMMON
+  imports LAMBDA-SYNTAX
   imports DOMAINS
 
   configuration <T>

--- a/k-distribution/tutorial/1_k/3_lambda++/lesson_5/lambda.k
+++ b/k-distribution/tutorial/1_k/3_lambda++/lesson_5/lambda.k
@@ -3,12 +3,7 @@
 require "domains.k"
 
 module LAMBDA-SYNTAX
-  imports LAMBDA-COMMON
-  imports ID
-endmodule
-
-module LAMBDA-COMMON
-  imports DOMAINS-COMMON
+  imports DOMAINS-SYNTAX
 
   syntax Exp ::= Id
                | "lambda" Id "." Exp  [latex(\lambda{#1}.{#2})]
@@ -33,7 +28,7 @@ module LAMBDA-COMMON
 endmodule
 
 module LAMBDA
-  imports LAMBDA-COMMON
+  imports LAMBDA-SYNTAX
   imports DOMAINS
 
   configuration <T>

--- a/k-distribution/tutorial/1_k/3_lambda++/lesson_6/lambda.k
+++ b/k-distribution/tutorial/1_k/3_lambda++/lesson_6/lambda.k
@@ -30,12 +30,7 @@ module.  Type kompile --help to see how to tell the parser which syntax to use.
 */
 
 module LAMBDA-SYNTAX
-  imports LAMBDA-COMMON
-  imports ID
-endmodule
-
-module LAMBDA-COMMON
-  imports DOMAINS-COMMON
+  imports DOMAINS-SYNTAX
 /*@ \section{Syntax}
 We move all the LAMBDA++ syntax here. */
 
@@ -66,7 +61,7 @@ endmodule
 
 
 module LAMBDA
-  imports LAMBDA-COMMON
+  imports LAMBDA-SYNTAX
   imports DOMAINS
 
 /*@ \section{Semantics}

--- a/k-distribution/tutorial/1_k/4_imp++/lesson_8/imp.k
+++ b/k-distribution/tutorial/1_k/4_imp++/lesson_8/imp.k
@@ -78,12 +78,7 @@ of a program using the \texttt{search} option of \texttt{krun}.
 */
 
 module IMP-SYNTAX
-imports IMP-COMMON
-imports ID
-endmodule
-
-module IMP-COMMON
-imports DOMAINS-COMMON
+imports DOMAINS-SYNTAX
 
 /*@ \section{Syntax}
 IMP++ adds several syntactic constructs to IMP\@.  Also, since the
@@ -152,7 +147,7 @@ endmodule
 
 
 module IMP
-  imports IMP-COMMON
+  imports IMP-SYNTAX
   imports DOMAINS
 /*@ \section{Semantics}
 We next give the semantics of IMP++\@.  We start by first defining its

--- a/k-distribution/tutorial/1_k/5_types/lesson_9.5/lambda.k
+++ b/k-distribution/tutorial/1_k/5_types/lesson_9.5/lambda.k
@@ -4,12 +4,7 @@ require "unification.k"
 require "substitution.k"
 
 module LAMBDA-SYNTAX
-  imports LAMBDA-COMMON
-  imports ID
-endmodule
-
-module LAMBDA-COMMON
-  imports DOMAINS-COMMON
+  imports DOMAINS-SYNTAX
   syntax Exp ::= Int | Bool | Id
                | "(" Exp ")"                      [bracket]
                | Exp Exp                          [strict, left]
@@ -31,7 +26,7 @@ module LAMBDA-COMMON
 endmodule
 
 module LAMBDA
-  imports LAMBDA-COMMON
+  imports LAMBDA-SYNTAX
   imports DOMAINS
   imports UNIFICATION
   imports SUBSTITUTION

--- a/k-distribution/tutorial/1_k/5_types/lesson_9/lambda.k
+++ b/k-distribution/tutorial/1_k/5_types/lesson_9/lambda.k
@@ -3,12 +3,7 @@ require "domains.k"
 require "unification.k"
 
 module LAMBDA-SYNTAX
-  imports LAMBDA-COMMON
-  imports ID
-endmodule
-
-module LAMBDA-COMMON
-  imports DOMAINS-COMMON
+  imports DOMAINS-SYNTAX
   syntax Exp ::= Int | Bool | Id
                | "(" Exp ")"                      [bracket]
                | Exp Exp                          [strict, left]
@@ -30,7 +25,7 @@ module LAMBDA-COMMON
 endmodule
 
 module LAMBDA
-  imports LAMBDA-COMMON
+  imports LAMBDA-SYNTAX
   imports DOMAINS
   imports UNIFICATION
 

--- a/k-distribution/tutorial/2_languages/1_simple/1_untyped/simple-untyped.k
+++ b/k-distribution/tutorial/2_languages/1_simple/1_untyped/simple-untyped.k
@@ -59,12 +59,7 @@ language definitions discussed in the \K tutorial.} */
 require "domains.k"
 
 module SIMPLE-UNTYPED-SYNTAX
-  imports SIMPLE-UNTYPED-COMMON
-  imports ID
-endmodule
-
-module SIMPLE-UNTYPED-COMMON
-  imports DOMAINS-COMMON
+  imports DOMAINS-SYNTAX
 
 /*@ \section{Syntax}
 We start by defining the SIMPLE syntax.  The language constructs discussed
@@ -249,7 +244,7 @@ endmodule
 
 
 module SIMPLE-UNTYPED
-  imports SIMPLE-UNTYPED-COMMON
+  imports SIMPLE-UNTYPED-SYNTAX
   imports DOMAINS
 
 /*@ \section{Basic Semantic Infrastructure}

--- a/k-distribution/tutorial/2_languages/2_kool/1_untyped/kool-untyped.k
+++ b/k-distribution/tutorial/2_languages/2_kool/1_untyped/kool-untyped.k
@@ -133,12 +133,7 @@ those were all borrowed from SIMPLE. */
 require "domains.k"
 
 module KOOL-UNTYPED-SYNTAX
-  imports KOOL-UNTYPED-COMMON
-  imports ID
-endmodule
-
-module KOOL-UNTYPED-COMMON
-  imports DOMAINS-COMMON
+  imports DOMAINS-SYNTAX
 
 /*@ \section{Syntax}
 
@@ -261,7 +256,7 @@ assignment, etc.).  Finally, we discuss in detail the
 semantics of the additional KOOL constructs. */
 
 module KOOL-UNTYPED
-  imports KOOL-UNTYPED-COMMON
+  imports KOOL-UNTYPED-SYNTAX
   imports DOMAINS
 
 /*@ \subsection{Configuration}

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -96,7 +96,7 @@ public class KastFrontEnd extends FrontEnd {
             if (options.module == null) {
                 mod = def.syntaxModule();
             } else {
-                Option<org.kframework.definition.Module> mod2 = def.kompiledDefinition.getModule(options.module);
+                Option<org.kframework.definition.Module> mod2 = def.kompiledDefinition.getModule(options.module+"-#PROGRAM");
                 if (mod2.isEmpty()) {
                     throw KEMException.innerParserError("Module " + options.module + " not found. Specify a module with -m.");
                 }

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -94,9 +94,9 @@ public class KastFrontEnd extends FrontEnd {
             }
             org.kframework.definition.Module mod;
             if (options.module == null) {
-                mod = def.syntaxModule();
+                mod = def.programParsingModuleForModule(def.mainSyntaxModuleName()).get();
             } else {
-                Option<org.kframework.definition.Module> mod2 = def.kompiledDefinition.getModule(options.module+"-#PROGRAM");
+                Option<org.kframework.definition.Module> mod2 = def.programParsingModuleForModule(options.module);
                 if (mod2.isEmpty()) {
                     throw KEMException.innerParserError("Module " + options.module + " not found. Specify a module with -m.");
                 }

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -94,9 +94,9 @@ public class KastFrontEnd extends FrontEnd {
             }
             org.kframework.definition.Module mod;
             if (options.module == null) {
-                mod = def.programParsingModuleFor(def.mainSyntaxModuleName()).get();
+                mod = def.programParsingModuleFor(def.mainSyntaxModuleName(), kem).get();
             } else {
-                Option<org.kframework.definition.Module> mod2 = def.programParsingModuleFor(options.module);
+                Option<org.kframework.definition.Module> mod2 = def.programParsingModuleFor(options.module, kem);
                 if (mod2.isEmpty()) {
                     throw KEMException.innerParserError("Module " + options.module + " not found. Specify a module with -m.");
                 }

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -94,7 +94,7 @@ public class KastFrontEnd extends FrontEnd {
             }
             org.kframework.definition.Module mod;
             if (options.module == null) {
-                mod = def.syntaxModule();
+                mod = def.programsModule();
             } else {
                 Option<org.kframework.definition.Module> mod2 = def.kompiledDefinition.getModule(options.module);
                 if (mod2.isEmpty()) {

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -94,9 +94,9 @@ public class KastFrontEnd extends FrontEnd {
             }
             org.kframework.definition.Module mod;
             if (options.module == null) {
-                mod = def.programParsingModuleForModule(def.mainSyntaxModuleName()).get();
+                mod = def.generatedProgramParsingModuleFor(def.mainSyntaxModuleName()).get();
             } else {
-                Option<org.kframework.definition.Module> mod2 = def.programParsingModuleForModule(options.module);
+                Option<org.kframework.definition.Module> mod2 = def.generatedProgramParsingModuleFor(options.module);
                 if (mod2.isEmpty()) {
                     throw KEMException.innerParserError("Module " + options.module + " not found. Specify a module with -m.");
                 }

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -94,9 +94,9 @@ public class KastFrontEnd extends FrontEnd {
             }
             org.kframework.definition.Module mod;
             if (options.module == null) {
-                mod = def.generatedProgramParsingModuleFor(def.mainSyntaxModuleName()).get();
+                mod = def.programParsingModuleFor(def.mainSyntaxModuleName()).get();
             } else {
-                Option<org.kframework.definition.Module> mod2 = def.generatedProgramParsingModuleFor(options.module);
+                Option<org.kframework.definition.Module> mod2 = def.programParsingModuleFor(options.module);
                 if (mod2.isEmpty()) {
                     throw KEMException.innerParserError("Module " + options.module + " not found. Specify a module with -m.");
                 }

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -94,7 +94,7 @@ public class KastFrontEnd extends FrontEnd {
             }
             org.kframework.definition.Module mod;
             if (options.module == null) {
-                mod = def.programsModule();
+                mod = def.syntaxModule();
             } else {
                 Option<org.kframework.definition.Module> mod2 = def.kompiledDefinition.getModule(options.module);
                 if (mod2.isEmpty()) {

--- a/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
+++ b/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
@@ -54,7 +54,7 @@ public class CompiledDefinition implements Serializable {
      * A function that takes a string and the source of that string and parses it as a program into KAST.
      */
     public BiFunction<String, Source, K> getProgramParser(KExceptionManager kem) {
-        return getParser(kompiledDefinition.mainSyntaxModule(), programStartSymbol, kem);
+        return getParser(kompiledDefinition.programParsingModule(), programStartSymbol, kem);
     }
 
     /**

--- a/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
+++ b/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
@@ -56,7 +56,7 @@ public class CompiledDefinition implements Serializable {
      * A function that takes a string and the source of that string and parses it as a program into KAST.
      */
     public BiFunction<String, Source, K> getProgramParser(KExceptionManager kem) {
-        return getParser(programParsingModuleForModule(mainSyntaxModuleName()).get(), programStartSymbol, kem);
+        return getParser(generatedProgramParsingModuleFor(mainSyntaxModuleName()).get(), programStartSymbol, kem);
     }
 
     /**
@@ -75,8 +75,8 @@ public class CompiledDefinition implements Serializable {
 
     public String mainSyntaxModuleName() { return parsedDefinition.att().<String>getOptional(Att.syntaxModule()).get(); }
 
-    public Option<Module> programParsingModuleForModule(String syntaxModuleName) {
-        return kompiledDefinition.getModule(syntaxModuleName + RuleGrammarGenerator.POSTFIX);
+    public Option<Module> generatedProgramParsingModuleFor(String moduleName) {
+        return kompiledDefinition.getModule(moduleName + RuleGrammarGenerator.POSTFIX);
     }
 
     public Module languageParsingModule() { return languageParsingModule; }

--- a/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
+++ b/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
@@ -87,7 +87,7 @@ public class CompiledDefinition implements Serializable {
 
         Option<Module> userProgramParsingModule = parsedDefinition.getModule(moduleName + RuleGrammarGenerator.POSTFIX);
         if (userProgramParsingModule.isDefined()) {
-            kem.registerCompilerHiddenWarning("Module " + userProgramParsingModule.get().name() + " is user-defined.");
+            kem.registerInternalHiddenWarning("Module " + userProgramParsingModule.get().name() + " is user-defined.");
             return userProgramParsingModule;
         } else {
             Option<Module> moduleOption = parsedDefinition.getModule(moduleName);
@@ -95,7 +95,7 @@ public class CompiledDefinition implements Serializable {
                     Option.apply(gen.getProgramsGrammar(moduleOption.get())) :
                     Option.empty();
             if (programParsingModuleOption.isDefined()) {
-                kem.registerCompilerHiddenWarning("Module " + programParsingModuleOption.get().name() + " has been automatically generated.");
+                kem.registerInternalHiddenWarning("Module " + programParsingModuleOption.get().name() + " has been automatically generated.");
             }
             return programParsingModuleOption;
         }

--- a/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
+++ b/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
@@ -12,6 +12,7 @@ import org.kframework.kore.Sort;
 import org.kframework.parser.TreeNodesToKORE;
 import org.kframework.parser.concrete2kore.ParseInModule;
 import org.kframework.parser.concrete2kore.generator.RuleGrammarGenerator;
+import org.kframework.utils.errorsystem.KException;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.errorsystem.ParseFailedException;
 import org.kframework.utils.file.FileUtil;
@@ -38,19 +39,17 @@ public class CompiledDefinition implements Serializable {
     public final Definition kompiledDefinition;
     public final Sort programStartSymbol;
     public final KLabel topCellInitializer;
-    private KExceptionManager kem;
     private final Module languageParsingModule;
     private transient Map<String, Rule> cachedcompiledPatterns;
     private transient Map<String, Rule> cachedParsedPatterns;
 
 
-    public CompiledDefinition(KompileOptions kompileOptions, Definition parsedDefinition, Definition kompiledDefinition, Sort programStartSymbol, KLabel topCellInitializer, KExceptionManager kem) {
+    public CompiledDefinition(KompileOptions kompileOptions, Definition parsedDefinition, Definition kompiledDefinition, Sort programStartSymbol, KLabel topCellInitializer) {
         this.kompileOptions = kompileOptions;
         this.parsedDefinition = parsedDefinition;
         this.kompiledDefinition = kompiledDefinition;
         this.programStartSymbol = programStartSymbol;
         this.topCellInitializer = topCellInitializer;
-        this.kem = kem;
         this.languageParsingModule = kompiledDefinition.getModule("LANGUAGE-PARSING").get();
     }
 
@@ -58,7 +57,7 @@ public class CompiledDefinition implements Serializable {
      * A function that takes a string and the source of that string and parses it as a program into KAST.
      */
     public BiFunction<String, Source, K> getProgramParser(KExceptionManager kem) {
-        return getParser(programParsingModuleFor(mainSyntaxModuleName()).get(), programStartSymbol, kem);
+        return getParser(programParsingModuleFor(mainSyntaxModuleName(), kem).get(), programStartSymbol, kem);
     }
 
     /**
@@ -82,7 +81,7 @@ public class CompiledDefinition implements Serializable {
      * It automatically generates this module unless the user has already defined a module postfixed with
      * {@link RuleGrammarGenerator#POSTFIX}. In latter case, it uses the user-defined module.
      */
-    public Option<Module> programParsingModuleFor(String moduleName) {
+    public Option<Module> programParsingModuleFor(String moduleName, KExceptionManager kem) {
         RuleGrammarGenerator gen = new RuleGrammarGenerator(parsedDefinition, kompileOptions.strict());
 
         Option<Module> userProgramParsingModule = parsedDefinition.getModule(moduleName + RuleGrammarGenerator.POSTFIX);

--- a/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
+++ b/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2015 K Team. All Rights Reserved.
 package org.kframework.kompile;
 
+import org.kframework.Collections;
 import org.kframework.attributes.Source;
 import org.kframework.definition.Definition;
 import org.kframework.definition.Module;
@@ -54,7 +55,7 @@ public class CompiledDefinition implements Serializable {
      * A function that takes a string and the source of that string and parses it as a program into KAST.
      */
     public BiFunction<String, Source, K> getProgramParser(KExceptionManager kem) {
-        return getParser(kompiledDefinition.programParsingModule(), programStartSymbol, kem);
+        return getParser(kompiledDefinition.mainSyntaxModule(), programStartSymbol, kem);
     }
 
     /**
@@ -113,9 +114,5 @@ public class CompiledDefinition implements Serializable {
         stream.defaultReadObject();
         cachedcompiledPatterns = new ConcurrentHashMap<>();
         cachedParsedPatterns = new ConcurrentHashMap<>();
-    }
-
-    public Module programsModule() {
-        return parsedDefinition.programParsingModule();
     }
 }

--- a/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
+++ b/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
@@ -1,7 +1,6 @@
 // Copyright (c) 2015 K Team. All Rights Reserved.
 package org.kframework.kompile;
 
-import org.kframework.Collections;
 import org.kframework.attributes.Att;
 import org.kframework.attributes.Source;
 import org.kframework.definition.Definition;
@@ -16,6 +15,7 @@ import org.kframework.parser.concrete2kore.generator.RuleGrammarGenerator;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.errorsystem.ParseFailedException;
 import org.kframework.utils.file.FileUtil;
+import scala.Option;
 import scala.Tuple2;
 import scala.util.Either;
 
@@ -56,7 +56,7 @@ public class CompiledDefinition implements Serializable {
      * A function that takes a string and the source of that string and parses it as a program into KAST.
      */
     public BiFunction<String, Source, K> getProgramParser(KExceptionManager kem) {
-        return getParser(syntaxModule(), programStartSymbol, kem);
+        return getParser(programParsingModuleForModule(mainSyntaxModuleName()).get(), programStartSymbol, kem);
     }
 
     /**
@@ -73,9 +73,10 @@ public class CompiledDefinition implements Serializable {
         return kompiledDefinition.mainModule();
     }
 
-    public Module syntaxModule() {
-        String syntaxModuleName = parsedDefinition.att().<String>getOptional(Att.syntaxModule()).get();
-        return kompiledDefinition.getModule(syntaxModuleName + RuleGrammarGenerator.POSTFIX).get();
+    public String mainSyntaxModuleName() { return parsedDefinition.att().<String>getOptional(Att.syntaxModule()).get(); }
+
+    public Option<Module> programParsingModuleForModule(String syntaxModuleName) {
+        return kompiledDefinition.getModule(syntaxModuleName + RuleGrammarGenerator.POSTFIX);
     }
 
     public Module languageParsingModule() { return languageParsingModule; }

--- a/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
+++ b/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
@@ -114,4 +114,8 @@ public class CompiledDefinition implements Serializable {
         cachedcompiledPatterns = new ConcurrentHashMap<>();
         cachedParsedPatterns = new ConcurrentHashMap<>();
     }
+
+    public Module programsModule() {
+        return parsedDefinition.programParsingModule();
+    }
 }

--- a/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
+++ b/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
@@ -56,7 +56,7 @@ public class CompiledDefinition implements Serializable {
      * A function that takes a string and the source of that string and parses it as a program into KAST.
      */
     public BiFunction<String, Source, K> getProgramParser(KExceptionManager kem) {
-        return getParser(generatedProgramParsingModuleFor(mainSyntaxModuleName()).get(), programStartSymbol, kem);
+        return getParser(programParsingModuleFor(mainSyntaxModuleName()).get(), programStartSymbol, kem);
     }
 
     /**
@@ -75,7 +75,12 @@ public class CompiledDefinition implements Serializable {
 
     public String mainSyntaxModuleName() { return parsedDefinition.att().<String>getOptional(Att.syntaxModule()).get(); }
 
-    public Option<Module> generatedProgramParsingModuleFor(String moduleName) {
+    /**
+     * @return the module used for generating the program (i.e. ground) parser for the module named moduleName
+     * It automatically generates this module unless the user has already defined a module postfixed with
+     * {@link RuleGrammarGenerator#POSTFIX}. In latter case, it uses the user-defined module.
+     */
+    public Option<Module> programParsingModuleFor(String moduleName) {
         RuleGrammarGenerator gen = new RuleGrammarGenerator(parsedDefinition, kompileOptions.strict());
 
         Option<Module> userProgramParsingModule = parsedDefinition.getModule(moduleName + RuleGrammarGenerator.POSTFIX);

--- a/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
+++ b/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
@@ -2,6 +2,7 @@
 package org.kframework.kompile;
 
 import org.kframework.Collections;
+import org.kframework.attributes.Att;
 import org.kframework.attributes.Source;
 import org.kframework.definition.Definition;
 import org.kframework.definition.Module;
@@ -55,7 +56,7 @@ public class CompiledDefinition implements Serializable {
      * A function that takes a string and the source of that string and parses it as a program into KAST.
      */
     public BiFunction<String, Source, K> getProgramParser(KExceptionManager kem) {
-        return getParser(kompiledDefinition.mainSyntaxModule(), programStartSymbol, kem);
+        return getParser(syntaxModule(), programStartSymbol, kem);
     }
 
     /**
@@ -72,7 +73,10 @@ public class CompiledDefinition implements Serializable {
         return kompiledDefinition.mainModule();
     }
 
-    public Module syntaxModule() { return kompiledDefinition.mainSyntaxModule(); }
+    public Module syntaxModule() {
+        String syntaxModuleName = parsedDefinition.att().<String>getOptional(Att.syntaxModule()).get();
+        return kompiledDefinition.getModule(syntaxModuleName + RuleGrammarGenerator.POSTFIX).get();
+    }
 
     public Module languageParsingModule() { return languageParsingModule; }
 

--- a/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
+++ b/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
@@ -76,7 +76,15 @@ public class CompiledDefinition implements Serializable {
     public String mainSyntaxModuleName() { return parsedDefinition.att().<String>getOptional(Att.syntaxModule()).get(); }
 
     public Option<Module> generatedProgramParsingModuleFor(String moduleName) {
-        return kompiledDefinition.getModule(moduleName + RuleGrammarGenerator.POSTFIX);
+        RuleGrammarGenerator gen = new RuleGrammarGenerator(parsedDefinition, kompileOptions.strict());
+
+        Option<Module> userProgramParsingModule = parsedDefinition.getModule(moduleName + RuleGrammarGenerator.POSTFIX);
+        if(userProgramParsingModule.isDefined()) {
+            return userProgramParsingModule;
+        } else {
+            Option<Module> moduleOption = parsedDefinition.getModule(moduleName);
+            return moduleOption.isDefined() ? Option.apply(gen.getProgramsGrammar(moduleOption.get())) : Option.empty();
+        }
     }
 
     public Module languageParsingModule() { return languageParsingModule; }

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -222,7 +222,7 @@ public class Kompile {
     }
 
     public Definition addProgramModule(Definition d) {
-        Module programsModule = gen.getProgramsGrammar(d.programParsingModule());
+        Module programsModule = gen.getProgramsGrammar(d.mainSyntaxModule());
         java.util.Set<Module> allModules = mutable(d.modules());
         allModules.add(programsModule);
         return Definition(d.mainModule(), programsModule, immutable(allModules));

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -163,9 +163,9 @@ public class Kompile {
         if (!errors.isEmpty()) {
             kem.addAllKException(errors.stream().map(e -> e.exception).collect(Collectors.toList()));
             kem.print();
+
             throw KEMException.compilerError("Had " + errors.size() + " structural errors.");
         }
-
     }
 
     public Function<Definition, Definition> defaultSteps() {

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -187,7 +187,6 @@ public class Kompile {
                 .andThen(new Strategy(kompileOptions.experimental.heatCoolStrategies).addStrategyCellToRulesTransformer())
                 .andThen(func(ConcretizeCells::transformDefinition))
                 .andThen(func(this::addSemanticsModule))
-                .andThen(func(this::addProgramModule))
                 .apply(def);
     }
 
@@ -218,11 +217,6 @@ public class Kompile {
     public Definition resolveFreshConstants(Definition input) {
         return DefinitionTransformer.from(new ResolveFreshConstants(input)::resolve, "resolving !Var variables")
                 .apply(input);
-    }
-
-    public <R> Definition addProgramModule(Definition d) {
-        Set<Module> programParsingModules = stream(d.modules()).map(gen::getProgramsGrammar).collect(Collections.toSet());
-        return Definition(d.mainModule(), or(d.modules(), programParsingModules), d.att());
     }
 
     private Sentence concretizeSentence(Sentence s, Definition input) {

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -210,10 +210,10 @@ public class Kompile {
 
         Module languageParsingModule = Module("LANGUAGE-PARSING",
                 Set(d.mainModule(),
-                        d.mainSyntaxModule(),
-                        d.getModule("K-TERM").get()), Set(), Att());
+                        d.getModule("K-TERM").get(),
+                        d.getModule("ID").get()), Set(), Att());
         allModules.add(languageParsingModule);
-        return Definition(withKSeq, d.mainSyntaxModule(), immutable(allModules));
+        return Definition(withKSeq, immutable(allModules), d.att());
     }
 
     public Definition resolveFreshConstants(Definition input) {
@@ -221,11 +221,9 @@ public class Kompile {
                 .apply(input);
     }
 
-    public Definition addProgramModule(Definition d) {
-        Module programsModule = gen.getProgramsGrammar(d.mainSyntaxModule());
-        java.util.Set<Module> allModules = mutable(d.modules());
-        allModules.add(programsModule);
-        return Definition(d.mainModule(), programsModule, immutable(allModules));
+    public <R> Definition addProgramModule(Definition d) {
+        Set<Module> programParsingModules = stream(d.modules()).map(gen::getProgramsGrammar).collect(Collections.toSet());
+        return Definition(d.mainModule(), or(d.modules(), programParsingModules), d.att());
     }
 
     private Sentence concretizeSentence(Sentence s, Definition input) {

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -162,6 +162,7 @@ public class Kompile {
 
         if (!errors.isEmpty()) {
             kem.addAllKException(errors.stream().map(e -> e.exception).collect(Collectors.toList()));
+            kem.print();
             throw KEMException.compilerError("Had " + errors.size() + " structural errors.");
         }
 
@@ -211,7 +212,7 @@ public class Kompile {
         Module languageParsingModule = Module("LANGUAGE-PARSING",
                 Set(d.mainModule(),
                         d.getModule("K-TERM").get(),
-                        d.getModule("ID").get()), Set(), Att());
+                        d.getModule(RuleGrammarGenerator.ID).get()), Set(), Att());
         allModules.add(languageParsingModule);
         return Definition(withKSeq, immutable(allModules), d.att());
     }

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -162,8 +162,6 @@ public class Kompile {
 
         if (!errors.isEmpty()) {
             kem.addAllKException(errors.stream().map(e -> e.exception).collect(Collectors.toList()));
-            kem.print();
-
             throw KEMException.compilerError("Had " + errors.size() + " structural errors.");
         }
     }

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -153,7 +153,7 @@ public class Kompile {
 
         ConfigurationInfoFromModule configInfo = new ConfigurationInfoFromModule(kompiledDefinition.mainModule());
 
-        return new CompiledDefinition(kompileOptions, parsedDef, kompiledDefinition, programStartSymbol, configInfo.getDefaultCell(configInfo.topCell()).klabel(), kem);
+        return new CompiledDefinition(kompileOptions, parsedDef, kompiledDefinition, programStartSymbol, configInfo.getDefaultCell(configInfo.topCell()).klabel());
     }
 
     private void checkDefinition(Definition parsedDef) {

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -212,7 +212,7 @@ public class Kompile {
         Module languageParsingModule = Module("LANGUAGE-PARSING",
                 Set(d.mainModule(),
                         d.getModule("K-TERM").get(),
-                        d.getModule(RuleGrammarGenerator.ID).get()), Set(), Att());
+                        d.getModule(RuleGrammarGenerator.ID_PROGRAM_PARSING).get()), Set(), Att());
         allModules.add(languageParsingModule);
         return Definition(withKSeq, immutable(allModules), d.att());
     }

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -222,7 +222,7 @@ public class Kompile {
     }
 
     public Definition addProgramModule(Definition d) {
-        Module programsModule = gen.getProgramsGrammar(d.mainSyntaxModule());
+        Module programsModule = gen.getProgramsGrammar(d.programParsingModule());
         java.util.Set<Module> allModules = mutable(d.modules());
         allModules.add(programsModule);
         return Definition(d.mainModule(), programsModule, immutable(allModules));

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -153,7 +153,7 @@ public class Kompile {
 
         ConfigurationInfoFromModule configInfo = new ConfigurationInfoFromModule(kompiledDefinition.mainModule());
 
-        return new CompiledDefinition(kompileOptions, parsedDef, kompiledDefinition, programStartSymbol, configInfo.getDefaultCell(configInfo.topCell()).klabel());
+        return new CompiledDefinition(kompileOptions, parsedDef, kompiledDefinition, programStartSymbol, configInfo.getDefaultCell(configInfo.topCell()).klabel(), kem);
     }
 
     private void checkDefinition(Definition parsedDef) {

--- a/kernel/src/main/java/org/kframework/kore/convertors/KILtoKORE.java
+++ b/kernel/src/main/java/org/kframework/kore/convertors/KILtoKORE.java
@@ -88,8 +88,7 @@ public class KILtoKORE extends KILTransformation<Object> {
 
         return Definition(
                 koreModules.get(mainModule.getName()),
-                koreModules.get(mainModule.getName()),
-                immutable(new HashSet<>(koreModules.values())));
+                immutable(new HashSet<>(koreModules.values())), Att());
     }
 
     public org.kframework.definition.Module apply(Module mainModule, Set<Module> allKilModules,

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/ParserUtils.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/ParserUtils.java
@@ -2,6 +2,7 @@
 package org.kframework.parser.concrete2kore;
 
 import org.apache.commons.io.FileUtils;
+import org.kframework.attributes.Att;
 import org.kframework.attributes.Source;
 import org.kframework.definition.Module;
 import org.kframework.kil.Definition;
@@ -212,6 +213,6 @@ public class ParserUtils {
             syntaxModule = opt.get();
         }
 
-        return org.kframework.definition.Definition.apply(mainModule, syntaxModule, immutable(modules), Att());
+        return org.kframework.definition.Definition.apply(mainModule, immutable(modules), Att().add(Att.syntaxModule(), syntaxModule.name()));
     }
 }

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/ParserUtils.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/ParserUtils.java
@@ -212,11 +212,6 @@ public class ParserUtils {
             syntaxModule = opt.get();
         }
 
-        Module idSyntaxModule = modules.stream().filter(m -> m.name().equals(("ID"))).findFirst().get();
-
-        Module programParsingModule = Module.apply(mainModuleName + "-PROGRAM", Set(syntaxModule, idSyntaxModule), Set(), Att());
-        modules.add(programParsingModule);
-
-        return org.kframework.definition.Definition.apply(mainModule, programParsingModule, immutable(modules), Att());
+        return org.kframework.definition.Definition.apply(mainModule, syntaxModule, immutable(modules), Att());
     }
 }

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/ParserUtils.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/ParserUtils.java
@@ -211,6 +211,12 @@ public class ParserUtils {
         } else {
             syntaxModule = opt.get();
         }
-        return org.kframework.definition.Definition.apply(mainModule, syntaxModule, immutable(modules), Att());
+
+        Module idSyntaxModule = modules.stream().filter(m -> m.name().equals(("ID"))).findFirst().get();
+
+        Module programParsingModule = Module.apply(mainModuleName + "-PROGRAM", Set(syntaxModule, idSyntaxModule), Set(), Att());
+        modules.add(programParsingModule);
+
+        return org.kframework.definition.Definition.apply(mainModule, programParsingModule, immutable(modules), Att());
     }
 }

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
@@ -73,7 +73,7 @@ public class RuleGrammarGenerator {
     public static final String ID = "ID";
     public static final String RULE_LISTS = "RULE-LISTS";
 
-    public static final String POSTFIX = "-PROGRAM";
+    public static final String POSTFIX = "-PROGRAM-PARSING";
 
     /**
      * Initialize a grammar generator.

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
@@ -73,6 +73,8 @@ public class RuleGrammarGenerator {
     public static final String ID = "ID";
     public static final String RULE_LISTS = "RULE-LISTS";
 
+    public static final String POSTFIX = "-PROGRAM";
+
     /**
      * Initialize a grammar generator.
      * @param baseK A Definition containing a K module giving the syntax of K itself.
@@ -128,7 +130,7 @@ public class RuleGrammarGenerator {
         if(idOpt.isDefined())
             modules = org.kframework.Collections.add(idOpt.get(), modules);
 
-        return Module.apply(mod.name() + "-PROGRAM-LISTS", modules, Set(), Att());
+        return Module.apply(mod.name() + POSTFIX, modules, Set(), Att());
     }
 
     public static boolean isParserSort(Sort s) {

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
@@ -18,9 +18,11 @@ import org.kframework.kil.Attribute;
 import org.kframework.kil.loader.Constants;
 import org.kframework.kore.Sort;
 import org.kframework.parser.concrete2kore.ParseInModule;
+import scala.Option;
 import scala.collection.Seq;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -68,6 +70,7 @@ public class RuleGrammarGenerator {
     public static final String K_BOTTOM_SORT = "K-BOTTOM-SORT";
     public static final String AUTO_FOLLOW = "AUTO-FOLLOW";
     public static final String PROGRAM_LISTS = "PROGRAM-LISTS";
+    public static final String ID = "ID";
     public static final String RULE_LISTS = "RULE-LISTS";
 
     /**
@@ -119,8 +122,13 @@ public class RuleGrammarGenerator {
      */
     public Module getProgramsGrammar(Module mod) {
         // import PROGRAM-LISTS so user lists are modified to parse programs
-        Module newM = new Module(mod.name() + "-PROGRAM-LISTS", Set(mod, baseK.getModule(PROGRAM_LISTS).get()), Set(), Att());
-        return newM;
+        scala.collection.Set<Module> modules = org.kframework.Collections.Set(mod, baseK.getModule(PROGRAM_LISTS).get());
+
+        Option<Module> idOpt = baseK.getModule(ID);
+        if(idOpt.isDefined())
+            modules = org.kframework.Collections.add(idOpt.get(), modules);
+
+        return Module.apply(mod.name() + "-PROGRAM-LISTS", modules, Set(), Att());
     }
 
     public static boolean isParserSort(Sort s) {

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/generator/RuleGrammarGenerator.java
@@ -70,10 +70,10 @@ public class RuleGrammarGenerator {
     public static final String K_BOTTOM_SORT = "K-BOTTOM-SORT";
     public static final String AUTO_FOLLOW = "AUTO-FOLLOW";
     public static final String PROGRAM_LISTS = "PROGRAM-LISTS";
-    public static final String ID = "ID";
     public static final String RULE_LISTS = "RULE-LISTS";
 
     public static final String POSTFIX = "-PROGRAM-PARSING";
+    public static final String ID = "ID" + POSTFIX;
 
     /**
      * Initialize a grammar generator.
@@ -127,7 +127,7 @@ public class RuleGrammarGenerator {
         scala.collection.Set<Module> modules = org.kframework.Collections.Set(mod, baseK.getModule(PROGRAM_LISTS).get());
 
         Option<Module> idOpt = baseK.getModule(ID);
-        if(idOpt.isDefined())
+        if(idOpt.isDefined() && !mod.equals(idOpt.get()))
             modules = org.kframework.Collections.add(idOpt.get(), modules);
 
         return Module.apply(mod.name() + POSTFIX, modules, Set(), Att());

--- a/kernel/src/main/java/org/kframework/utils/errorsystem/KExceptionManager.java
+++ b/kernel/src/main/java/org/kframework/utils/errorsystem/KExceptionManager.java
@@ -157,8 +157,8 @@ public class KExceptionManager {
         register(ExceptionType.HIDDENWARNING, KExceptionGroup.INTERNAL, message, null, e, null, null);
     }
 
-    public void registerCompilerHiddenWarning(String message) {
-        register(ExceptionType.HIDDENWARNING, KExceptionGroup.COMPILER, message, null, null, null, null);
+    public void registerInternalHiddenWarning(String message) {
+        register(ExceptionType.HIDDENWARNING, KExceptionGroup.INTERNAL, message, null, null, null, null);
     }
 
     public void registerInternalHiddenWarning(String message, ASTNode node) {

--- a/kernel/src/main/java/org/kframework/utils/errorsystem/KExceptionManager.java
+++ b/kernel/src/main/java/org/kframework/utils/errorsystem/KExceptionManager.java
@@ -157,6 +157,10 @@ public class KExceptionManager {
         register(ExceptionType.HIDDENWARNING, KExceptionGroup.INTERNAL, message, null, e, null, null);
     }
 
+    public void registerCompilerHiddenWarning(String message) {
+        register(ExceptionType.HIDDENWARNING, KExceptionGroup.COMPILER, message, null, null, null, null);
+    }
+
     public void registerInternalHiddenWarning(String message, ASTNode node) {
         register(ExceptionType.HIDDENWARNING, KExceptionGroup.INTERNAL, message, null, null, node.getLocation(), node.getSource());
     }

--- a/kernel/src/test/java/org/kframework/parser/outer/NewOuterParserTest.java
+++ b/kernel/src/test/java/org/kframework/parser/outer/NewOuterParserTest.java
@@ -43,7 +43,7 @@ public class NewOuterParserTest {
                 Lists.newArrayList(BUILTIN_DIRECTORY),
                 true);
 
-        K kBody = ParserUtils.parseWithModule(theTextToParse, startSymbol, source, definition.mainSyntaxModule());
+        K kBody = ParserUtils.parseWithModule(theTextToParse, startSymbol, source, definition.programParsingModule());
         //System.out.println(kBody);
     }
 }

--- a/kernel/src/test/java/org/kframework/parser/outer/NewOuterParserTest.java
+++ b/kernel/src/test/java/org/kframework/parser/outer/NewOuterParserTest.java
@@ -5,6 +5,7 @@ package org.kframework.parser.outer;
 import com.beust.jcommander.internal.Lists;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
+import org.kframework.attributes.Att;
 import org.kframework.attributes.Source;
 import org.kframework.definition.Definition;
 import org.kframework.kore.K;
@@ -43,7 +44,7 @@ public class NewOuterParserTest {
                 Lists.newArrayList(BUILTIN_DIRECTORY),
                 true);
 
-        K kBody = ParserUtils.parseWithModule(theTextToParse, startSymbol, source, definition.mainSyntaxModule());
+        K kBody = ParserUtils.parseWithModule(theTextToParse, startSymbol, source, definition.getModule(definition.att().<String>get(Att.syntaxModule()).get()).get());
         //System.out.println(kBody);
     }
 }

--- a/kernel/src/test/java/org/kframework/parser/outer/NewOuterParserTest.java
+++ b/kernel/src/test/java/org/kframework/parser/outer/NewOuterParserTest.java
@@ -43,7 +43,7 @@ public class NewOuterParserTest {
                 Lists.newArrayList(BUILTIN_DIRECTORY),
                 true);
 
-        K kBody = ParserUtils.parseWithModule(theTextToParse, startSymbol, source, definition.programParsingModule());
+        K kBody = ParserUtils.parseWithModule(theTextToParse, startSymbol, source, definition.mainSyntaxModule());
         //System.out.println(kBody);
     }
 }

--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -114,6 +114,7 @@ object Att {
   val stuck = "#STUCK"
   val refers_THIS_CONFIGURATION = "refers_THIS_CONFIGURATION"
   val refers_RESTORE_CONFIGURATION = "refers_RESTORE_CONFIGURATION"
+  val syntaxModule = "syntaxModule"
 }
 
 trait AttributesToString {

--- a/kore/src/main/scala/org/kframework/definition/Constructors.scala
+++ b/kore/src/main/scala/org/kframework/definition/Constructors.scala
@@ -2,6 +2,7 @@
 
 package org.kframework.definition
 
+import org.kframework.attributes.Att
 import org.kframework.{attributes, definition}
 import org.kframework.kore._
 import collection._
@@ -15,8 +16,8 @@ import collection._
 
 object Constructors {
 
-  def Definition(mainModule: Module, syntaxModule: Module, modules: Set[Module]) =
-    definition.Definition(mainModule, syntaxModule, modules)
+  def Definition(mainModule: Module, modules: Set[Module], att: Att) =
+    definition.Definition(mainModule, modules, att)
 
   def Module(name: String, imports: Set[Module], sentences: Set[Sentence], att: attributes.Att) =
     definition.Module(name, imports, sentences, att)

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -7,6 +7,7 @@ import javax.annotation.Nonnull
 import dk.brics.automaton.{BasicAutomata, RegExp, RunAutomaton, SpecialOperations}
 import org.kframework.POSet
 import org.kframework.attributes.Att
+import org.kframework.definition.Constructors._
 import org.kframework.kore.Unapply.{KApply, KLabel}
 import org.kframework.kore._
 import org.kframework.utils.errorsystem.KEMException
@@ -15,6 +16,7 @@ import scala.annotation.meta.param
 import scala.collection.JavaConverters._
 
 import collection._
+import scala.collection.Set
 
 trait OuterKORE
 
@@ -43,6 +45,12 @@ case class Definition(
 
   assert(modules.contains(mainModule))
   assert(modules.contains(mainSyntaxModule))
+
+  // TODO: remove this method when cleaning up the way Kompile generates the parsing module
+  lazy val programParsingModule: Module = Module(
+      mainModule.name + "-PROGRAM",
+      Set(mainSyntaxModule) | modules.find(_.name == "ID").toSet,
+      Set())
 
   def getModule(name: String): Option[Module] = modules find { case m: Module => m.name == name; case _ => false }
 }

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -34,9 +34,8 @@ case class DivergingAttributesForTheSameKLabel(ps: Set[Production])
 
 case class Definition(
                        mainModule: Module,
-                       mainSyntaxModule: Module,
                        entryModules: Set[Module],
-                       att: Att = Att())
+                       att: Att)
   extends DefinitionToString with OuterKORE {
 
   private def allModules(m: Module): Set[Module] = m.imports | (m.imports flatMap allModules) + m
@@ -44,7 +43,6 @@ case class Definition(
   val modules = entryModules flatMap allModules
 
   assert(modules.contains(mainModule))
-  assert(modules.contains(mainSyntaxModule))
 
   def getModule(name: String): Option[Module] = modules find { case m: Module => m.name == name; case _ => false }
 }

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -46,12 +46,6 @@ case class Definition(
   assert(modules.contains(mainModule))
   assert(modules.contains(mainSyntaxModule))
 
-  // TODO: remove this method when cleaning up the way Kompile generates the parsing module
-  lazy val programParsingModule: Module = Module(
-      mainModule.name + "-PROGRAM",
-      Set(mainSyntaxModule) | modules.find(_.name == "ID").toSet,
-      Set())
-
   def getModule(name: String): Option[Module] = modules find { case m: Module => m.name == name; case _ => false }
 }
 

--- a/kore/src/main/scala/org/kframework/definition/transformers.scala
+++ b/kore/src/main/scala/org/kframework/definition/transformers.scala
@@ -84,8 +84,8 @@ class DefinitionTransformer(moduleTransformer: Module => Module) extends (Defini
   override def apply(d: Definition): Definition = {
     definition.Definition(
       moduleTransformer(d.mainModule),
-      moduleTransformer(d.mainSyntaxModule),
-      d.entryModules map moduleTransformer)
+      d.entryModules map moduleTransformer,
+      d.att)
   }
 }
 
@@ -96,7 +96,7 @@ class SelectiveDefinitionTransformer(moduleTransformer: ModuleTransformer) exten
   override def apply(d: Definition): Definition = {
     definition.Definition(
       moduleTransformer(d.mainModule),
-      moduleTransformer(d.mainSyntaxModule),
-      d.entryModules map { m => moduleTransformer.memoization.getOrElse(m, m) })
+      d.entryModules map { m => moduleTransformer.memoization.getOrElse(m, m) },
+      d.att)
   }
 }

--- a/kore/src/test/scala/org/kframework/meta/TestMeta.scala
+++ b/kore/src/test/scala/org/kframework/meta/TestMeta.scala
@@ -37,9 +37,7 @@ class TestMeta {
   val metamodule = 'Module("TEST", 'Set(),
     'Set('Production("Foo", 'Sort("Foo"), 'List('Terminal("Bar")))))
 
-  val metad = 'Definition(metamodule, metamodule,
-    'Set(metamodule),
-    'Att('Set()))
+  val metad = 'Definition(metamodule, 'Set(metamodule), 'Att('Set()))
 
 
   @Ignore

--- a/kore/src/test/scala/org/kframework/meta/TestMeta.scala
+++ b/kore/src/test/scala/org/kframework/meta/TestMeta.scala
@@ -32,7 +32,7 @@ class TestMeta {
   }
 
   val m = Module("TEST", Set(), Set(Production("Foo", Sort("Foo"), Seq(Terminal("Bar", Seq())))))
-  val d = Definition(m, m, Set(m))
+  val d = Definition(m, Set(m), Att())
 
   val metamodule = 'Module("TEST", 'Set(),
     'Set('Production("Foo", 'Sort("Foo"), 'List('Terminal("Bar")))))


### PR DESCRIPTION
**the PR will break (well, fix) APIs**
- renames `*-COMMON` modules to `*-SYNTAX`
- the former `-SYNTAX` modules are now removed 
- @radumereuta, the ID importation is now done in the former `*-PROGRAM-LISTS` module. It is now called `*-PROGRAM`. Such a module is generated for **each** regular module in the definition -- this is inefficient and will hopefully become unnecessary after your work on cleaning up the frontend for sort and label modularization is finished.
- cleaned up a bit the way the "main syntax" module is identified; basically, there is no `mainSyntaxModule` in `Definition` anymore. The main syntax module is tracked by an attribute on `Definition`
- the last two changes above also solve a problem with the kast frontend using incomplete modules when parsing with a non-"main syntax module" module.
