### PR TITLE
Bugfix2219new

### DIFF
--- a/k-distribution/src/test/java/org/kframework/kdep/TstKdepOnKORE_IT.java
+++ b/k-distribution/src/test/java/org/kframework/kdep/TstKdepOnKORE_IT.java
@@ -44,7 +44,7 @@ public class TstKdepOnKORE_IT {
     /* *
      * kdepEmptyModuleTest runs the regression test for
      * `kdep --no-prelude k-distribution/src/test/resources/compiler-tests/empty-module.k`
-     * The empty-module.k is created with no imports, syntax, rules, and configuration in it.
+     * The empty-module.k is created with no imports and syntax but possibly rules and configurations in it.
      * Before bug2219 is fixed:
      * timestamp : \
      *     /Users/Youshan/Documents/427bugfix/k-distribution/src/test/resources/compiler-tests/empty-module.k \

--- a/k-distribution/src/test/java/org/kframework/kdep/TstKdepOnKORE_IT.java
+++ b/k-distribution/src/test/java/org/kframework/kdep/TstKdepOnKORE_IT.java
@@ -75,7 +75,7 @@ public class TstKdepOnKORE_IT {
     @Test
     public void kdepEmptyModuleTest() {
         // set --no-prelude option
-        kDepOptions.outerParsing.noPrelude = true;
+        kDepOptions.outerParsing.notAutoImportDomain = true;
         kem = new KExceptionManager(kDepOptions.global);
         sw = new Stopwatch(kDepOptions.global);
         String[] args = new String[]{"empty-module.k", definitionDir.toString()};

--- a/k-distribution/src/test/java/org/kframework/kdep/TstKdepOnKORE_IT.java
+++ b/k-distribution/src/test/java/org/kframework/kdep/TstKdepOnKORE_IT.java
@@ -1,0 +1,101 @@
+package org.kframework.kdep;
+
+import com.beust.jcommander.JCommander;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.junit.Test;
+import org.kframework.main.Tool;
+import org.kframework.utils.Stopwatch;
+import org.kframework.utils.errorsystem.KExceptionManager;
+import org.kframework.utils.file.FileUtil;
+import org.kframework.utils.inject.JCommanderModule;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URISyntaxException;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class TstKdepOnKORE_IT {
+    private KDepOptions kDepOptions;
+    private KDepFrontEnd frontEnd;
+
+    private File definitionFile;
+    private File tmpDir;
+    private File definitionDir;
+    private FileUtil files;
+
+    private KExceptionManager kem;
+    private Stopwatch sw;
+
+    @Before
+    public void setup() throws URISyntaxException, IOException {
+        kDepOptions = new KDepOptions();
+        // set definitionFile with its' module name
+        tmpDir = new File("src/test/resources/compiler-tests/tmpDir");
+        definitionDir = new File("src/test/resources/compiler-tests/");
+        definitionFile = new File("src/test/resources/compiler-tests/empty-module.k");
+        files = new FileUtil(tmpDir, definitionDir, definitionDir, definitionDir, kDepOptions.global, System.getenv());
+    }
+
+    /* *
+     * kdepEmptyModuleTest runs the regression test for
+     * `kdep --no-prelude k-distribution/src/test/resources/compiler-tests/empty-module.k`
+     * The empty-module.k is created with no imports, syntax, rules, and configuration in it.
+     * Before bug2219 is fixed:
+     * timestamp : \
+     *     /Users/Youshan/Documents/427bugfix/k-distribution/src/test/resources/compiler-tests/empty-module.k \
+     * After the bug2219 is fixed:
+     * timestamp : \
+     *     /Users/Youshan/Documents/427bugfix/k-distribution/src/test/resources/compiler-tests/empty-module.k \
+     *     /Users/Youshan/Documents/427bugfix/kernel/target/../../k-distribution/include/builtin/kast.k \
+     *     /Users/Youshan/Documents/427bugfix/kernel/target/../../k-distribution/include/builtin/domains.k \
+     * This tests makes sure that when we set -no-prelude flag, kast.k and domains.k are loaded
+     * but not imported.
+     */
+
+    private String runKDepAndRedirectOutput() {
+        // redirect system stdout to outstream and save in baos
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream outstream = new PrintStream(baos);
+        PrintStream old = System.out; // save the previous System.out
+        System.setOut(outstream);
+
+        frontEnd.main();
+        String output = baos.toString();
+
+        // redirect output to stdout again
+        System.setOut(old);
+        return output;
+    }
+
+    @Test
+    public void kdepEmptyModuleTest() {
+        // set --no-prelude option
+        kDepOptions.outerParsing.noPrelude = true;
+        kem = new KExceptionManager(kDepOptions.global);
+        sw = new Stopwatch(kDepOptions.global);
+        String[] args = new String[]{"empty-module.k", definitionDir.toString()};
+
+        // parsing options
+        Set<Object> options = ImmutableSet.of(kDepOptions);
+        Set<Class<?>> experimentalOptions = ImmutableSet.of();
+        JCommander jc = JCommanderModule.jcommander(args, Tool.KDEP, options, experimentalOptions, kem, sw);
+        JCommanderModule.usage(jc);
+        JCommanderModule.experimentalUsage(jc);
+
+        // run kdep by running the main
+        frontEnd = new KDepFrontEnd(kDepOptions.outerParsing, kem, kDepOptions.global, sw, files);
+        String[] realOutputs = runKDepAndRedirectOutput().split("\n");
+
+        String[] expectedOutputs = new String[]{"timestamp : \\",
+            "    /Users/Youshan/Documents/427bugfix/k-distribution/src/test/resources/compiler-tests/empty-module.k \\",
+            "    /Users/Youshan/Documents/427bugfix/kernel/target/../../k-distribution/include/builtin/kast.k \\",
+            "    /Users/Youshan/Documents/427bugfix/kernel/target/../../k-distribution/include/builtin/domains.k \\"};
+
+        assertArrayEquals(realOutputs, expectedOutputs);
+    }
+}

