### PR TITLE
minor fixes to java backend to improve correctness of #KSequence

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
@@ -96,7 +96,7 @@ public class KItem extends Term implements KItemRepresentation, HasGlobalContext
     }
 
     private KItem(Term kLabel, Term kList, Sort sort, boolean isExactSort, Set<Sort> possibleSorts, Source source, Location location) {
-        super(Kind.KITEM, source, location);
+        super(computeKind(kLabel), source, location);
         this.kLabel = kLabel;
         this.kList = kList;
         this.sort = sort;
@@ -106,8 +106,18 @@ public class KItem extends Term implements KItemRepresentation, HasGlobalContext
         this.enableCache = false;
     }
 
+    private static Kind computeKind(Term kLabel) {
+        if (kLabel instanceof KLabelConstant) {
+            String name = ((KLabelConstant) kLabel).name();
+            if (name.equals(KLabels.DOTK) || name.equals(KLabels.KSEQ)) {
+                return Kind.K;
+            }
+        }
+        return Kind.KITEM;
+    }
+
     private KItem(Term kLabel, Term kList, GlobalContext global, Stage stage, Source source, Location location, BitSet[] childrenDonCareRuleMask) {
-        super(Kind.KITEM, source, location);
+        super(computeKind(kLabel), source, location);
         this.kLabel = kLabel;
         this.kList = kList;
         this.global = global;

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaBackend.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaBackend.java
@@ -122,7 +122,7 @@ public class JavaBackend implements Backend {
     private static K convertKSeqToKApply(K ruleBody) {
         return new TransformK() {
             public K apply(KSequence kseq) {
-                return ((ADT.KSequence) kseq).kApply();
+                return super.apply(((ADT.KSequence) kseq).kApply());
             }
         }.apply(ruleBody);
     }


### PR DESCRIPTION
Fixes an issue where KSequences inside a KApply inside a KSequence were not converted correctly, and a case where KSequences were incorrectly computed as sort KItem.
