### PR TITLE
fixes #2255

### DIFF
--- a/kernel/src/main/java/org/kframework/utils/FourWordBitSet.java
+++ b/kernel/src/main/java/org/kframework/utils/FourWordBitSet.java
@@ -134,6 +134,9 @@ public class FourWordBitSet implements BitSet<FourWordBitSet> {
     @Override
     public int nextSetBit(int i) {
         assert i <= size();
+        if (i == size()) {
+            return -1;
+        }
 
         if (i < Long.SIZE) {
             long maskedWord = word0 & (WORD_MASK << i);

--- a/kernel/src/main/java/org/kframework/utils/OneWordBitSet.java
+++ b/kernel/src/main/java/org/kframework/utils/OneWordBitSet.java
@@ -62,6 +62,10 @@ public class OneWordBitSet implements BitSet<OneWordBitSet> {
     @Override
     public int nextSetBit(int i) {
         assert i <= size();
+        if (i == size()) {
+            return -1;
+        }
+
         long maskedWord = word & (WORD_MASK << i);
         return maskedWord == 0 ? -1 : Long.numberOfTrailingZeros(maskedWord);
     }


### PR DESCRIPTION
This fixes a small but deep bug in implementations of `OneWordBitSet` and `FourWordBitSet` (in `nextSetBit` function) . The problem is probably related to misunderstanding the semantics of shift operation in Java. 
The full explanation of the bug can be found in my last [comment](https://github.com/kframework/k/issues/2255#issuecomment-272332846) in #2255 but in summary please note that according to Java language specification for [shift operation](https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.19), (long number << N) = (long number << (N%64)).

@cos @andreistefanescu @daejunpark  @grosu 
Please review