--- a/k-distribution/src/test/java/org/kframework/kompile/TstKompileOnKORE_IT.java
+++ b/k-distribution/src/test/java/org/kframework/kompile/TstKompileOnKORE_IT.java
@@ -1,0 +1,73 @@
+package org.kframework.kompile;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kframework.AbstractTest;
+import org.kframework.backend.java.symbolic.JavaBackend;
+import org.kframework.main.GlobalOptions;
+import org.kframework.utils.file.FileUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import static org.junit.Assert.*;
+
+public class TstKompileOnKORE_IT extends AbstractTest {
+
+    private KompileOptions kompileOptions;
+    private GlobalOptions globalOptions;
+
+    // for kompile
+    private Kompile kompile;
+    private File definitionFile;
+    private File tmpDir;
+    private File definitionDir;
+    private String mainModuleName;
+    private String mainProgramsModuleName;
+    private CompiledDefinition compiledDef;
+    private FileUtil files;
+
+
+
+    @Before
+    public void setup() throws URISyntaxException, IOException {
+        kompileOptions = new KompileOptions();
+        globalOptions = new GlobalOptions();
+        // set definitionFile with its' module name
+        tmpDir = new File("src/test/resources/compiler-tests/tmpDir");
+        definitionDir = new File("src/test/resources/compiler-tests/");
+        definitionFile = new File("src/test/resources/compiler-tests/empty-module.k");
+        mainModuleName = "EMPTY-MODULE";
+        mainProgramsModuleName = "EMPTY-MODULE";
+        files = new FileUtil(tmpDir, definitionDir, definitionDir, definitionDir, globalOptions, System.getenv());
+    }
+
+     /* *
+     * kompileEmptyModuleTest simulates the command for bug#2219
+     * `-kompile --no-prelude --debug k-distribution/src/test/resources/compiler-tests/empty-module.k`
+     * The empty-module.k is created with no imports, syntax, rules, and configuration in it.
+     * Before bug2219 is fixed, an NoSuchElementException is thrown in ModuleTransformerException class.
+     * After the bug is fixed, there should be no such exceptions.
+     */
+
+    @Test
+    public void kompileEmptyModuleTest() {
+        // set --no-prelude option
+        kompileOptions.outerParsing.noPrelude = true;
+
+        // kompile definition
+        kompile = new Kompile(kompileOptions, files, kem, false);
+        String exceptionCauseClass = null;
+        try {
+            compiledDef = kompile.run(definitionFile, mainModuleName, mainProgramsModuleName,
+                    new JavaBackend(kem, files, globalOptions, kompileOptions).steps());
+        } catch (Throwable throwable){
+            exceptionCauseClass = throwable.getClass().getName();
+            throwable.printStackTrace(); // set --debug option
+        }
+        // Make sure there is no exception
+        assertNull(exceptionCauseClass);
+    }
+
+}

