### PR TITLE
Remove special handling of bracket productions in priority visitors.

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/PriorityVisitor.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/PriorityVisitor.java
@@ -36,7 +36,7 @@ public class PriorityVisitor extends SetsTransformerWithErrors<ParseFailedExcept
     @Override
     public Either<java.util.Set<ParseFailedException>, Term> apply(TermCons tc) {
         assert tc.production() != null : this.getClass() + ":" + " production not found." + tc;
-        if (!tc.production().isSyntacticSubsort() && !tc.production().att().contains("bracket")) {
+        if (!tc.production().isSyntacticSubsort()) {
             // match only on the outermost elements
             if (tc.production().items().apply(0) instanceof NonTerminal) {
                 Either<java.util.Set<ParseFailedException>, Term> rez =
@@ -78,9 +78,6 @@ public class PriorityVisitor extends SetsTransformerWithErrors<ParseFailedExcept
         }
 
         public Either<java.util.Set<ParseFailedException>, Term> apply(TermCons tc) {
-            if (tc.production().att().contains("bracket")) return Right.apply(tc);
-            //if (Side.RIGHT  == side && !(tc.production().items().apply(0) instanceof NonTerminal)) return Right.apply(tc);
-            //if (Side.LEFT == side && !(tc.production().items().apply(tc.production().items().size() - 1) instanceof NonTerminal)) return Right.apply(tc);
             Tag parentLabel = new Tag(parent.production().klabel().get().name());
             Tag localLabel = new Tag(tc.production().klabel().get().name());
             if (priorities.lessThan(parentLabel, localLabel)) {


### PR DESCRIPTION
By doing this, I was able to put priorities on subsort productions and eliminate them from the AST later.
Really useful.