### PR TITLE
add assertion for unique module names in a definition

### DIFF
--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -42,6 +42,8 @@ case class Definition(
 
   val modules = entryModules flatMap allModules
 
+  assert(modules.map(m => m.name).size == modules.size)
+
   assert(modules.contains(mainModule))
 
   def getModule(name: String): Option[Module] = modules find { case m: Module => m.name == name; case _ => false }


### PR DESCRIPTION
This assertion fails on `k-distribution/samples-kore/kernelc`.
