### PR TITLE
Smt changes for EVM verification.

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
@@ -195,9 +195,9 @@ public class KILtoSMTLib extends CopyOnWriteTransformer {
         sb.append(leftTransformer.getConstantDeclarations(Sets.difference(
                 Sets.union(leftTransformer.variables(), rightTransformer.variables()),
                 rightHandSideOnlyVariables)));
-        sb.append("(assert (and ");
+        sb.append("(assert ");
         sb.append(leftExpression);
-        sb.append(" (not ");
+        sb.append(")\n(check-sat)\n(assert (not ");
         rightHandSideOnlyVariables = Sets.intersection(
                 rightTransformer.variables(),
                 rightHandSideOnlyVariables);
@@ -210,7 +210,7 @@ public class KILtoSMTLib extends CopyOnWriteTransformer {
         if (!rightHandSideOnlyVariables.isEmpty()) {
             sb.append(")");
         }
-        sb.append(")))");
+        sb.append("))");
         return sb.toString();
     }
 

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
@@ -85,6 +85,7 @@ public class KILtoSMTLib extends CopyOnWriteTransformer {
             "int_max",
             "int_min",
             "int_abs",
+            "int_and",
             /* extra float theory */
             "remainder",
             "min",

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SMTOperations.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SMTOperations.java
@@ -55,7 +55,7 @@ public class SMTOperations {
             Set<Variable> rightOnlyVariables) {
         if (smtOptions.smt == SMTSolver.Z3) {
             try {
-                return z3.isUnsat(
+                return z3.isImplication(
                         KILtoSMTLib.translateImplication(left, right, rightOnlyVariables),
                         smtOptions.z3ImplTimeout);
             } catch (UnsupportedOperationException e) {

--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -311,7 +311,7 @@ module INT
                  Int ">>Int" Int                [function, left, latex({#1}\mathrel{\gg_{\scriptstyle\it Int}}{#2}), hook(INT.shr)]
                | Int "<<Int" Int                [function, left, latex({#1}\mathrel{\ll_{\scriptstyle\it Int}}{#2}), hook(INT.shl)]
                > left:
-                 Int "&Int" Int                 [function, left, latex({#1}\mathrel{\&_{\scriptstyle\it Int}}{#2}), hook(INT.and)]
+                 Int "&Int" Int                 [function, left, smtlib(int_and), latex({#1}\mathrel{\&_{\scriptstyle\it Int}}{#2}), hook(INT.and)]
                > left:
                  Int "xorInt" Int               [function, left, latex({#1}\mathrel{\oplus_{\scriptstyle\it Int}}{#2}), hook(INT.xor)]
                > left:


### PR DESCRIPTION
This adds a missing smtlib attribute necessary for EVM verification, and changes how Z3 presents implications in a way that helps some EVM proofs. For some reason, calling check-sat between asserting the antecedent of an implication and asserting the negation of the consequent allows some things to be proved quickly which would instead timeout (it helps even when the first check-sat call returns "unknown", and other commands that should try to do some solving like `(apply smt)` do not provide the same benefit). 