--- a/k-distribution/src/test/java/org/kframework/kompile/TstKompileOnKORE_IT.java
+++ b/k-distribution/src/test/java/org/kframework/kompile/TstKompileOnKORE_IT.java
@@ -46,7 +46,7 @@ public class TstKompileOnKORE_IT extends AbstractTest {
      /* *
      * kompileEmptyModuleTest simulates the command for bug#2219
      * `-kompile --no-prelude --debug k-distribution/src/test/resources/compiler-tests/empty-module.k`
-     * The empty-module.k is created with no imports, syntax, rules, and configuration in it.
+     * The empty-module.k is created with no imports and syntax but possibly rules and configurations in it.
      * Before bug2219 is fixed, an NoSuchElementException is thrown in ModuleTransformerException class.
      * After the bug is fixed, there should be no such exceptions.
      */

--- a/k-distribution/src/test/java/org/kframework/kompile/TstKompileOnKORE_IT.java
+++ b/k-distribution/src/test/java/org/kframework/kompile/TstKompileOnKORE_IT.java
@@ -54,7 +54,7 @@ public class TstKompileOnKORE_IT extends AbstractTest {
     @Test
     public void kompileEmptyModuleTest() {
         // set --no-prelude option
-        kompileOptions.outerParsing.noPrelude = true;
+        kompileOptions.outerParsing.notAutoImportDomain = true;
 
         // kompile definition
         kompile = new Kompile(kompileOptions, files, kem, false);

--- a/k-distribution/src/test/java/org/kframework/utils/KoreUtils.java
+++ b/k-distribution/src/test/java/org/kframework/utils/KoreUtils.java
@@ -2,32 +2,29 @@
 package org.kframework.utils;
 
 import org.kframework.HookProvider;
-import org.kframework.backend.java.symbolic.JavaBackend;
-import org.kframework.backend.java.symbolic.JavaExecutionOptions;
-import org.kframework.kore.KORE;
-import org.kframework.kore.KToken;
-import org.kframework.kore.Sort;
-import org.kframework.krun.KRunOptions;
-import org.kframework.rewriter.Rewriter;
 import org.kframework.attributes.Source;
 import org.kframework.backend.java.symbolic.InitializeRewriter;
-import org.kframework.backend.java.symbolic.Stage;
+import org.kframework.backend.java.symbolic.JavaBackend;
+import org.kframework.backend.java.symbolic.JavaExecutionOptions;
 import org.kframework.builtin.Sorts;
 import org.kframework.definition.Module;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kompile.Kompile;
 import org.kframework.kompile.KompileOptions;
 import org.kframework.kore.K;
+import org.kframework.kore.KORE;
+import org.kframework.kore.KToken;
+import org.kframework.kore.Sort;
 import org.kframework.krun.KRun;
+import org.kframework.krun.KRunOptions;
 import org.kframework.krun.api.io.FileSystem;
 import org.kframework.krun.ioserver.filesystem.portable.PortableFileSystem;
 import org.kframework.main.GlobalOptions;
+import org.kframework.rewriter.Rewriter;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
-import org.kframework.utils.options.SMTOptions;
 
 import java.io.File;
-import java.io.IOException;
 import java.lang.invoke.MethodHandle;
 import java.net.URISyntaxException;
 import java.util.HashMap;
@@ -35,7 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
-import static org.kframework.kore.KORE.KToken;
+import static org.kframework.kore.KORE.*;
 
 /**
  * Created by Manasvi on 6/19/15.
@@ -61,7 +58,7 @@ public class KoreUtils {
         this(fileName, mainModuleName, mainProgramsModuleName, false, Sorts.K(), false, false, kem);
     }
 
-    public KoreUtils(String fileName, String mainModuleName, String mainProgramsModuleName, boolean search, Sort sort, boolean heatCoolStrategies, boolean noPrelude, KExceptionManager kem) throws URISyntaxException {
+    public KoreUtils(String fileName, String mainModuleName, String mainProgramsModuleName, boolean search, Sort sort, boolean heatCoolStrategies, boolean notAutoImportDomain, KExceptionManager kem) throws URISyntaxException {
         this.kem = kem;
         File definitionFile = testResource(fileName);
         KompileOptions kompileOptions = new KompileOptions();
@@ -70,7 +67,7 @@ public class KoreUtils {
         globalOptions.warnings = GlobalOptions.Warnings.ALL;
 
         kompileOptions.experimental.heatCoolStrategies = heatCoolStrategies;
-        kompileOptions.outerParsing.noPrelude = noPrelude;
+        kompileOptions.outerParsing.notAutoImportDomain = notAutoImportDomain;
 
         KRunOptions krunOptions = new KRunOptions();
         krunOptions.search = search;

--- a/k-distribution/src/test/resources/compiler-tests/empty-module.k
+++ b/k-distribution/src/test/resources/compiler-tests/empty-module.k
@@ -1,0 +1,2 @@
+module EMPTY-MODULE
+endmodule

--- a/kernel/src/main/java/org/kframework/KapiGlobal.java
+++ b/kernel/src/main/java/org/kframework/KapiGlobal.java
@@ -65,8 +65,8 @@ public class KapiGlobal {
         this.kompileOptions.outerParsing.includes = v;
     }
 
-    public void setNoPrelude(boolean v) {
-        this.kompileOptions.outerParsing.noPrelude = v;
+    public void setNotAutoImportDomain(boolean v) {
+        this.kompileOptions.outerParsing.notAutoImportDomain = v;
     }
 
     public void setSmtPrelude(String v) {

--- a/kernel/src/main/java/org/kframework/kdep/KDepFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kdep/KDepFrontEnd.java
@@ -9,18 +9,12 @@ import org.kframework.main.FrontEnd;
 import org.kframework.main.GlobalOptions;
 import org.kframework.parser.concrete2kore.ParserUtils;
 import org.kframework.utils.Stopwatch;
-import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
-import org.kframework.utils.file.JarInfo;
-import org.kframework.utils.inject.CommonModule;
-import org.kframework.utils.inject.JCommanderModule;
 import org.kframework.utils.options.OuterParsingOptions;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -74,12 +68,12 @@ public class KDepFrontEnd extends FrontEnd {
 
         lookupDirectories.add(0, options.mainDefinitionFile(files).getParentFile());
 
-        // load builtin files if needed first
-        if (!options.noPrelude) {
-            modules.addAll(parser.slurp(Kompile.REQUIRE_PRELUDE_K,
-                    source,
-                    lookupDirectories));
-        }
+        // always load
+        modules.addAll(parser.slurp(Kompile.REQUIRE_PRELUDE_K,
+                source,
+                lookupDirectories));
+
+
 
         modules.addAll(parser.slurp(FileUtil.load(options.mainDefinitionFile(files)),
                 source,

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -97,7 +97,7 @@ public class Kompile {
         List<File> lookupDirectories = kompileOptions.outerParsing.includes.stream().map(files::resolveWorkingDirectory).collect(Collectors.toList());
         this.definitionParsing = new DefinitionParsing(
                 lookupDirectories, kompileOptions.strict(), kem,
-                parser, cacheParses, files.resolveKompiled("cache.bin"), !kompileOptions.outerParsing.noPrelude);
+                parser, cacheParses, files.resolveKompiled("cache.bin"), !kompileOptions.outerParsing.notAutoImportDomain);
         this.sw = sw;
     }
 
@@ -217,7 +217,7 @@ public class Kompile {
     }
 
     public Module parseModule(CompiledDefinition definition, File definitionFile) {
-        return definitionParsing.parseModule(definition, definitionFile, !kompileOptions.outerParsing.noPrelude);
+        return definitionParsing.parseModule(definition, definitionFile, !kompileOptions.outerParsing.notAutoImportDomain);
     }
 
     private Sentence concretizeSentence(Sentence s, Definition input) {

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/ParserUtils.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/ParserUtils.java
@@ -249,8 +249,7 @@ public class ParserUtils {
             List<File> lookupDirectories,
             boolean autoImportDomains) {
         Set<Module> previousModules = new HashSet<>();
-        if (autoImportDomains)
-            previousModules.addAll(loadModules(new HashSet<>(), Kompile.REQUIRE_PRELUDE_K, source, lookupDirectories, false));
+        previousModules.addAll(loadModules(new HashSet<>(), Kompile.REQUIRE_PRELUDE_K, source, lookupDirectories, false));
         Set<Module> modules = loadModules(previousModules, definitionText, source, lookupDirectories, autoImportDomains);
         modules.addAll(previousModules); // add the previous modules, since load modules is not additive
         Optional<Module> opt = modules.stream().filter(m -> m.name().equals(mainModuleName)).findFirst();

--- a/kernel/src/main/java/org/kframework/utils/options/OuterParsingOptions.java
+++ b/kernel/src/main/java/org/kframework/utils/options/OuterParsingOptions.java
@@ -40,8 +40,6 @@ public class OuterParsingOptions implements Serializable {
     @Parameter(names="-I", description="Add a directory to the search path for requires statements.", variableArity = true)
     public List<String> includes = new ArrayList<>();
 
-    @Parameter(names="--no-prelude", description="Do not implicitly require prelude.k. It also deactivates automatic inclusion of the DOMAINS and DOMAINS-SYNTAX modules.")
-    public boolean noPrelude = false;
-
-
+    @Parameter(names="--notAutoImportDomain", description="Do not implicitly require prelude.k. It also deactivates automatic inclusion of the DOMAINS and DOMAINS-SYNTAX modules.")
+    public boolean notAutoImportDomain = false;
 }


### PR DESCRIPTION
## Bug Description
A NoSuchElementException occurs when using --no-prelude to generate compiledDefinition for an empty module definition file (no syntax but possibly rules and configurations). E.g.
`kompile --no-prelude --debug empty-module.k`
This bug is due to the problem that "DEFAULT-DEFINITIONS", the built-in modules in k-distribution's kast.k and domains.k are **NOT LOADED**. 

Note that --no-prelude flag is intended to **NOT IMPORT** domains.k but **SHOULD LOAD** the domains.k. As parsing configurations requires many modules in domains.k, e.g. Map module, we would better **LOAD** all the built-in modules (kast and domain), and simply **NOT IMPORT** them.

## Change Log
1. ParserUtils.loadDefinition(), load Kompile.REQUIRE_PRELUDE_K to previousModules even with --no-prelude flag. This change fixes the bug2219.
2. KDepFrontEnd.run(), load Kompile.REQUIRE_PRELUDE_K to modules even with --no-prelude flag. This change is to keep the meaning of --no-prelude flag consistent throughout kframework: load prelude.k to modules but not import into k compiled definition.
3. change the misleading names of no-prelude (and noprelude) to notAutoImportDomain

## Tests
Create unit tests for kompile and kdep empty module in k-distribution: TstKompileOnKORE_IT.java and TstKdepOnKORE_IT.java
