### PR TITLE
Parser @API interface

### DIFF
--- a/kernel/src/main/java/org/kframework/Parser.java
+++ b/kernel/src/main/java/org/kframework/Parser.java
@@ -30,15 +30,15 @@ public class Parser {
     /**
      * Parses a string with a particular start symbol/sort.
      *
-     * @param withSort the start symbol/sort
+     * @param startSymbol the start symbol/sort
      * @param toParse  the String to parse
      * @param fromSource  the Source of the String toParse
      * @return a pair: the left projection is a parsed string as a K, if successful;
      * the right projection is the set of issues encountered while parsing
      */
     @SuppressWarnings("unchecked")
-    public Tuple2<Option<K>, Set<Warning>> apply(Sort withSort, String toParse, Source fromSource) {
-        Tuple2<Either<Set<ParseFailedException>, K>, Set<ParseFailedException>> res = parseInModule.parseString(toParse, withSort, fromSource);
+    public Tuple2<Option<K>, Set<Warning>> apply(Sort startSymbol, String toParse, Source fromSource) {
+        Tuple2<Either<Set<ParseFailedException>, K>, Set<ParseFailedException>> res = parseInModule.parseString(toParse, startSymbol, fromSource);
 
         Set<Warning> problemSet = new HashSet<>();
         problemSet.addAll((Set<Warning>) (Object) res._2());
@@ -50,13 +50,13 @@ public class Parser {
     /**
      * Parses a string with a particular start symbol/sort.
      *
-     * @param withSort the start symbol/sort
+     * @param startSymbol the start symbol/sort
      * @param toParse  the String to parse
      * @return a pair: the left projection is a parsed string as a K, if successful;
      * the right projection is the set of issues encountered while parsing
      */
-    public Tuple2<Option<K>, Set<Warning>> apply(Sort withSort, String toParse) {
-        return apply(withSort, toParse, Source.apply("generated"));
+    public Tuple2<Option<K>, Set<Warning>> apply(Sort startSymbol, String toParse) {
+        return apply(startSymbol, toParse, Source.apply("generated"));
     }
 
     public static Parser from(Module module) {

--- a/kernel/src/main/java/org/kframework/Parser.java
+++ b/kernel/src/main/java/org/kframework/Parser.java
@@ -1,0 +1,67 @@
+// Copyright (c) 2015 K Team. All Rights Reserved.
+package org.kframework;
+
+import org.kframework.attributes.Source;
+import org.kframework.definition.Module;
+import org.kframework.kore.K;
+import org.kframework.kore.Sort;
+import org.kframework.parser.concrete2kore.ParseInModule;
+import org.kframework.utils.errorsystem.ParseFailedException;
+import scala.Option;
+import scala.Tuple2;
+import scala.util.Either;
+import scala.util.control.Exception;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Parses a string with a particular start symbol/sort.
+ * Constructed via the static {@link #from methods}
+ */
+@API
+public class Parser {
+    private final ParseInModule parseInModule;
+    private Module module;
+
+    private Parser(Module module) {
+        this.module = module;
+        this.parseInModule = new ParseInModule(module);
+    }
+
+    /**
+     * Parses a string with a particular start symbol/sort.
+     *
+     * @param withSort the start symbol/sort
+     * @param toParse  the String to parse
+     * @param fromSource  the Source of the String toParse
+     * @return a pair: the left projection is a parsed string as a K, if successful;
+     * the right projection is the set of issues encountered while parsing
+     */
+    @SuppressWarnings("unchecked")
+    public Tuple2<Option<K>, Set<Warning>> apply(Sort withSort, String toParse, Source fromSource) {
+        Tuple2<Either<Set<ParseFailedException>, K>, Set<ParseFailedException>> res = parseInModule.parseString(toParse, withSort, fromSource);
+
+        Set<Warning> problemSet = new HashSet<>();
+        problemSet.addAll((Set<Warning>) (Object) res._2());
+        if (res._1().isLeft())
+            problemSet.addAll((Set<Warning>) (Object) res._1().left().get());
+        return Tuple2.apply(res._1().right().toOption(), problemSet);
+    }
+
+    /**
+     * Parses a string with a particular start symbol/sort.
+     *
+     * @param withSort the start symbol/sort
+     * @param toParse  the String to parse
+     * @return a pair: the left projection is a parsed string as a K, if successful;
+     * the right projection is the set of issues encountered while parsing
+     */
+    public Tuple2<Option<K>, Set<Warning>> apply(Sort withSort, String toParse) {
+        return apply(withSort, toParse, Source.apply("generated"));
+    }
+
+    public static Parser from(Module module) {
+        return new Parser(module);
+    }
+}

--- a/kernel/src/main/java/org/kframework/Parser.java
+++ b/kernel/src/main/java/org/kframework/Parser.java
@@ -22,10 +22,8 @@ import java.util.Set;
 @API
 public class Parser {
     private final ParseInModule parseInModule;
-    private Module module;
 
     private Parser(Module module) {
-        this.module = module;
         this.parseInModule = new ParseInModule(module);
     }
 

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/ParseInModule.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/ParseInModule.java
@@ -46,7 +46,7 @@ public class ParseInModule implements Serializable {
     private final Module parsingModule;
     private volatile Grammar grammar = null;
     private final boolean strict;
-    ParseInModule(Module seedModule) {
+    public ParseInModule(Module seedModule) {
         this(seedModule, seedModule, seedModule, seedModule, true);
     }
 

--- a/kernel/src/test/java/org/kframework/ParserTest.java
+++ b/kernel/src/test/java/org/kframework/ParserTest.java
@@ -1,0 +1,38 @@
+// Copyright (c) 2015 K Team. All Rights Reserved.
+package org.kframework;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.kframework.definition.*;
+import org.kframework.kore.K;
+import org.kframework.kore.Sort;
+import scala.Option;
+import scala.Tuple2;
+
+import java.util.Set;
+
+import static org.kframework.kore.KORE.*;
+import static org.kframework.Collections.*;
+
+public class ParserTest {
+    private static final Sort xSort = Sort("X");
+    Module m = Module.apply("TEST", Set(
+            Production.apply(xSort, Seq(Terminal.apply("x")), Att().add("klabel", "x"))
+    ));
+
+    @Test
+    public void simpleNoWarning() {
+        Tuple2<Option<K>, Set<Warning>> actual = Parser.from(m).apply(xSort, "x");
+        assertTrue("The parse should succeed, but was " + actual, actual._1().isDefined());
+        assertTrue("There should be no warnings, but were: " + actual._2(), actual._2().isEmpty());
+        assertEquals(KApply(KLabel("x")), actual._1().get());
+    }
+
+    @Test
+    public void simpleFailedParse() {
+        Tuple2<Option<K>, Set<Warning>> actual = Parser.from(m).apply(xSort, "y");
+        assertTrue("The parse should fail, but was " + actual, actual._1().isEmpty());
+        assertTrue("There should be one error, but were: " + actual._2(), actual._2().size() == 1);
+    }
+}

--- a/kore/src/main/java/org/kframework/API.java
+++ b/kore/src/main/java/org/kframework/API.java
@@ -1,0 +1,14 @@
+package org.kframework;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * Marker for classes we consider as part fo the K API.
+ * It is particularly important for these classes to be well-documented.
+ */
+@Target(ElementType.TYPE)
+public @interface API {
+
+}

--- a/kore/src/main/java/org/kframework/API.java
+++ b/kore/src/main/java/org/kframework/API.java
@@ -1,6 +1,6 @@
+// Copyright (c) 2015 K Team. All Rights Reserved.
 package org.kframework;
 
-import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 

--- a/kore/src/main/java/org/kframework/Warning.java
+++ b/kore/src/main/java/org/kframework/Warning.java
@@ -1,0 +1,7 @@
+// Copyright (c) 2015 K Team. All Rights Reserved.
+package org.kframework;
+
+@API
+public interface Warning {
+
+}

--- a/kore/src/main/java/org/kframework/utils/errorsystem/ParseFailedException.java
+++ b/kore/src/main/java/org/kframework/utils/errorsystem/ParseFailedException.java
@@ -1,8 +1,10 @@
 // Copyright (c) 2014-2015 K Team. All Rights Reserved.
 package org.kframework.utils.errorsystem;
 
+import org.kframework.Warning;
+
 @SuppressWarnings("serial")
-public class ParseFailedException extends KEMException {
+public class ParseFailedException extends KEMException implements Warning {
     KException exception;
 
     public ParseFailedException(KException kException) {

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -77,6 +77,9 @@ trait GeneratingListSubsortProductions extends Sorting {
 }
 
 object Module {
+  def apply(name: String, unresolvedLocalSentences: Set[Sentence]): Module = {
+    new Module(name, Set(), unresolvedLocalSentences, Att())
+  }
   def apply(name: String, imports: Set[Module], unresolvedLocalSentences: Set[Sentence], @(Nonnull@param) att: Att = Att()): Module = {
     new Module(name, imports, unresolvedLocalSentences, att)
   }
@@ -354,9 +357,12 @@ case class RegexTerminal(precedeRegex: String, regex: String, followRegex: Strin
   }
 }
 
+object Terminal {
+  def apply(value: String): Terminal = Terminal(value, Seq())
+}
+
 case class Terminal(value: String, followRegex: Seq[String]) extends TerminalLike // hooked
   with TerminalToString {
-  def this(value: String) = this(value, Seq())
 
   lazy val pattern = new RunAutomaton(BasicAutomata.makeString(value), false)
   lazy val followPattern =


### PR DESCRIPTION
This PR:
- adds the @API annotation which will annotate all classes that we consider as part of the K API, i.e., classes that third-parties can rely on when using the K framework as a library
- create `org.kframework.Parser` class as the entry point for K's parsing engine

@radumereuta, I know you meant `org.kframework.parser.concrete2kore.ParseInModule` to fill this role, and I know we discussed its public interface at the time. Unfortunately, in time, its interface has started to accumulate "stuff" that is being used elsewhere, and we should keep the K-library-user-facing interfaces, i.e., `@API`, as small as possible. Also, it may be good to separate the classes used as `@API` from the rest of the implementation (via composition) so that we have the freedom to play with the implementation 

Once we merge this, I will make an announcement on the k-list for people to be extra careful when touching anything that's `@API`. Also, slowly, we should go back to improving the documentation of all classes that should be part of the `@API`. I propose to only add the `@API` when a class/interface passes muster in terms of both cleanliness and documentation.

@dwightguth, @bmmoore, @andreistefanescu, @grosu, you might also want to have a look, in case you have something against it.
