### PR TITLE
updates of all lambda++ lessons (only lesson_1 changed in definition)

### DIFF
--- a/k-distribution/tutorial/1_k/3_lambda++/lesson_1/lambda.k
+++ b/k-distribution/tutorial/1_k/3_lambda++/lesson_1/lambda.k
@@ -1,5 +1,5 @@
 // Copyright (c) 2012-2015 K Team. All Rights Reserved.
-require "modules/substitution.k"
+require "substitution.k"
 
 module LAMBDA
   imports SUBSTITUTION
@@ -9,7 +9,7 @@ module LAMBDA
   syntax Exp ::= Val
                | Exp Exp              [strict, left]
                | "(" Exp ")"          [bracket]
-  syntax Variable ::= Id
+  syntax KVariable ::= Id
   syntax KResult ::= Val
 
   rule (lambda X:Id . E:Exp) V:Val => E[V / X]

--- a/k-distribution/tutorial/1_k/3_lambda++/lesson_2/tests/free-variable-capture.lambda.out
+++ b/k-distribution/tutorial/1_k/3_lambda++/lesson_2/tests/free-variable-capture.lambda.out
@@ -2,16 +2,4 @@ Search results:
 
 Solution 1:
 V:K -->
-a ~> (HOLE ((lambda x . (lambda y . x) y) z))
-
-Solution 2:
-V:K -->
-y ~> closure ( .Map , x , lambda y . x ) HOLE ~> HOLE z ~> (a HOLE)
-
-Solution 3:
-V:K -->
-y ~> lambda x . (lambda y . x) HOLE ~> HOLE z ~> (a HOLE)
-
-Solution 4:
-V:K -->
-z ~> (lambda x . (lambda y . x) y) HOLE ~> (a HOLE)
+a ~> #freezer3 ( ( lambda x . lambda y . x ) y z )

--- a/k-distribution/tutorial/1_k/3_lambda++/lesson_4/tests/callcc-env1.lambda.out
+++ b/k-distribution/tutorial/1_k/3_lambda++/lesson_4/tests/callcc-env1.lambda.out
@@ -2,8 +2,4 @@ Search results:
 
 Solution 1:
 V:K -->
-3
-
-Solution 2:
-V:K -->
 4

--- a/k-distribution/tutorial/1_k/3_lambda++/lesson_4/tests/callcc-env2.lambda.out
+++ b/k-distribution/tutorial/1_k/3_lambda++/lesson_4/tests/callcc-env2.lambda.out
@@ -3,7 +3,3 @@ Search results:
 Solution 1:
 V:K -->
 3
-
-Solution 2:
-V:K -->
-4

--- a/k-distribution/tutorial/1_k/3_lambda++/lesson_4/tests/callcc-with-let.lambda.out
+++ b/k-distribution/tutorial/1_k/3_lambda++/lesson_4/tests/callcc-with-let.lambda.out
@@ -2,8 +2,4 @@ Search results:
 
 Solution 1:
 V:K -->
-32
-
-Solution 2:
-V:K -->
 33


### PR DESCRIPTION
This is the artificial PR of 3_lambda++ for @grosu to review. 
For definitions, only lesson 1 changed a little bit as it is substitution based, other lessons have no difference. 
We have been using tests-kore folder for testing, but here I updated tests directly for the ease of review. Basically, we cannot produce more than one search result now. Other tests not showing here have exactly the same output as before.
In the branch to be really merged, I keep the original tests folders unchanged and new outputs are in tests-kore.
