### PR TITLE
Added a builtin #getTime function

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/BuiltinIOOperations.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/BuiltinIOOperations.java
@@ -31,6 +31,10 @@ public class BuiltinIOOperations {
         this.fs = fs;
     }
 
+    public Term getTime(TermContext termContext) {
+        return IntToken.of(System.currentTimeMillis());
+    }
+
     public Term open(StringToken term1, StringToken term2, TermContext termContext) {
         try {
             return IntToken.of(fs.open(term1.stringValue(), term2.stringValue()));

--- a/java-backend/src/main/resources/org/kframework/backend/java/symbolic/hooks.properties
+++ b/java-backend/src/main/resources/org/kframework/backend/java/symbolic/hooks.properties
@@ -227,6 +227,7 @@ IO.seek : org.kframework.backend.java.builtins.BuiltinIOOperations.seek
 IO.putc : org.kframework.backend.java.builtins.BuiltinIOOperations.putc
 IO.write : org.kframework.backend.java.builtins.BuiltinIOOperations.write
 IO.system : org.kframework.backend.java.builtins.BuiltinIOOperations.system
+IO.getTime : org.kframework.backend.java.builtins.BuiltinIOOperations.getTime
 
 # reflective hooks
 

--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -539,6 +539,7 @@ module K-IO
                | "#open" "(" String "," String ")" [function, hook(IO.open), impure]
                | "#tell" "(" Int ")" [function, hook(IO.tell), impure]
                | "#getc" "(" Int ")"             [function, hook(IO.getc), impure]
+               | "#getTime"                [function, hook(IO.getTime), impure]
   syntax String ::= "#read" "(" Int "," Int ")"    [function, hook(IO.read), impure]
 
   syntax K ::= "#close" "(" Int ")" [function, hook(IO.close), impure]

--- a/k-distribution/include/io/io.k
+++ b/k-distribution/include/io/io.k
@@ -14,6 +14,7 @@ module K-IO
                  | "#tell" "(" Int ")" [function, hook(IO.tell), impure]
                  | "#getc" "(" Int ")"             [function, hook(IO.getc), impure]
                  | "#read" "(" Int "," Int ")"    [function, hook(IO.read), impure]
+                 | "#getTime"                [function, hook(IO.getTime), impure]
 
   syntax K ::= "#close" "(" Int ")" [function, hook(IO.close), impure]
              | "#seek" "(" Int "," Int ")" [function, hook(IO.seek), impure]


### PR DESCRIPTION
# getTime simply calls `System.currentTimeMillis()` to return time in milliseconds. Should close issue #1055.
