### PR TITLE
remove the format attribute in PRETTY output mode.

### DIFF
--- a/kore/src/main/scala/org/kframework/unparser/KOREToTreeNodes.scala
+++ b/kore/src/main/scala/org/kframework/unparser/KOREToTreeNodes.scala
@@ -55,11 +55,15 @@ object KOREToTreeNodes {
         }
         case RegexTerminal(_, _, _) => throw new AssertionError("Unimplemented yet")
       }
-      if (p.att.contains("format")) {
+        
+      unparsedItems.mkString(" ")
+
+      //TODO: Recover this code to enable format attribute (in PRETTY output mode).      
+      /*if (p.att.contains("format")) {
         p.att.get[String]("format").get.format(unparsedItems: _*)
       } else {
         unparsedItems.mkString(" ")
-      }
+      }*/
     }
   }
 }


### PR DESCRIPTION
remove the format attribute in PRETTY output mode (for cs427 purpose). Can recover it if necessary
