### PR TITLE
parent/pom.xml: Enforce Plugin Version 1.4.1 => 3.0.0-M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.4.1</version>
+        <version>3.0.0-M1</version>
         <configuration>
           <rules>
             <requireJavaVersion>


### PR DESCRIPTION
The old version of the plugin had issues dealing with
versions of Java outside the range 1.8 range. The update
fixes the issue.