### PR TITLE
Added dependency cycle detection as per #1423

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/ParserUtils.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/ParserUtils.java
@@ -22,7 +22,9 @@ import org.kframework.utils.file.FileUtil;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -116,6 +118,15 @@ public class ParserUtils {
             Source source,
             File currentDirectory,
             List<File> lookupDirectories) {
+        return slurp(definitionText, source, currentDirectory, lookupDirectories, new ArrayDeque<>());
+    }
+
+    private List<org.kframework.kil.Module> slurp(
+            String definitionText,
+            Source source,
+            File currentDirectory,
+            List<File> lookupDirectories,
+            Deque<File> parents) {
         List<DefinitionItem> items = Outer.parse(source, definitionText, null);
         if (options.verbose) {
             System.out.println("Importing: " + source);
@@ -123,17 +134,17 @@ public class ParserUtils {
         List<org.kframework.kil.Module> results = new ArrayList<>();
 
         for (DefinitionItem di : items) {
-            if (di instanceof org.kframework.kil.Module)
+            if (di instanceof org.kframework.kil.Module) {
                 results.add((org.kframework.kil.Module) di);
-            else if (di instanceof Require) {
+            } else if (di instanceof Require) {
                 // resolve location of the new file
 
                 String definitionFileName = ((Require) di).getValue();
 
-                ArrayList<File> allLookupDirectoris = new ArrayList<>(lookupDirectories);
-                allLookupDirectoris.add(0, currentDirectory);
+                ArrayList<File> allLookupDirectories = new ArrayList<>(lookupDirectories);
+                allLookupDirectories.add(0, currentDirectory);
 
-                Optional<File> definitionFile = allLookupDirectoris.stream()
+                Optional<File> definitionFile = allLookupDirectories.stream()
                         .map(lookupDirectory -> {
                             if (new File(definitionFileName).isAbsolute()) {
                                 return new File(definitionFileName);
@@ -144,16 +155,40 @@ public class ParserUtils {
                         .filter(file -> file.exists()).findFirst();
 
                 if (definitionFile.isPresent()) {
+                    // Look for dependency cycle
+                    if (parents.stream().
+                            anyMatch(parent -> {
+                                try {
+                                    File sourceFile = new File(source.source());
+                                    return parent.getCanonicalFile().equals(sourceFile.getCanonicalFile());
+                                } catch (IOException e) {
+                                    // Catch exceptions from getCanonicalFile
+                                    return false;
+                                }
+                            })) {
+                        String dependencyChain = (new File(source.source())).getName() + " -> "
+                                + parents.stream().map(File::getName).collect(Collectors.joining(" -> "));
+                        throw KExceptionManager.criticalError("Dependency cycle detected: " + dependencyChain, di);
+                    } else {
+                        parents.push(new File(source.source()));
+                    }
+
                     results.addAll(slurp(loadDefinitionText(definitionFile.get()),
                             Source.apply(definitionFile.get().getAbsolutePath()),
                             definitionFile.get().getParentFile(),
-                            lookupDirectories));
+                            lookupDirectories,
+                            parents));
                 }
                 else
                     throw KExceptionManager.criticalError("Could not find file: " +
-                            definitionFileName + "\nLookup directories:" + allLookupDirectoris, di);
+                            definitionFileName + "\nLookup directories:" + allLookupDirectories, di);
             }
         }
+
+        if (!parents.isEmpty()) {
+            File p = parents.pop();
+        }
+
         return results;
     }
 


### PR DESCRIPTION
Mimics a recursive DFS approach for detecting cycles in module requirements. Use canonical paths to ensure that file comparisons are correct.

This is my first time contributing/using K, so please let me know what you think!
