### PR TITLE
simple typed static works!

### DIFF
--- a/k-distribution/tutorial/2_languages/1_simple/2_typed/1_static/simple-typed-static.k
+++ b/k-distribution/tutorial/2_languages/1_simple/2_typed/1_static/simple-typed-static.k
@@ -591,20 +591,18 @@ list of variable declarations. */
 /*@ The \texttt{ltype} context allows only expressions which have an
  lvalue to evaluate. */
 
-// We would like to say the following instead of the predicate rule below:
-//  syntax LValue ::= Id | Exp "[" Exps "]"
-// but unfortunately that currently generates some ambiguous parsings.
   syntax LValue ::= Id
-  rule isLValue(_:Exp[_:Exps]) => true
+                  | Exp "[" Exps "]"
+  syntax Exp ::= LValue  // K should be able to infer this
+                         // if not added, then it gets stuck with an Id on k cell
+
+// Instead of the second LValue production above you can use a rule:
+//  rule isLValue(_:Exp[_:Exps]) => true
 
   syntax Exp ::= ltype(Exp)
-// We would like to say:
 //  context ltype(HOLE:LValue)
-// but we currently cannot type the HOLE
-//  context ltype(HOLE) requires isLValue(HOLE)
-
+// The above context does not work due to some error, so we write instead
   context ltype(HOLE) requires isLValue(HOLE)
-  syntax Exp ::= LValue
 
 //@ The function \texttt{getTypes} is the same as in SIMPLE typed dynamic.
 

--- a/k-distribution/tutorial/2_languages/2_kool/2_typed/2_static/NOTES.md
+++ b/k-distribution/tutorial/2_languages/2_kool/2_typed/2_static/NOTES.md
@@ -1,0 +1,11 @@
+<!-- Copyright (c) 2016 K Team. All Rights Reserved. -->
+
+Why is the following happening at line 347?  It should infer the sort Stmts for S:
+
+  rule <task> <k> {S} => block ...</k> <tenv> Rho </tenv> R </task>
+       (.Bag => <task> <k> S </k> <tenv> Rho </tenv> R </task>)
+
+  [Error] Critical: Could not infer a sort for variable 'S' to match every location.
+
+Similarly at line 517.
+


### PR DESCRIPTION
@cos: this passes all the tests.

However, I did not modify the .out files, for the reasons explained in previous issues.  If you can take care of #2098 then you can go ahead and also uncomment https://github.com/kframework/k/blob/master/k-distribution/tutorial/2_languages/1_simple/tests/config.xml#L14 so the tests get included, too.  Then we can mark SIMPLE as done!

Now I'm moving to KOOL typed static.
