### PR TITLE
avoid using cell specific sets

### DIFF
--- a/kernel/src/main/java/org/kframework/kore/compile/GenerateSentencesFromConfigDecl.java
+++ b/kernel/src/main/java/org/kframework/kore/compile/GenerateSentencesFromConfigDecl.java
@@ -329,19 +329,19 @@ public class GenerateSentencesFromConfigDecl {
             // syntax CellBag ::= Cell
             // syntax CellBag ::= ".CellBag" [hook(BAG.unit), function]
             // syntax CellBag ::= CellBagItem(Cell) [hook(BAG.element), function]
-            // syntax CellBag  ::= CellBag CellBag [assoc, comm, unit(.CellBag), element(CellBagItem), wrapElement(<cell>), hook(BAG.concat), function]
+            // syntax CellBag  ::= CellBag CellBag [assoc, comm, unit(.CellBag), element(CellBagItem), wrapElement(<cell>), hook(BAG.concat), avoid, function]
             // -or-
             // syntax CellSet [hook(SET.Set)]
             // syntax CellSet ::= Cell
             // syntax CellSet ::= ".CellSet" [hook(SET.unit), function]
             // syntax CellSet ::= CellSetItem(Cell) [hook(SET.element), function]
-            // syntax CellSet ::= CellSet CellSet [assoc, conmm, idem, unit(.CellSet), element(CellSetItem), wrapElement(<cell>), hook(SET.concat), function]
+            // syntax CellSet ::= CellSet CellSet [assoc, conmm, idem, unit(.CellSet), element(CellSetItem), wrapElement(<cell>), hook(SET.concat), avoid, function]
             // -or-
             // syntax CellList [hook(LIST.List)]
             // syntax CellList ::= Cell
             // syntax CellList ::= ".CellList" [hook(LIST.unit), function]
             // syntax CellList ::= CellListItem(Cell) [hook(LIST.element), function]
-            // syntax CellList ::= CellList CellList [assoc, unit(.CellList), element(CellListItem), wrapElement(<cell>), hook(LIST.concat), function]
+            // syntax CellList ::= CellList CellList [assoc, unit(.CellList), element(CellListItem), wrapElement(<cell>), hook(LIST.concat), avoid, function]
             String type = cellProperties.<String>getOptional("type").orElse("Bag");
             Sort bagSort = Sort(sortName + type);
             Att bagAtt = Att()
@@ -350,6 +350,7 @@ public class GenerateSentencesFromConfigDecl {
                     .add("wrapElement", "<" + cellName + ">")
                     .add(Attribute.UNIT_KEY, "." + bagSort.name())
                     .add(Attribute.HOOK_KEY, type.toUpperCase() + ".concat")
+                    .add("avoid")
                     .add(Attribute.FUNCTION_KEY);
             String unitHook = type.toUpperCase() + ".unit", elementHook = type.toUpperCase() + ".element";
             switch(type) {

--- a/kernel/src/main/java/org/kframework/kore/compile/GenerateSentencesFromConfigDecl.java
+++ b/kernel/src/main/java/org/kframework/kore/compile/GenerateSentencesFromConfigDecl.java
@@ -350,7 +350,7 @@ public class GenerateSentencesFromConfigDecl {
                     .add("wrapElement", "<" + cellName + ">")
                     .add(Attribute.UNIT_KEY, "." + bagSort.name())
                     .add(Attribute.HOOK_KEY, type.toUpperCase() + ".concat")
-                    .add("avoid")
+                    .add("avoid") // needed to ensure cell collections are parsed as Bag instead of CellBag
                     .add(Attribute.FUNCTION_KEY);
             String unitHook = type.toUpperCase() + ".unit", elementHook = type.toUpperCase() + ".element";
             switch(type) {

--- a/kernel/src/test/java/org/kframework/kore/compile/GenerateSentencesFromConfigDeclTest.java
+++ b/kernel/src/test/java/org/kframework/kore/compile/GenerateSentencesFromConfigDeclTest.java
@@ -75,7 +75,7 @@ public class GenerateSentencesFromConfigDeclTest {
                         Seq(NonTerminal(Sort("ThreadCellBag")), NonTerminal(Sort("ThreadCellBag"))),
                         Att().add("assoc","").add("comm","").add("unit",".ThreadCellBag")
                                 .add("element","ThreadCellBagItem").add("wrapElement","<thread>")
-                                .add("function").add("hook","BAG.concat")),
+                                .add("function").add("avoid").add("hook","BAG.concat")),
                 Production(".ThreadCellBag", Sort("ThreadCellBag"),
                         Seq(Terminal(".ThreadCellBag")),
                         Att().add("function").add("hook","BAG.unit")),


### PR DESCRIPTION
Fixes a bug where `<thread>...</thread> <thread>...</thread>` is parsed incorrectly leading  to lack of correct cell completion.
