### PR TITLE
Cache function/anywhere symbol evaluation

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/JavaSymbolicObject.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/JavaSymbolicObject.java
@@ -2,7 +2,9 @@
 
 package org.kframework.backend.java.kil;
 
+import com.google.common.collect.Sets;
 import org.kframework.backend.java.symbolic.BinderSubstitutionTransformer;
+import org.kframework.backend.java.symbolic.ConjunctiveFormula;
 import org.kframework.backend.java.symbolic.IncrementalCollector;
 import org.kframework.backend.java.symbolic.LocalVisitor;
 import org.kframework.backend.java.symbolic.SubstitutionTransformer;
@@ -47,6 +49,7 @@ public abstract class JavaSymbolicObject<T extends JavaSymbolicObject<T>> extend
     volatile transient PSet<Variable> variableSet = null;
     volatile transient Boolean isGround = null;
     volatile transient Boolean isNormal = null;
+    volatile transient Set<ConjunctiveFormula> isEvaluated = Sets.newHashSet();
     volatile transient Set<Term> userVariableSet = null;
 
     protected JavaSymbolicObject() {
@@ -93,8 +96,8 @@ public abstract class JavaSymbolicObject<T extends JavaSymbolicObject<T>> extend
     /**
      * Returns true if a call to {@link org.kframework.backend.java.kil.Term#substituteAndEvaluate(java.util.Map, TermContext)} may simplify this term.
      */
-    public boolean canSubstituteAndEvaluate(Map<Variable, ? extends Term> substitution) {
-        return (!substitution.isEmpty() && !isGround()) || !isNormal();
+    public boolean canSubstituteAndEvaluate(Map<Variable, ? extends Term> substitution, ConjunctiveFormula constraint) {
+        return !Sets.intersection(substitution.keySet(), variableSet()).isEmpty() || !isEvaluated(constraint);
     }
 
     /**
@@ -139,6 +142,15 @@ public abstract class JavaSymbolicObject<T extends JavaSymbolicObject<T>> extend
 
     public boolean isConcrete() {
         return isGround() && isNormal();
+    }
+
+    /**
+     * Returns true if the function and anywhere symbols in this
+     * {@code JavaSymbolicObject} have been evaluated under the given
+     * {@code ConjunctiveFormula}, false otherwise.
+     */
+    public boolean isEvaluated(ConjunctiveFormula constraint) {
+        return isEvaluated.contains(constraint);
     }
 
     /**

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
@@ -273,11 +273,15 @@ public class KItem extends Term implements KItemRepresentation, HasGlobalContext
     }
 
     public Term evaluateFunction(TermContext context) {
-        return global.kItemOps.evaluateFunction(this, context);
+        Term result = global.kItemOps.evaluateFunction(this, context);
+        result.isEvaluated.add(context.getTopConstraint());
+        return result;
     }
 
     public Term resolveFunctionAndAnywhere(TermContext context) {
-        return global.kItemOps.resolveFunctionAndAnywhere(this, context);
+        Term result = global.kItemOps.resolveFunctionAndAnywhere(this, context);
+        result.isEvaluated.add(context.getTopConstraint());
+        return result;
     }
 
     @Override

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/Term.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/Term.java
@@ -78,7 +78,7 @@ public abstract class Term extends JavaSymbolicObject<Term> implements Comparabl
      * {@code evaluate} method instead.
      */
     public Term substituteAndEvaluate(Map<Variable, ? extends Term> substitution, TermContext context) {
-        return canSubstituteAndEvaluate(substitution) ?
+        return canSubstituteAndEvaluate(substitution, context.getTopConstraint()) ?
                (Term) this.accept(new SubstituteAndEvaluateTransformer(substitution, context)) :
                this;
     }

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SubstituteAndEvaluateTransformer.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SubstituteAndEvaluateTransformer.java
@@ -38,7 +38,7 @@ public class SubstituteAndEvaluateTransformer extends CopyOnWriteTransformer {
     }
 
     protected boolean proceed(JavaSymbolicObject object) {
-        return object.canSubstituteAndEvaluate(substitution);
+        return object.canSubstituteAndEvaluate(substitution, context.getTopConstraint());
     }
 
     @Override


### PR DESCRIPTION
Check if the `function`/`anywhere` symbols have been evaluated before, and if the substitution does not contain any of the variables in the term, then do not attempt to evaluate again. This is not sound if we attempt to evaluate with a different set of rules. The substitution and term variables intersection is also more expensive than the previous check, so this change may result in reduce performance in other cases, but on the `evm` proofs is speeds things up.

I don't remember, how can I run all tests to make sure that this doesn't break anything?