### PR TITLE
for better debugging: add original name when renaming variable

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/Variable.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/Variable.java
@@ -63,6 +63,7 @@ public class Variable extends Term implements org.kframework.frontend.KVariable 
     }
 
     /* TODO(AndreiS): cache the variables */
+    private String originalName = "";
     private final String name;
     private final Sort sort;
     private final boolean anonymous;
@@ -102,6 +103,7 @@ public class Variable extends Term implements org.kframework.frontend.KVariable 
     public Variable getFreshCopy() {
         Variable var = Variable.getAnonVariable(sort);
         var.copyAttributesFrom(this);
+        var.originalName = this.name;
         return var;
     }
 
@@ -165,7 +167,7 @@ public class Variable extends Term implements org.kframework.frontend.KVariable 
 
     @Override
     public String toString() {
-        return name + ":" + sort;
+        return originalName + name + ":" + sort;
     }
 
     @Override


### PR DESCRIPTION
make the variable names more informative when debugging, e.g., `V_123` instead of `_123` where `V` is user-introduced variable name.